### PR TITLE
파일 링크 수정 및 몇몇 오타 수정

### DIFF
--- a/material/library/numpy_for_deep_learning.ipynb
+++ b/material/library/numpy_for_deep_learning.ipynb
@@ -1,21 +1,4 @@
 {
-  "nbformat": 4,
-  "nbformat_minor": 0,
-  "metadata": {
-    "colab": {
-      "name": "numpy_for_deep_learning.ipynb",
-      "provenance": [],
-      "collapsed_sections": [],
-      "toc_visible": true
-    },
-    "kernelspec": {
-      "name": "python3",
-      "display_name": "Python 3"
-    },
-    "language_info": {
-      "name": "python"
-    }
-  },
   "cells": [
     {
       "cell_type": "markdown",
@@ -37,25 +20,26 @@
     },
     {
       "cell_type": "code",
+      "execution_count": 1,
       "metadata": {
         "colab": {
           "base_uri": "https://localhost:8080/"
         },
         "id": "z2-FJJ8b6eZo",
-        "outputId": "92428d23-8ba9-473f-8d74-7830a89a3916"
+        "outputId": "755eceac-3f07-4d15-d4c1-246c4406ce4c"
       },
-      "source": [
-        "!pip install numpy"
-      ],
-      "execution_count": null,
       "outputs": [
         {
+          "name": "stdout",
           "output_type": "stream",
           "text": [
-            "Requirement already satisfied: numpy in /usr/local/lib/python3.7/dist-packages (1.19.5)\n"
-          ],
-          "name": "stdout"
+            "Looking in indexes: https://pypi.org/simple, https://us-python.pkg.dev/colab-wheels/public/simple/\n",
+            "Requirement already satisfied: numpy in /usr/local/lib/python3.7/dist-packages (1.21.6)\n"
+          ]
         }
+      ],
+      "source": [
+        "%pip install numpy"
       ]
     },
     {
@@ -69,14 +53,14 @@
     },
     {
       "cell_type": "code",
+      "execution_count": 2,
       "metadata": {
         "id": "xV3jVYiFL-jO"
       },
+      "outputs": [],
       "source": [
         "import numpy as np\n"
-      ],
-      "execution_count": null,
-      "outputs": []
+      ]
     },
     {
       "cell_type": "markdown",
@@ -89,13 +73,29 @@
     },
     {
       "cell_type": "code",
+      "execution_count": 3,
       "metadata": {
         "colab": {
           "base_uri": "https://localhost:8080/"
         },
         "id": "qeqF5uD875UG",
-        "outputId": "b5db5512-37d0-4801-eb93-852a13182e5b"
+        "outputId": "9f94b6e0-60a6-4922-f0b2-6637073ca438"
       },
+      "outputs": [
+        {
+          "name": "stdout",
+          "output_type": "stream",
+          "text": [
+            "[0 1 2 3 4]\n",
+            "a[0] = 0\n",
+            "a[1] = 1\n",
+            "a[1:3] = [1 2]\n",
+            "a[0:3] = [0 1 2]\n",
+            "a[1:] = [1 2 3 4]\n",
+            "a[:] = [0 1 2 3 4]\n"
+          ]
+        }
+      ],
       "source": [
         "a = np.array([0,1,2,3,4])\n",
         "\n",
@@ -106,22 +106,6 @@
         "print(\"a[0:3] =\",a[0:3])\n",
         "print(\"a[1:] =\",a[1:])\n",
         "print(\"a[:] =\",a[:])"
-      ],
-      "execution_count": null,
-      "outputs": [
-        {
-          "output_type": "stream",
-          "text": [
-            "[0 1 2 3 4]\n",
-            "a[0] = 0\n",
-            "a[1] = 1\n",
-            "a[1:3] = [1 2]\n",
-            "a[0:3] = [0 1 2]\n",
-            "a[1:] = [1 2 3 4]\n",
-            "a[:] = [0 1 2 3 4]\n"
-          ],
-          "name": "stdout"
-        }
       ]
     },
     {
@@ -135,41 +119,26 @@
     },
     {
       "cell_type": "code",
+      "execution_count": 3,
       "metadata": {
         "id": "Z-srJKHR8gEN"
       },
-      "source": [
-        ""
-      ],
-      "execution_count": null,
-      "outputs": []
+      "outputs": [],
+      "source": []
     },
     {
       "cell_type": "code",
+      "execution_count": 4,
       "metadata": {
         "colab": {
           "base_uri": "https://localhost:8080/"
         },
         "id": "R91NHIkx8MzU",
-        "outputId": "a8590e5b-64e6-4d6e-c33a-382475cfe997"
+        "outputId": "4fb50077-0f33-45a9-e6fa-e7be38a19bb4"
       },
-      "source": [
-        "a = np.array([ [0,1,2], [3,4,5] ])\n",
-        "\n",
-        "print(a)\n",
-        "print(\"a[0] =\",a[0])\n",
-        "print(\"a[1] =\",a[1])\n",
-        "print(\"a[1:3]\\n\",a[1:3])\n",
-        "print(\"a[0:3]\\n\",a[0:3])\n",
-        "print(\"a[1:]\\n\",a[1:])\n",
-        "print(\"a[:]\\n\",a[:])\n",
-        "\n",
-        "print(\"a[1][2] =\",a[1][2])\n",
-        "print(\"a[1,2] =\",a[1,2])"
-      ],
-      "execution_count": null,
       "outputs": [
         {
+          "name": "stdout",
           "output_type": "stream",
           "text": [
             "[[0 1 2]\n",
@@ -188,9 +157,22 @@
             " [3 4 5]]\n",
             "a[1][2] = 5\n",
             "a[1,2] = 5\n"
-          ],
-          "name": "stdout"
+          ]
         }
+      ],
+      "source": [
+        "a = np.array([ [0,1,2], [3,4,5] ])\n",
+        "\n",
+        "print(a)\n",
+        "print(\"a[0] =\",a[0])\n",
+        "print(\"a[1] =\",a[1])\n",
+        "print(\"a[1:3]\\n\",a[1:3])\n",
+        "print(\"a[0:3]\\n\",a[0:3])\n",
+        "print(\"a[1:]\\n\",a[1:])\n",
+        "print(\"a[:]\\n\",a[:])\n",
+        "\n",
+        "print(\"a[1][2] =\",a[1][2])\n",
+        "print(\"a[1,2] =\",a[1,2])"
       ]
     },
     {
@@ -206,14 +188,12 @@
     },
     {
       "cell_type": "code",
+      "execution_count": 4,
       "metadata": {
         "id": "20bFLcQg9RbM"
       },
-      "source": [
-        ""
-      ],
-      "execution_count": null,
-      "outputs": []
+      "outputs": [],
+      "source": []
     },
     {
       "cell_type": "markdown",
@@ -226,13 +206,26 @@
     },
     {
       "cell_type": "code",
+      "execution_count": 5,
       "metadata": {
         "colab": {
           "base_uri": "https://localhost:8080/"
         },
         "id": "9lGBp0EL6sTs",
-        "outputId": "54158730-17c4-41e2-d499-97d9b7bf2203"
+        "outputId": "0b19d380-115e-46c2-a356-32029b4fbb47"
       },
+      "outputs": [
+        {
+          "name": "stdout",
+          "output_type": "stream",
+          "text": [
+            "[0 1 2 3 4]\n",
+            "a.shape = (5,)\n",
+            "a.ndim = 1\n",
+            "a.dtype = int64\n"
+          ]
+        }
+      ],
       "source": [
         "a = np.array([0,1,2,3,4])\n",
         "\n",
@@ -240,19 +233,6 @@
         "print(\"a.shape =\", a.shape) # 데이터 모양\n",
         "print(\"a.ndim =\", a.ndim)   # 차원 수. number of dimension\n",
         "print(\"a.dtype =\", a.dtype) # 데이터 타입. data type"
-      ],
-      "execution_count": null,
-      "outputs": [
-        {
-          "output_type": "stream",
-          "text": [
-            "[0 1 2 3 4]\n",
-            "a.shape = (5,)\n",
-            "a.ndim = 1\n",
-            "a.dtype = int64\n"
-          ],
-          "name": "stdout"
-        }
       ]
     },
     {
@@ -268,13 +248,27 @@
     },
     {
       "cell_type": "code",
+      "execution_count": 6,
       "metadata": {
         "colab": {
           "base_uri": "https://localhost:8080/"
         },
         "id": "U2I2WPXz7Yf2",
-        "outputId": "0aa1d969-80ca-4137-8afe-a2c7a4d5cb70"
+        "outputId": "1b4808d6-b6c5-4c31-9431-e3a8db5a53ae"
       },
+      "outputs": [
+        {
+          "name": "stdout",
+          "output_type": "stream",
+          "text": [
+            "[[0 1 2]\n",
+            " [3 4 5]]\n",
+            "a.shape = (2, 3)\n",
+            "a.ndim = 2\n",
+            "a.dtype = int64\n"
+          ]
+        }
+      ],
       "source": [
         "l = [ [0,1,2], [3,4,5] ]\n",
         "a = np.array(l)\n",
@@ -283,20 +277,6 @@
         "print(\"a.shape =\", a.shape)\n",
         "print(\"a.ndim =\", a.ndim)\n",
         "print(\"a.dtype =\", a.dtype)"
-      ],
-      "execution_count": null,
-      "outputs": [
-        {
-          "output_type": "stream",
-          "text": [
-            "[[0 1 2]\n",
-            " [3 4 5]]\n",
-            "a.shape = (2, 3)\n",
-            "a.ndim = 2\n",
-            "a.dtype = int64\n"
-          ],
-          "name": "stdout"
-        }
       ]
     },
     {
@@ -325,9 +305,11 @@
     },
     {
       "cell_type": "code",
+      "execution_count": 7,
       "metadata": {
         "id": "kPbzUP1M9-z9"
       },
+      "outputs": [],
       "source": [
         "def pa(a, message=None): # print array\n",
         "  if message!=None:\n",
@@ -339,61 +321,59 @@
         "  message = message+\"\\n\" if message!=None else \"\"\n",
         "  message = \"{}shape={}, dimension={}, dtype={}\".format(message, a.shape, a.ndim, a.dtype)\n",
         "  pa(a, message)"
-      ],
-      "execution_count": null,
-      "outputs": []
+      ]
     },
     {
       "cell_type": "code",
+      "execution_count": 8,
       "metadata": {
         "colab": {
           "base_uri": "https://localhost:8080/"
         },
         "id": "11P_lZW0-Njh",
-        "outputId": "828ce770-6ffa-4362-9d31-9ff4810d44e4"
+        "outputId": "826b3d4d-fdde-494a-e500-32515b1e2a30"
       },
-      "source": [
-        "a = np.array([0,1,2,3])\n",
-        "paf(a)"
-      ],
-      "execution_count": null,
       "outputs": [
         {
+          "name": "stdout",
           "output_type": "stream",
           "text": [
             "shape=(4,), dimension=1, dtype=int64\n",
             "[0 1 2 3]\n",
             "\n"
-          ],
-          "name": "stdout"
+          ]
         }
+      ],
+      "source": [
+        "a = np.array([0,1,2,3])\n",
+        "paf(a)"
       ]
     },
     {
       "cell_type": "code",
+      "execution_count": 9,
       "metadata": {
         "colab": {
           "base_uri": "https://localhost:8080/"
         },
         "id": "ZW0eUZcQ-NJ0",
-        "outputId": "f1ffd5fe-e676-40b1-fcde-b5a04314badd"
+        "outputId": "88d137ca-69d4-4600-8be3-7831abfe0843"
       },
-      "source": [
-        "a = np.array([[0,1,2], [3,4,5]])\n",
-        "paf(a)"
-      ],
-      "execution_count": null,
       "outputs": [
         {
+          "name": "stdout",
           "output_type": "stream",
           "text": [
             "shape=(2, 3), dimension=2, dtype=int64\n",
             "[[0 1 2]\n",
             " [3 4 5]]\n",
             "\n"
-          ],
-          "name": "stdout"
+          ]
         }
+      ],
+      "source": [
+        "a = np.array([[0,1,2], [3,4,5]])\n",
+        "paf(a)"
       ]
     },
     {
@@ -407,28 +387,28 @@
     },
     {
       "cell_type": "code",
+      "execution_count": 10,
       "metadata": {
         "colab": {
           "base_uri": "https://localhost:8080/"
         },
         "id": "CSeurtFW-VJg",
-        "outputId": "9debe466-322a-4986-8ce7-a8e28d96a094"
+        "outputId": "5521f964-0377-4f72-c232-06a66b1521ed"
       },
-      "source": [
-        "a = np.arange(12)\n",
-        "paf(a)"
-      ],
-      "execution_count": null,
       "outputs": [
         {
+          "name": "stdout",
           "output_type": "stream",
           "text": [
             "shape=(12,), dimension=1, dtype=int64\n",
             "[ 0  1  2  3  4  5  6  7  8  9 10 11]\n",
             "\n"
-          ],
-          "name": "stdout"
+          ]
         }
+      ],
+      "source": [
+        "a = np.arange(12)\n",
+        "paf(a)"
       ]
     },
     {
@@ -444,54 +424,54 @@
     },
     {
       "cell_type": "code",
+      "execution_count": 11,
       "metadata": {
         "colab": {
           "base_uri": "https://localhost:8080/"
         },
         "id": "7LRK__qf_yG7",
-        "outputId": "e25090f0-bfe8-4592-f6dd-b6b121b5c472"
+        "outputId": "f341221c-ee8f-4b93-8520-fe17d3de2db5"
       },
-      "source": [
-        "a = np.arange(3,10)\n",
-        "paf(a)"
-      ],
-      "execution_count": null,
       "outputs": [
         {
+          "name": "stdout",
           "output_type": "stream",
           "text": [
             "shape=(7,), dimension=1, dtype=int64\n",
             "[3 4 5 6 7 8 9]\n",
             "\n"
-          ],
-          "name": "stdout"
+          ]
         }
+      ],
+      "source": [
+        "a = np.arange(3,10)\n",
+        "paf(a)"
       ]
     },
     {
       "cell_type": "code",
+      "execution_count": 12,
       "metadata": {
         "colab": {
           "base_uri": "https://localhost:8080/"
         },
         "id": "m-hd7Gfc_1Rh",
-        "outputId": "4616a292-eb78-4c9b-8dc0-9501e83cc72f"
+        "outputId": "ab7221b6-12ab-4e21-e44e-93509c809f00"
       },
-      "source": [
-        "a = np.arange(3,10,2)\n",
-        "paf(a)"
-      ],
-      "execution_count": null,
       "outputs": [
         {
+          "name": "stdout",
           "output_type": "stream",
           "text": [
             "shape=(4,), dimension=1, dtype=int64\n",
             "[3 5 7 9]\n",
             "\n"
-          ],
-          "name": "stdout"
+          ]
         }
+      ],
+      "source": [
+        "a = np.arange(3,10,2)\n",
+        "paf(a)"
       ]
     },
     {
@@ -500,25 +480,22 @@
         "id": "TWKvt2Hr_qX0"
       },
       "source": [
-        "# 모양 변경 - resahpe()"
+        "# 모양 변경 - reshape()"
       ]
     },
     {
       "cell_type": "code",
+      "execution_count": 13,
       "metadata": {
         "colab": {
           "base_uri": "https://localhost:8080/"
         },
         "id": "Upvh2LU6-vHM",
-        "outputId": "66df6250-8000-49df-ff1f-5eecdee368b3"
+        "outputId": "f10f03c3-dae8-4cf1-c240-501752d374db"
       },
-      "source": [
-        "a = np.arange(12).reshape(3,4)\n",
-        "paf(a)"
-      ],
-      "execution_count": null,
       "outputs": [
         {
+          "name": "stdout",
           "output_type": "stream",
           "text": [
             "shape=(3, 4), dimension=2, dtype=int64\n",
@@ -526,9 +503,12 @@
             " [ 4  5  6  7]\n",
             " [ 8  9 10 11]]\n",
             "\n"
-          ],
-          "name": "stdout"
+          ]
         }
+      ],
+      "source": [
+        "a = np.arange(12).reshape(3,4)\n",
+        "paf(a)"
       ]
     },
     {
@@ -542,29 +522,17 @@
     },
     {
       "cell_type": "code",
+      "execution_count": 14,
       "metadata": {
         "colab": {
           "base_uri": "https://localhost:8080/"
         },
         "id": "9146uY-5_FiH",
-        "outputId": "0161e9a4-4091-4563-dcb7-cdc2af5d8a9c"
+        "outputId": "93a4b80f-87ef-4862-9625-96056198ed5c"
       },
-      "source": [
-        "a = np.arange(12)\n",
-        "paf(a)\n",
-        "\n",
-        "a.reshape(3,4)\n",
-        "paf(a,\"a.reshape(3,4)\")\n",
-        "\n",
-        "b = a.reshape(3,4)\n",
-        "paf(b, \"b = a.reshape(3,4)\")\n",
-        "\n",
-        "a = np.arange(12).reshape(3,4)\n",
-        "paf(a, \"a = np.arange(12).reshape(3,4)\")"
-      ],
-      "execution_count": null,
       "outputs": [
         {
+          "name": "stdout",
           "output_type": "stream",
           "text": [
             "shape=(12,), dimension=1, dtype=int64\n",
@@ -586,9 +554,21 @@
             " [ 4  5  6  7]\n",
             " [ 8  9 10 11]]\n",
             "\n"
-          ],
-          "name": "stdout"
+          ]
         }
+      ],
+      "source": [
+        "a = np.arange(12)\n",
+        "paf(a)\n",
+        "\n",
+        "a.reshape(3,4)\n",
+        "paf(a,\"a.reshape(3,4)\")\n",
+        "\n",
+        "b = a.reshape(3,4)\n",
+        "paf(b, \"b = a.reshape(3,4)\")\n",
+        "\n",
+        "a = np.arange(12).reshape(3,4)\n",
+        "paf(a, \"a = np.arange(12).reshape(3,4)\")"
       ]
     },
     {
@@ -604,26 +584,17 @@
     },
     {
       "cell_type": "code",
+      "execution_count": 15,
       "metadata": {
         "colab": {
           "base_uri": "https://localhost:8080/"
         },
         "id": "8nmzscHh_cr5",
-        "outputId": "dd35aea9-7c62-41d0-b08f-b112212e59e3"
+        "outputId": "49c46bc1-9e75-4048-9d3c-fb3deea52db3"
       },
-      "source": [
-        "a = np.arange(12).reshape(3,4)\n",
-        "paf(a, \"reshape(3,4)\")\n",
-        "\n",
-        "a = np.arange(12).reshape(3,-1)\n",
-        "paf(a, \"reshape(3,-1)\")\n",
-        "\n",
-        "a = np.arange(12).reshape(-1,4)\n",
-        "paf(a, \"reshape(-1,4)\")"
-      ],
-      "execution_count": null,
       "outputs": [
         {
+          "name": "stdout",
           "output_type": "stream",
           "text": [
             "reshape(3,4)\n",
@@ -644,9 +615,18 @@
             " [ 4  5  6  7]\n",
             " [ 8  9 10 11]]\n",
             "\n"
-          ],
-          "name": "stdout"
+          ]
         }
+      ],
+      "source": [
+        "a = np.arange(12).reshape(3,4)\n",
+        "paf(a, \"reshape(3,4)\")\n",
+        "\n",
+        "a = np.arange(12).reshape(3,-1)\n",
+        "paf(a, \"reshape(3,-1)\")\n",
+        "\n",
+        "a = np.arange(12).reshape(-1,4)\n",
+        "paf(a, \"reshape(-1,4)\")"
       ]
     },
     {
@@ -660,29 +640,17 @@
     },
     {
       "cell_type": "code",
+      "execution_count": 16,
       "metadata": {
         "colab": {
           "base_uri": "https://localhost:8080/"
         },
         "id": "HRRWhHbuAXA3",
-        "outputId": "ea7ded21-d42c-4073-d70a-b2e4d50af00f"
+        "outputId": "7293621d-e718-409c-8078-786d511b6e71"
       },
-      "source": [
-        "a = np.arange(24).reshape(2,3,4)\n",
-        "paf(a, \"reshape(2,3,4)\")\n",
-        "\n",
-        "a = np.arange(24).reshape(-1,3,4)\n",
-        "paf(a, \"reshape(-1,3,4)\")\n",
-        "\n",
-        "a = np.arange(24).reshape(2,-1,4)\n",
-        "paf(a, \"reshape(2,-1,4)\")\n",
-        "\n",
-        "a = np.arange(24).reshape(2,3,-4)\n",
-        "paf(a, \"reshape(2,3,-4)\")"
-      ],
-      "execution_count": null,
       "outputs": [
         {
+          "name": "stdout",
           "output_type": "stream",
           "text": [
             "reshape(2,3,4)\n",
@@ -725,9 +693,21 @@
             "  [16 17 18 19]\n",
             "  [20 21 22 23]]]\n",
             "\n"
-          ],
-          "name": "stdout"
+          ]
         }
+      ],
+      "source": [
+        "a = np.arange(24).reshape(2,3,4)\n",
+        "paf(a, \"reshape(2,3,4)\")\n",
+        "\n",
+        "a = np.arange(24).reshape(-1,3,4)\n",
+        "paf(a, \"reshape(-1,3,4)\")\n",
+        "\n",
+        "a = np.arange(24).reshape(2,-1,4)\n",
+        "paf(a, \"reshape(2,-1,4)\")\n",
+        "\n",
+        "a = np.arange(24).reshape(2,3,-4)\n",
+        "paf(a, \"reshape(2,3,-4)\")"
       ]
     },
     {
@@ -743,7 +723,7 @@
         "np.full()\n",
         "np.zeros_like()\n",
         "np.ones_like()\n",
-        "np.full_liek()\n",
+        "np.full_like()\n",
         "\n",
         "np.eye()\n",
         "```"
@@ -760,20 +740,17 @@
     },
     {
       "cell_type": "code",
+      "execution_count": 17,
       "metadata": {
         "colab": {
           "base_uri": "https://localhost:8080/"
         },
         "id": "P677y13SCOzJ",
-        "outputId": "5edd36ba-b130-4031-eb6c-cc344f2f67a8"
+        "outputId": "dcbb5487-cb42-4ce1-d79c-a3108b3ce874"
       },
-      "source": [
-        "a = np.zeros((3,4))\n",
-        "paf(a)"
-      ],
-      "execution_count": null,
       "outputs": [
         {
+          "name": "stdout",
           "output_type": "stream",
           "text": [
             "shape=(3, 4), dimension=2, dtype=float64\n",
@@ -781,27 +758,27 @@
             " [0. 0. 0. 0.]\n",
             " [0. 0. 0. 0.]]\n",
             "\n"
-          ],
-          "name": "stdout"
+          ]
         }
+      ],
+      "source": [
+        "a = np.zeros((3,4))\n",
+        "paf(a)"
       ]
     },
     {
       "cell_type": "code",
+      "execution_count": 18,
       "metadata": {
         "colab": {
           "base_uri": "https://localhost:8080/"
         },
         "id": "yUWR68u9CmkP",
-        "outputId": "4b42e707-e920-4e7c-baf2-a91d60a1ac31"
+        "outputId": "b0d19866-4d12-4f72-dc6f-d415d8e32cfd"
       },
-      "source": [
-        "a = np.zeros((3,4), dtype=int)\n",
-        "paf(a)"
-      ],
-      "execution_count": null,
       "outputs": [
         {
+          "name": "stdout",
           "output_type": "stream",
           "text": [
             "shape=(3, 4), dimension=2, dtype=int64\n",
@@ -809,37 +786,40 @@
             " [0 0 0 0]\n",
             " [0 0 0 0]]\n",
             "\n"
-          ],
-          "name": "stdout"
+          ]
         }
+      ],
+      "source": [
+        "a = np.zeros((3,4), dtype=int)\n",
+        "paf(a)"
       ]
     },
     {
       "cell_type": "code",
+      "execution_count": 19,
       "metadata": {
         "colab": {
           "base_uri": "https://localhost:8080/"
         },
         "id": "ImUcaE-3CtGx",
-        "outputId": "3dd21e62-3338-43b2-c591-521c0f28df78"
+        "outputId": "b7cd2d41-a911-46d7-ceb0-b92a5706b08b"
       },
-      "source": [
-        "a = np.zeros((3,4), dtype=np.int)\n",
-        "paf(a)"
-      ],
-      "execution_count": null,
       "outputs": [
         {
+          "name": "stdout",
           "output_type": "stream",
           "text": [
-            "shape=(3, 4), dimension=2, dtype=int64\n",
+            "shape=(3, 4), dimension=2, dtype=int32\n",
             "[[0 0 0 0]\n",
             " [0 0 0 0]\n",
             " [0 0 0 0]]\n",
             "\n"
-          ],
-          "name": "stdout"
+          ]
         }
+      ],
+      "source": [
+        "a = np.zeros((3,4), dtype=np.int32)\n",
+        "paf(a)"
       ]
     },
     {
@@ -853,15 +833,15 @@
     },
     {
       "cell_type": "code",
+      "execution_count": 20,
       "metadata": {
         "id": "mVQmOoEJDIv5"
       },
+      "outputs": [],
       "source": [
         "a = np.arange(12).reshape(3,4)\n",
         "b = np.zeros((3,4))"
-      ],
-      "execution_count": null,
-      "outputs": []
+      ]
     },
     {
       "cell_type": "markdown",
@@ -876,20 +856,17 @@
     },
     {
       "cell_type": "code",
+      "execution_count": 21,
       "metadata": {
         "colab": {
           "base_uri": "https://localhost:8080/"
         },
         "id": "gnwS5_qVCf48",
-        "outputId": "c5ed089a-2a93-422c-8501-b84e0f068d9d"
+        "outputId": "4dd0cf0a-7c16-43ab-8d6e-b61ee7665f47"
       },
-      "source": [
-        "a = np.ones((3,4))\n",
-        "paf(a)"
-      ],
-      "execution_count": null,
       "outputs": [
         {
+          "name": "stdout",
           "output_type": "stream",
           "text": [
             "shape=(3, 4), dimension=2, dtype=float64\n",
@@ -897,27 +874,27 @@
             " [1. 1. 1. 1.]\n",
             " [1. 1. 1. 1.]]\n",
             "\n"
-          ],
-          "name": "stdout"
+          ]
         }
+      ],
+      "source": [
+        "a = np.ones((3,4))\n",
+        "paf(a)"
       ]
     },
     {
       "cell_type": "code",
+      "execution_count": 22,
       "metadata": {
         "colab": {
           "base_uri": "https://localhost:8080/"
         },
         "id": "d5m8DnoaDv85",
-        "outputId": "634e5f43-85ef-4476-a671-fcf639f7bac1"
+        "outputId": "a0203231-673d-4342-8470-01ab2740acc0"
       },
-      "source": [
-        "a = np.full((3,4), 9)\n",
-        "paf(a)"
-      ],
-      "execution_count": null,
       "outputs": [
         {
+          "name": "stdout",
           "output_type": "stream",
           "text": [
             "shape=(3, 4), dimension=2, dtype=int64\n",
@@ -925,9 +902,12 @@
             " [9 9 9 9]\n",
             " [9 9 9 9]]\n",
             "\n"
-          ],
-          "name": "stdout"
+          ]
         }
+      ],
+      "source": [
+        "a = np.full((3,4), 9)\n",
+        "paf(a)"
       ]
     },
     {
@@ -941,21 +921,17 @@
     },
     {
       "cell_type": "code",
+      "execution_count": 23,
       "metadata": {
         "colab": {
           "base_uri": "https://localhost:8080/"
         },
         "id": "K6FruRRpD9Yc",
-        "outputId": "c09acf39-6d72-4966-8f55-3ad1a88b488d"
+        "outputId": "297f9b39-8613-4aae-fdbe-784feea7aecb"
       },
-      "source": [
-        "a = np.arange(12).reshape(3,4)\n",
-        "b = np.zeros_like(a)\n",
-        "paf(b)"
-      ],
-      "execution_count": null,
       "outputs": [
         {
+          "name": "stdout",
           "output_type": "stream",
           "text": [
             "shape=(3, 4), dimension=2, dtype=int64\n",
@@ -963,28 +939,28 @@
             " [0 0 0 0]\n",
             " [0 0 0 0]]\n",
             "\n"
-          ],
-          "name": "stdout"
+          ]
         }
+      ],
+      "source": [
+        "a = np.arange(12).reshape(3,4)\n",
+        "b = np.zeros_like(a)\n",
+        "paf(b)"
       ]
     },
     {
       "cell_type": "code",
+      "execution_count": 24,
       "metadata": {
         "colab": {
           "base_uri": "https://localhost:8080/"
         },
         "id": "kfm2m0vDCln3",
-        "outputId": "c46815d0-86c7-4bd7-e10d-d659bc40bfdb"
+        "outputId": "fb95994f-4e40-4a89-f347-6275da72842c"
       },
-      "source": [
-        "a = np.arange(12).reshape(3,4)\n",
-        "b = np.ones_like(a)\n",
-        "paf(b)"
-      ],
-      "execution_count": null,
       "outputs": [
         {
+          "name": "stdout",
           "output_type": "stream",
           "text": [
             "shape=(3, 4), dimension=2, dtype=int64\n",
@@ -992,28 +968,28 @@
             " [1 1 1 1]\n",
             " [1 1 1 1]]\n",
             "\n"
-          ],
-          "name": "stdout"
+          ]
         }
+      ],
+      "source": [
+        "a = np.arange(12).reshape(3,4)\n",
+        "b = np.ones_like(a)\n",
+        "paf(b)"
       ]
     },
     {
       "cell_type": "code",
+      "execution_count": 25,
       "metadata": {
         "colab": {
           "base_uri": "https://localhost:8080/"
         },
         "id": "oZoP80OoEB3H",
-        "outputId": "e55a8008-90e5-4a31-9729-3d8f2e672fe0"
+        "outputId": "5ca0a866-8942-43f8-a623-f75e5cbeac4c"
       },
-      "source": [
-        "a = np.arange(12).reshape(3,4)\n",
-        "b = np.full_like(a,9)\n",
-        "paf(b)"
-      ],
-      "execution_count": null,
       "outputs": [
         {
+          "name": "stdout",
           "output_type": "stream",
           "text": [
             "shape=(3, 4), dimension=2, dtype=int64\n",
@@ -1021,9 +997,13 @@
             " [9 9 9 9]\n",
             " [9 9 9 9]]\n",
             "\n"
-          ],
-          "name": "stdout"
+          ]
         }
+      ],
+      "source": [
+        "a = np.arange(12).reshape(3,4)\n",
+        "b = np.full_like(a,9)\n",
+        "paf(b)"
       ]
     },
     {
@@ -1037,20 +1017,17 @@
     },
     {
       "cell_type": "code",
+      "execution_count": 26,
       "metadata": {
         "colab": {
           "base_uri": "https://localhost:8080/"
         },
         "id": "suuKjP_3EOS0",
-        "outputId": "2650f442-8d04-4197-89ec-9358ef7edfb4"
+        "outputId": "036d9265-a646-47e3-ca58-8bfd61530a38"
       },
-      "source": [
-        "a = np.eye(3)\n",
-        "paf(a)"
-      ],
-      "execution_count": null,
       "outputs": [
         {
+          "name": "stdout",
           "output_type": "stream",
           "text": [
             "shape=(3, 3), dimension=2, dtype=float64\n",
@@ -1058,27 +1035,27 @@
             " [0. 1. 0.]\n",
             " [0. 0. 1.]]\n",
             "\n"
-          ],
-          "name": "stdout"
+          ]
         }
+      ],
+      "source": [
+        "a = np.eye(3)\n",
+        "paf(a)"
       ]
     },
     {
       "cell_type": "code",
+      "execution_count": 27,
       "metadata": {
         "colab": {
           "base_uri": "https://localhost:8080/"
         },
         "id": "xGiqbQhREZir",
-        "outputId": "ca87c228-fe84-4da8-f1bc-5ef16e41e772"
+        "outputId": "ba338bfe-a38d-4992-aed5-33502043cb08"
       },
-      "source": [
-        "a = np.eye(5)\n",
-        "paf(a)"
-      ],
-      "execution_count": null,
       "outputs": [
         {
+          "name": "stdout",
           "output_type": "stream",
           "text": [
             "shape=(5, 5), dimension=2, dtype=float64\n",
@@ -1088,9 +1065,12 @@
             " [0. 0. 0. 1. 0.]\n",
             " [0. 0. 0. 0. 1.]]\n",
             "\n"
-          ],
-          "name": "stdout"
+          ]
         }
+      ],
+      "source": [
+        "a = np.eye(5)\n",
+        "paf(a)"
       ]
     },
     {
@@ -1115,29 +1095,29 @@
     },
     {
       "cell_type": "code",
+      "execution_count": 28,
       "metadata": {
         "colab": {
           "base_uri": "https://localhost:8080/"
         },
         "id": "3J-elhY0Eb7T",
-        "outputId": "a7dccb8e-fca8-491a-c474-3a38b111e544"
+        "outputId": "4d3621a3-b1c6-42a4-e897-73fea6b1cd9d"
       },
-      "source": [
-        "a = np.random.rand(10)\n",
-        "paf(a)"
-      ],
-      "execution_count": null,
       "outputs": [
         {
+          "name": "stdout",
           "output_type": "stream",
           "text": [
             "shape=(10,), dimension=1, dtype=float64\n",
-            "[0.80766515 0.05779151 0.04767833 0.99349897 0.02464331 0.20765442\n",
-            " 0.70306882 0.18226527 0.51490508 0.74830849]\n",
+            "[0.72005961 0.93001495 0.42845221 0.41004575 0.22624822 0.44752332\n",
+            " 0.02286037 0.04913273 0.81638257 0.6759105 ]\n",
             "\n"
-          ],
-          "name": "stdout"
+          ]
         }
+      ],
+      "source": [
+        "a = np.random.rand(10)\n",
+        "paf(a)"
       ]
     },
     {
@@ -1151,64 +1131,63 @@
     },
     {
       "cell_type": "code",
+      "execution_count": 29,
       "metadata": {
         "colab": {
           "base_uri": "https://localhost:8080/",
           "height": 265
         },
         "id": "GIfv5Ym7Et40",
-        "outputId": "b1c754cd-b490-4e8d-9612-3fdfa377779b"
+        "outputId": "ab17729f-0532-4768-f459-d41b0d7111d5"
       },
+      "outputs": [
+        {
+          "data": {
+            "image/png": "iVBORw0KGgoAAAANSUhEUgAAAXcAAAD4CAYAAAAXUaZHAAAABHNCSVQICAgIfAhkiAAAAAlwSFlzAAALEgAACxIB0t1+/AAAADh0RVh0U29mdHdhcmUAbWF0cGxvdGxpYiB2ZXJzaW9uMy4yLjIsIGh0dHA6Ly9tYXRwbG90bGliLm9yZy+WH4yJAAAPzUlEQVR4nO3dfYylZ1nH8e+PrgVBpIUdm7pt3RKKulYNzaSUkCCyREsh3SY2zTaCC65uQEAUEyjyR41K0kYFISK6oZXFIKVWtBsBtZY2jYQWp7T2lZelULp12x2E1hcisHL5x3mK4zLbOTPPnLd7vp9kM+c8L+dc9zlnfnOd+zzn2VQVkqS2PGHSBUiS1p/hLkkNMtwlqUGGuyQ1yHCXpAZtmnQBAJs3b66tW7dOugxJmim33nrrV6pqbrl1UxHuW7duZWFhYdJlSNJMSXL/sdY5LSNJDTLcJalBhrskNchwl6QGGe6S1CDDXZIaZLhLUoMMd0lqkOEuSQ2aim+oStI4bL3kI9+5/KXLXjrBSkbPzl2SGmS4S1KDVgz3JFcmOZzkriXLfi/JZ5LckeSvk5ywZN1bkhxI8tkkPzuqwiVJxzZM5/4+4Nyjll0HnFlVPwF8DngLQJJtwE7gx7p9/jjJcetWrSRpKCt+oFpVNyXZetSyf1hy9Wbgwu7yDuCqqvoG8MUkB4CzgU+uS7UzaCN9gCNpeqzHnPsvAh/rLm8BHliy7mC37Lsk2ZNkIcnC4uLiOpQhSXpMr3BP8lbgCPCB1e5bVXurar6q5ufmlv2PRCRJa7Tm49yTvBJ4GbC9qqpb/CBw6pLNTumWaQNxKkqavDV17knOBd4EnF9VX1+yaj+wM8kTk5wOnAF8qn+ZkqTVWLFzT/JB4IXA5iQHgUsZHB3zROC6JAA3V9Wrq+ruJFcD9zCYrnltVf3PqIqXJC1vmKNlLl5m8RWPs/3bgLf1KUqPz2kPSSvxG6qS1CDDXZIaZLhLUoM85a82rKWfXYCfX6gtdu6S1CDDXZIa5LTMEsc6xHCjHHo4bePsU8+0jeVo016fZp+duyQ1yM5dE2cXq1E6+oPzjWLDhPuxnuBpCxODbrTG8YvuczhaPr7DcVpGkhq0YTp3aZattlu1u5WduyQ1yM69IZPs1jbqh1bStLJzl6QGGe6S1CCnZUaghSkKP5Abn2l/rKe9Pi3Pzl2SGmTnPgVG3el7att+7FxX5mM0fQx3SSPT8snfpp3TMpLUIDv3VbITmbxpeRynpQ5pOXbuktQgO3dJY+e7ntEz3KVlzMp3FQzJ2THu52rFaZkkVyY5nOSuJcuenuS6JJ/vfp7YLU+SdyU5kOSOJGeNsnhJ0vKG6dzfB/wR8P4lyy4Brq+qy5Jc0l1/M/AS4Izu33OB93Q/J2JWui/9H5+zjceDFEZjxc69qm4CvnrU4h3Avu7yPuCCJcvfXwM3AyckOXm9ipUkDWetc+4nVdWh7vJDwEnd5S3AA0u2O9gtO8RRkuwB9gCcdtppayzj/7PrGw27o+ky7m80t6rPf4Ay7D6T1PsD1aqqJLWG/fYCewHm5+dXvb8GNuIvolZnI/5xHvfrZRof47Ue5/7wY9Mt3c/D3fIHgVOXbHdKt0ySNEZr7dz3A7uAy7qf1y5Z/rokVzH4IPXRJdM3I2FHp8f4WhgvH+/ptmK4J/kg8EJgc5KDwKUMQv3qJLuB+4GLus0/CpwHHAC+DrxqBDVLklawYrhX1cXHWLV9mW0LeG3fombFNM6zSZM26x19K7/XfkP1GGb9BToOq32MWvmlGZdpfA1OY02jNMvj9cRhktQgO3dpFVp9tzItHeq01DGMaa/Vzl2SGmTnPiOmvUvQ5Pka0VKGu2baLAXaLNWq2ee0jCQ1yM69UdPeJU57fas1i+OZxZo1PDt3SWqQnbskjcgk3x0Z7tIUaXmqpOWxTSOnZSSpQXbuG9CsfGtSeoxd/+rZuUtSg+zcNVJ2XNJk2LlLUoPs3NU83z1oI9rw4b7Rf/E3+viX8rGYbdPy/E1LHU7LSFKDNnznPinT8td9tWa1bmmajONwZDt3SWqQ4S5JDXJaRtpAnFbbOOzcJalBvTr3JL8O/BJQwJ3Aq4CTgauAZwC3Aq+oqm/2rHPqjaIjssuStFZr7tyTbAF+FZivqjOB44CdwOXAO6rqWcDXgN3rUagkaXh9p2U2Ad+bZBPwZOAQ8CLgmm79PuCCnvchSVqlNYd7VT0I/D7wZQah/iiDaZhHqupIt9lBYMty+yfZk2QhycLi4uJay5AkLaPPtMyJwA7gdOAHgacA5w67f1Xtrar5qpqfm5tbaxmSpGX0mZZ5MfDFqlqsqm8BHwaeD5zQTdMAnAI82LNGSdIq9Qn3LwPnJHlykgDbgXuAG4ALu212Adf2K1GStFprPhSyqm5Jcg3waeAIcBuwF/gIcFWS3+2WXbEehUrSqLR42HGv49yr6lLg0qMW3wec3ed2JUn9+A1VSWqQ4S5JDTLcJalBhrskNchwl6QGGe6S1CDDXZIaZLhLUoMMd0lqkOEuSQ0y3CWpQYa7JDXIcJekBhnuktQgw12SGmS4S1KDDHdJapDhLkkNMtwlqUGGuyQ1yHCXpAYZ7pLUIMNdkhpkuEtSg3qFe5ITklyT5DNJ7k3yvCRPT3Jdks93P09cr2IlScPp27m/E/i7qvoR4CeBe4FLgOur6gzg+u66JGmM1hzuSZ4GvAC4AqCqvllVjwA7gH3dZvuAC/oWKUlanT6d++nAIvBnSW5L8t4kTwFOqqpD3TYPASf1LVKStDp9wn0TcBbwnqp6DvBfHDUFU1UF1HI7J9mTZCHJwuLiYo8yJElH6xPuB4GDVXVLd/0aBmH/cJKTAbqfh5fbuar2VtV8Vc3Pzc31KEOSdLQ1h3tVPQQ8kOSHu0XbgXuA/cCubtku4NpeFUqSVm1Tz/1fD3wgyfHAfcCrGPzBuDrJbuB+4KKe9yFJWqVe4V5VtwPzy6za3ud2JUn9+A1VSWqQ4S5JDTLcJalBhrskNchwl6QGGe6S1CDDXZIaZLhLUoMMd0lqkOEuSQ0y3CWpQYa7JDXIcJekBhnuktQgw12SGmS4S1KDDHdJapDhLkkNMtwlqUGGuyQ1yHCXpAYZ7pLUIMNdkhpkuEtSgwx3SWpQ73BPclyS25L8bXf99CS3JDmQ5ENJju9fpiRpNdajc38DcO+S65cD76iqZwFfA3avw31IklahV7gnOQV4KfDe7nqAFwHXdJvsAy7ocx+SpNXr27n/IfAm4Nvd9WcAj1TVke76QWDLcjsm2ZNkIcnC4uJizzIkSUutOdyTvAw4XFW3rmX/qtpbVfNVNT83N7fWMiRJy9jUY9/nA+cnOQ94EvD9wDuBE5Js6rr3U4AH+5cpSVqNNXfuVfWWqjqlqrYCO4GPV9XPAzcAF3ab7QKu7V2lJGlVRnGc+5uBNyY5wGAO/ooR3Ick6XH0mZb5jqq6Ebixu3wfcPZ63K4kaW38hqokNchwl6QGGe6S1CDDXZIaZLhLUoMMd0lqkOEuSQ0y3CWpQYa7JDXIcJekBhnuktQgw12SGmS4S1KDDHdJapDhLkkNMtwlqUGGuyQ1yHCXpAYZ7pLUIMNdkhpkuEtSgwx3SWqQ4S5JDTLcJalBaw73JKcmuSHJPUnuTvKGbvnTk1yX5PPdzxPXr1xJ0jD6dO5HgN+oqm3AOcBrk2wDLgGur6ozgOu765KkMVpzuFfVoar6dHf5P4B7gS3ADmBft9k+4IK+RUqSVmdd5tyTbAWeA9wCnFRVh7pVDwEnHWOfPUkWkiwsLi6uRxmSpE7vcE/yfcBfAb9WVf++dF1VFVDL7VdVe6tqvqrm5+bm+pYhSVqiV7gn+R4Gwf6Bqvpwt/jhJCd3608GDvcrUZK0Wn2OlglwBXBvVb19yar9wK7u8i7g2rWXJ0lai0099n0+8ArgziS3d8t+E7gMuDrJbuB+4KJ+JUqSVmvN4V5V/wTkGKu3r/V2JUn9+Q1VSWqQ4S5JDTLcJalBhrskNchwl6QGGe6S1CDDXZIaZLhLUoMMd0lqkOEuSQ0y3CWpQYa7JDXIcJekBhnuktQgw12SGmS4S1KDDHdJapDhLkkNMtwlqUGGuyQ1yHCXpAYZ7pLUIMNdkhpkuEtSgwx3SWrQyMI9yblJPpvkQJJLRnU/kqTvNpJwT3Ic8G7gJcA24OIk20ZxX5Kk7zaqzv1s4EBV3VdV3wSuAnaM6L4kSUfZNKLb3QI8sOT6QeC5SzdIsgfY0139zySfXeN9bQa+ssZ9Z5Vj3hgc8waQy3uN+YeOtWJU4b6iqtoL7O17O0kWqmp+HUqaGY55Y3DMG8OoxjyqaZkHgVOXXD+lWyZJGoNRhfs/A2ckOT3J8cBOYP+I7kuSdJSRTMtU1ZEkrwP+HjgOuLKq7h7FfbEOUzszyDFvDI55YxjJmFNVo7hdSdIE+Q1VSWqQ4S5JDZqZcF/pdAZJnpjkQ936W5JsHX+V62uIMb8xyT1J7khyfZJjHvM6K4Y9bUWSn0tSSWb+sLlhxpzkou65vjvJX4y7xvU2xGv7tCQ3JLmte32fN4k610uSK5McTnLXMdYnybu6x+OOJGf1vtOqmvp/DD6U/QLwTOB44F+AbUdt8yvAn3SXdwIfmnTdYxjzTwNP7i6/ZiOMudvuqcBNwM3A/KTrHsPzfAZwG3Bid/0HJl33GMa8F3hNd3kb8KVJ191zzC8AzgLuOsb684CPAQHOAW7pe5+z0rkPczqDHcC+7vI1wPYkGWON623FMVfVDVX19e7qzQy+TzDLhj1txe8AlwP/Pc7iRmSYMf8y8O6q+hpAVR0ec43rbZgxF/D93eWnAf86xvrWXVXdBHz1cTbZAby/Bm4GTkhycp/7nJVwX+50BluOtU1VHQEeBZ4xlupGY5gxL7WbwV/+WbbimLu3q6dW1UfGWdgIDfM8Pxt4dpJPJLk5ybljq240hhnzbwEvT3IQ+Cjw+vGUNjGr/X1f0cROP6D1k+TlwDzwU5OuZZSSPAF4O/DKCZcybpsYTM28kMG7s5uS/HhVPTLRqkbrYuB9VfUHSZ4H/HmSM6vq25MubFbMSuc+zOkMvrNNkk0M3sr921iqG42hTuGQ5MXAW4Hzq+obY6ptVFYa81OBM4Ebk3yJwdzk/hn/UHWY5/kgsL+qvlVVXwQ+xyDsZ9UwY94NXA1QVZ8EnsTgpGKtWvdTtsxKuA9zOoP9wK7u8oXAx6v7pGJGrTjmJM8B/pRBsM/6PCysMOaqerSqNlfV1qrayuBzhvOramEy5a6LYV7bf8OgayfJZgbTNPeNs8h1NsyYvwxsB0jyowzCfXGsVY7XfuAXuqNmzgEerapDvW5x0p8ir+LT5vMYdCxfAN7aLfttBr/cMHjy/xI4AHwKeOakax7DmP8ReBi4vfu3f9I1j3rMR217IzN+tMyQz3MYTEfdA9wJ7Jx0zWMY8zbgEwyOpLkd+JlJ19xzvB8EDgHfYvBObDfwauDVS57jd3ePx53r8br29AOS1KBZmZaRJK2C4S5JDTLcJalBhrskNchwl6QGGe6S1CDDXZIa9L/62LAcsWwGegAAAABJRU5ErkJggg==",
+            "text/plain": [
+              "<Figure size 432x288 with 1 Axes>"
+            ]
+          },
+          "metadata": {
+            "needs_background": "light"
+          },
+          "output_type": "display_data"
+        }
+      ],
       "source": [
         "a = np.random.rand(10000)\n",
         "\n",
         "import matplotlib.pyplot as plt\n",
         "plt.hist(a, bins=100)\n",
         "plt.show()"
-      ],
-      "execution_count": null,
-      "outputs": [
-        {
-          "output_type": "display_data",
-          "data": {
-            "image/png": "iVBORw0KGgoAAAANSUhEUgAAAXcAAAD4CAYAAAAXUaZHAAAABHNCSVQICAgIfAhkiAAAAAlwSFlzAAALEgAACxIB0t1+/AAAADh0RVh0U29mdHdhcmUAbWF0cGxvdGxpYiB2ZXJzaW9uMy4yLjIsIGh0dHA6Ly9tYXRwbG90bGliLm9yZy+WH4yJAAAPyklEQVR4nO3df4zkd13H8eeLngVBoIVbm3pXvBKKelYNzaaUkCByREshvSaSpo3ogRcvICCKCRT5o0ZD0kYFISJ6oZXDYGmtaC8Cai1tGoktbmntT34chdKr194itP4gApW3f8wXWK+73Zn9zuzsfPb5SC478/0x8/7MzL72/f3Md+ZSVUiS2vKEaRcgSRo/w12SGmS4S1KDDHdJapDhLkkN2jLtAgC2bt1aO3bsmHYZkjRTbrnllq9U1dxy6zZEuO/YsYOFhYVplyFJMyXJfSutc1pGkhpkuEtSgwx3SWqQ4S5JDVo13JNcnuRokjuXLPu9JJ9JcnuSv05ywpJ1b0tyKMlnk/zcpAqXJK1smM79A8DZxyy7Fji9qn4S+BzwNoAkO4ELgB/v9vnjJMeNrVpJ0lBWDfequhH46jHL/qGqHu2u3gRs7y7vBj5cVd+oqi8Ch4Azx1ivJGkI45hz/2Xg493lbcD9S9Yd7pY9RpJ9SRaSLCwuLo6hDEnSd/QK9yRvBx4FPjTqvlW1v6rmq2p+bm7ZD1hJktZozZ9QTfJq4BXArvre//jxAHDKks22d8sE7Ljoo9+9/KVLXj7FSiS1bk2de5KzgbcA51bV15esOghckOSJSU4FTgM+1b9MSdIoVu3ck1wBvBjYmuQwcDGDs2OeCFybBOCmqnptVd2V5CrgbgbTNa+vqv+dVPGSpOWtGu5VdeEyiy97nO3fAbyjT1Ear6XTQeCUkLQZ+AlVSWqQ4S5JDTLcJalBhrskNWhD/E9M0ij8vIC0Ojt3SWqQnfuIWuga+4xhWuM/9nROaZatx++RnbskNcjOvYdJ//XdLEcJLYxzI/Bx1FJ27pLUIDv3GWSHJj2Wvxf/n+G+xCReHL4RKGkanJaRpAbZuc+41g5FWz7S2QinkbbwGtFw7NwlqUGGuyQ1yHCXpAY5565lOU8rzTbDfZMzxKU2OS0jSQ3aNJ37rHSoLZ8KqM1hVn7XWmfnLkkNaqpzP7br3cxdg0cAo/MbLFe30uuqz2Ox2R/TSbFzl6QGNdW5azJm5ShgEl2l1tdG7uJnbWbAcNem1feP1kYOoj7WI8RmpWGYZatOyyS5PMnRJHcuWfaMJNcm+Xz388RueZK8J8mhJLcnOWOSxUuSljdM5/4B4I+ADy5ZdhFwXVVdkuSi7vpbgZcBp3X/ng+8r/spSVM36tHW4x1hbPQjt1U796q6EfjqMYt3Awe6yweA85Ys/2AN3ASckOTkcRUrSRrOWufcT6qqI93lB4GTusvbgPuXbHe4W3aEYyTZB+wDeNaznrXGMjaOjf5XXBtXnzeCV9rXOe3RtPj72/tUyKoqoNaw3/6qmq+q+bm5ub5lSJKWWGvn/lCSk6vqSDftcrRb/gBwypLttnfLpKlpsSvbaDxSWN16P0ZrDfeDwB7gku7nNUuWvyHJhxm8kfrIkukb9bAeL4w+92GAapJWen35R2Vlq4Z7kiuAFwNbkxwGLmYQ6lcl2QvcB5zfbf4x4BzgEPB14DUTqFmStIpVw72qLlxh1a5lti3g9X2L0tpslC5mo9SxkW20x2ij1aP+/G4ZSWqQXz8wAXZBGoeN8j5Gq6/nVsf1HYb7CjbKL1arWvvF8vWyutae843OaRlJapCdu6SJ2Qjd+kaoYRrs3CWpQXbuWjeT6KA2a1em2TDN16eduyQ1yM59CJPuOD27YuPp8/x4NDEe03ocx/k/dE1T0+G+UR7k1cxKnZvVRnh+bAY0KqdlJKlBTXfuUos2wpGENj47d0lqkJ271swOUtPg6244du6S1KCZ79xbOW1JksZp5sNdGoV/zL/Hx6JtTstIUoPs3CU1x6MSO3dJapLhLkkNMtwlqUHOuUtSTxtxjt9wlzaRjRhCmgynZSSpQb3CPclvJLkryZ1JrkjypCSnJrk5yaEkVyY5flzFSpKGs+ZwT7IN+DVgvqpOB44DLgAuBd5VVc8BvgbsHUehkqTh9Z2W2QJ8f5ItwJOBI8BLgKu79QeA83rehyRpRGsO96p6APh94MsMQv0R4Bbg4ap6tNvsMLCtb5GSpNH0mZY5EdgNnAr8EPAU4OwR9t+XZCHJwuLi4lrLkCQto8+pkC8FvlhViwBJPgK8EDghyZaue98OPLDczlW1H9gPMD8/Xz3qGJmng0lqXZ859y8DZyV5cpIAu4C7geuBV3bb7AGu6VeiJGlUfebcb2bwxumngTu629oPvBV4c5JDwDOBy8ZQpyRpBL0+oVpVFwMXH7P4XuDMPrcrSerHT6hKUoMMd0lqkOEuSQ0y3CWpQYa7JDXIcJekBhnuktQgw12SGmS4S1KDDHdJapDhLkkNMtwlqUGGuyQ1yHCXpAYZ7pLUIMNdkhpkuEtSgwx3SWqQ4S5JDTLcJalBhrskNchwl6QGGe6S1CDDXZIaZLhLUoMMd0lqUK9wT3JCkquTfCbJPUlekOQZSa5N8vnu54njKlaSNJy+nfu7gb+rqh8Ffgq4B7gIuK6qTgOu665LktbRmsM9ydOBFwGXAVTVN6vqYWA3cKDb7ABwXt8iJUmj6dO5nwosAn+W5NYk70/yFOCkqjrSbfMgcNJyOyfZl2QhycLi4mKPMiRJx+oT7luAM4D3VdXzgP/mmCmYqiqgltu5qvZX1XxVzc/NzfUoQ5J0rD7hfhg4XFU3d9evZhD2DyU5GaD7ebRfiZKkUa053KvqQeD+JD/SLdoF3A0cBPZ0y/YA1/SqUJI0si09938j8KEkxwP3Aq9h8AfjqiR7gfuA83vehyRpRL3CvapuA+aXWbWrz+1KkvrxE6qS1CDDXZIaZLhLUoMMd0lqkOEuSQ0y3CWpQYa7JDXIcJekBhnuktQgw12SGmS4S1KDDHdJapDhLkkNMtwlqUGGuyQ1yHCXpAYZ7pLUIMNdkhpkuEtSgwx3SWqQ4S5JDTLcJalBhrskNchwl6QGGe6S1CDDXZIa1DvckxyX5NYkf9tdPzXJzUkOJbkyyfH9y5QkjWIcnfubgHuWXL8UeFdVPQf4GrB3DPchSRpBr3BPsh14OfD+7nqAlwBXd5scAM7rcx+SpNH17dz/EHgL8O3u+jOBh6vq0e76YWDbcjsm2ZdkIcnC4uJizzIkSUutOdyTvAI4WlW3rGX/qtpfVfNVNT83N7fWMiRJy9jSY98XAucmOQd4EvA04N3ACUm2dN37duCB/mVKkkax5s69qt5WVduragdwAfCJqvoF4Hrgld1me4BrelcpSRrJJM5zfyvw5iSHGMzBXzaB+5AkPY4+0zLfVVU3ADd0l+8FzhzH7UqS1sZPqEpSgwx3SWqQ4S5JDTLcJalBhrskNchwl6QGGe6S1CDDXZIaZLhLUoMMd0lqkOEuSQ0y3CWpQYa7JDXIcJekBhnuktQgw12SGmS4S1KDDHdJapDhLkkNMtwlqUGGuyQ1yHCXpAYZ7pLUIMNdkhpkuEtSgwx3SWrQmsM9ySlJrk9yd5K7krypW/6MJNcm+Xz388TxlStJGkafzv1R4DeraidwFvD6JDuBi4Drquo04LruuiRpHa053KvqSFV9urv8n8A9wDZgN3Cg2+wAcF7fIiVJoxnLnHuSHcDzgJuBk6rqSLfqQeCkFfbZl2QhycLi4uI4ypAkdXqHe5IfAP4K+PWq+o+l66qqgFpuv6raX1XzVTU/NzfXtwxJ0hK9wj3J9zEI9g9V1Ue6xQ8lOblbfzJwtF+JkqRR9TlbJsBlwD1V9c4lqw4Ce7rLe4Br1l6eJGkttvTY94XALwJ3JLmtW/ZbwCXAVUn2AvcB5/crUZI0qjWHe1X9E5AVVu9a6+1KkvrzE6qS1CDDXZIaZLhLUoMMd0lqkOEuSQ0y3CWpQYa7JDXIcJekBhnuktQgw12SGmS4S1KDDHdJapDhLkkNMtwlqUGGuyQ1yHCXpAYZ7pLUIMNdkhpkuEtSgwx3SWqQ4S5JDTLcJalBhrskNchwl6QGGe6S1CDDXZIaNLFwT3J2ks8mOZTkokndjyTpsSYS7kmOA94LvAzYCVyYZOck7kuS9FiT6tzPBA5V1b1V9U3gw8DuCd2XJOkYWyZ0u9uA+5dcPww8f+kGSfYB+7qr/5Xks2u8r63AV9a476xyzJuDY94EcmmvMf/wSismFe6rqqr9wP6+t5Nkoarmx1DSzHDMm4Nj3hwmNeZJTcs8AJyy5Pr2bpkkaR1MKtz/BTgtyalJjgcuAA5O6L4kSceYyLRMVT2a5A3A3wPHAZdX1V2TuC/GMLUzgxzz5uCYN4eJjDlVNYnblSRNkZ9QlaQGGe6S1KCZCffVvs4gyROTXNmtvznJjvWvcryGGPObk9yd5PYk1yVZ8ZzXWTHs11Yk+fkklWTmT5sbZsxJzu+e67uS/MV61zhuQ7y2n5Xk+iS3dq/vc6ZR57gkuTzJ0SR3rrA+Sd7TPR63Jzmj951W1Yb/x+BN2S8AzwaOB/4V2HnMNr8K/El3+QLgymnXvQ5j/hngyd3l122GMXfbPRW4EbgJmJ923evwPJ8G3Aqc2F3/wWnXvQ5j3g+8rru8E/jStOvuOeYXAWcAd66w/hzg40CAs4Cb+97nrHTuw3ydwW7gQHf5amBXkqxjjeO26pir6vqq+np39SYGnyeYZcN+bcXvApcC/7OexU3IMGP+FeC9VfU1gKo6us41jtswYy7gad3lpwP/to71jV1V3Qh89XE22Q18sAZuAk5IcnKf+5yVcF/u6wy2rbRNVT0KPAI8c12qm4xhxrzUXgZ/+WfZqmPuDldPqaqPrmdhEzTM8/xc4LlJPpnkpiRnr1t1kzHMmH8beFWSw8DHgDeuT2lTM+rv+6qm9vUDGp8krwLmgZ+edi2TlOQJwDuBV0+5lPW2hcHUzIsZHJ3dmOQnqurhqVY1WRcCH6iqP0jyAuDPk5xeVd+edmGzYlY692G+zuC72yTZwuBQ7t/XpbrJGOorHJK8FHg7cG5VfWOdapuU1cb8VOB04IYkX2IwN3lwxt9UHeZ5PgwcrKpvVdUXgc8xCPtZNcyY9wJXAVTVPwNPYvClYq0a+1e2zEq4D/N1BgeBPd3lVwKfqO6dihm16piTPA/4UwbBPuvzsLDKmKvqkaraWlU7qmoHg/cZzq2qhemUOxbDvLb/hkHXTpKtDKZp7l3PIsdsmDF/GdgFkOTHGIT74rpWub4OAr/UnTVzFvBIVR3pdYvTfhd5hHebz2HQsXwBeHu37HcY/HLD4Mn/S+AQ8Cng2dOueR3G/I/AQ8Bt3b+D06550mM+ZtsbmPGzZYZ8nsNgOupu4A7ggmnXvA5j3gl8ksGZNLcBPzvtmnuO9wrgCPAtBkdie4HXAq9d8hy/t3s87hjH69qvH5CkBs3KtIwkaQSGuyQ1yHCXpAYZ7pLUIMNdkhpkuEtSgwx3SWrQ/wHNH65ez+ko8wAAAABJRU5ErkJggg==\n",
-            "text/plain": [
-              "<Figure size 432x288 with 1 Axes>"
-            ]
-          },
-          "metadata": {
-            "tags": [],
-            "needs_background": "light"
-          }
-        }
       ]
     },
     {
       "cell_type": "code",
+      "execution_count": 30,
       "metadata": {
         "colab": {
           "base_uri": "https://localhost:8080/"
         },
         "id": "E820WQMaJGTw",
-        "outputId": "c38b296e-d7f8-4680-a32d-4842e8fb6f5a"
+        "outputId": "45b78e70-8406-4672-b482-590f8f12292d"
       },
-      "source": [
-        "a = np.random.rand(3,4)\n",
-        "paf(a)"
-      ],
-      "execution_count": null,
       "outputs": [
         {
+          "name": "stdout",
           "output_type": "stream",
           "text": [
             "shape=(3, 4), dimension=2, dtype=float64\n",
-            "[[0.20158239 0.41542751 0.71559019 0.31998776]\n",
-            " [0.49412704 0.99676997 0.97556191 0.35991507]\n",
-            " [0.52223431 0.9745833  0.34221474 0.40789858]]\n",
+            "[[0.58535878 0.39828697 0.4260168  0.45584203]\n",
+            " [0.09403228 0.834621   0.0427     0.7862339 ]\n",
+            " [0.76918504 0.27728895 0.38072185 0.53157426]]\n",
             "\n"
-          ],
-          "name": "stdout"
+          ]
         }
+      ],
+      "source": [
+        "a = np.random.rand(3,4)\n",
+        "paf(a)"
       ]
     },
     {
@@ -1222,54 +1201,54 @@
     },
     {
       "cell_type": "code",
+      "execution_count": 31,
       "metadata": {
         "colab": {
           "base_uri": "https://localhost:8080/"
         },
         "id": "fdiJubJXE1F-",
-        "outputId": "031595db-9745-4f90-f813-956c8c85c87d"
+        "outputId": "ec2b2f8d-640d-486e-ca6f-b8bd625744f7"
       },
-      "source": [
-        "a = np.ceil(np.random.rand(12)*6).astype(int)\n",
-        "paf(a)"
-      ],
-      "execution_count": null,
       "outputs": [
         {
+          "name": "stdout",
           "output_type": "stream",
           "text": [
             "shape=(12,), dimension=1, dtype=int64\n",
-            "[6 2 6 3 2 3 4 2 3 4 3 4]\n",
+            "[5 6 1 4 1 5 5 1 5 4 3 2]\n",
             "\n"
-          ],
-          "name": "stdout"
+          ]
         }
+      ],
+      "source": [
+        "a = np.ceil(np.random.rand(12)*6).astype(int)\n",
+        "paf(a)"
       ]
     },
     {
       "cell_type": "code",
+      "execution_count": 32,
       "metadata": {
         "colab": {
           "base_uri": "https://localhost:8080/"
         },
         "id": "DT2ylLy5E-fd",
-        "outputId": "59c985fc-9024-43b9-ff4e-5bdc80312a17"
+        "outputId": "11f7c527-fb83-4c17-8f05-e8ceba681df3"
       },
-      "source": [
-        "a = np.random.randint(1, 7, size=12)\n",
-        "paf(a)"
-      ],
-      "execution_count": null,
       "outputs": [
         {
+          "name": "stdout",
           "output_type": "stream",
           "text": [
             "shape=(12,), dimension=1, dtype=int64\n",
-            "[5 1 6 1 3 4 6 1 2 6 2 3]\n",
+            "[2 5 1 1 5 2 5 3 6 1 4 2]\n",
             "\n"
-          ],
-          "name": "stdout"
+          ]
         }
+      ],
+      "source": [
+        "a = np.random.randint(1, 7, size=12)\n",
+        "paf(a)"
       ]
     },
     {
@@ -1283,30 +1262,30 @@
     },
     {
       "cell_type": "code",
+      "execution_count": 33,
       "metadata": {
         "colab": {
           "base_uri": "https://localhost:8080/"
         },
         "id": "OGiQejhoFR-5",
-        "outputId": "48486ff8-cce2-4bd9-a920-8a422c3c802d"
+        "outputId": "8d3ec61b-4ccb-4e6c-ef16-1e9c7429d19c"
       },
-      "source": [
-        "a = np.random.randint(1, 7, size=(3,4))\n",
-        "paf(a)"
-      ],
-      "execution_count": null,
       "outputs": [
         {
+          "name": "stdout",
           "output_type": "stream",
           "text": [
             "shape=(3, 4), dimension=2, dtype=int64\n",
-            "[[6 3 2 2]\n",
-            " [3 2 2 3]\n",
-            " [1 4 5 4]]\n",
+            "[[6 4 3 3]\n",
+            " [5 3 1 6]\n",
+            " [6 5 1 3]]\n",
             "\n"
-          ],
-          "name": "stdout"
+          ]
         }
+      ],
+      "source": [
+        "a = np.random.randint(1, 7, size=(3,4))\n",
+        "paf(a)"
       ]
     },
     {
@@ -1321,91 +1300,121 @@
     },
     {
       "cell_type": "code",
+      "execution_count": 34,
       "metadata": {
         "colab": {
           "base_uri": "https://localhost:8080/"
         },
         "id": "diJkurqiF4vg",
-        "outputId": "8c44bb98-61c0-49f9-e744-a26ed06ba4f3"
+        "outputId": "87449113-0822-4f23-bb98-44909966ae56"
       },
-      "source": [
-        " a = np.random.randn(10)\n",
-        " paf(a)"
-      ],
-      "execution_count": null,
       "outputs": [
         {
+          "name": "stdout",
           "output_type": "stream",
           "text": [
             "shape=(10,), dimension=1, dtype=float64\n",
-            "[-0.70801157 -0.49777664  0.92939457  0.21549183  0.9941236  -0.11493313\n",
-            "  0.53711129 -1.34512615 -0.4865359  -0.71839365]\n",
+            "[-0.09426955  0.77569138 -1.76227832  2.01413792 -0.76230425  0.48001561\n",
+            "  0.5403314   1.35819643  1.80560887  0.83075327]\n",
             "\n"
-          ],
-          "name": "stdout"
+          ]
         }
+      ],
+      "source": [
+        "a = np.random.randn(10)\n",
+        "paf(a)"
       ]
     },
     {
       "cell_type": "code",
+      "execution_count": 35,
       "metadata": {
         "colab": {
           "base_uri": "https://localhost:8080/"
         },
         "id": "vg70uZejFR7X",
-        "outputId": "dd80435b-0143-4f3d-9144-16fbdff52215"
+        "outputId": "91fd985e-c627-45ff-fd82-8828fe52a408"
       },
-      "source": [
-        " a = np.random.randn(3,4)\n",
-        " paf(a)"
-      ],
-      "execution_count": null,
       "outputs": [
         {
+          "name": "stdout",
           "output_type": "stream",
           "text": [
             "shape=(3, 4), dimension=2, dtype=float64\n",
-            "[[ 0.11314027 -0.80917778 -2.01917962  1.7624864 ]\n",
-            " [-0.18769248  0.32737454  0.88985877  1.37121664]\n",
-            " [-0.01535333 -0.92674612 -0.84985342  0.18126369]]\n",
+            "[[-1.21813126 -0.52271655  1.5479345  -0.059219  ]\n",
+            " [ 0.93396918  1.9138984  -0.26808795 -1.30544238]\n",
+            " [-0.72224512 -0.35443464  0.19545958  0.23894324]]\n",
             "\n"
-          ],
-          "name": "stdout"
+          ]
         }
+      ],
+      "source": [
+        "a = np.random.randn(3,4)\n",
+        "paf(a)"
       ]
     },
     {
       "cell_type": "code",
+      "execution_count": 36,
+      "metadata": {
+        "colab": {
+          "base_uri": "https://localhost:8080/"
+        },
+        "id": "jwnVqtgKutFH",
+        "outputId": "e6f43e03-00a6-467f-de24-63ebe0cb297a"
+      },
+      "outputs": [
+        {
+          "name": "stdout",
+          "output_type": "stream",
+          "text": [
+            "Looking in indexes: https://pypi.org/simple, https://us-python.pkg.dev/colab-wheels/public/simple/\n",
+            "Requirement already satisfied: matplotlib in /usr/local/lib/python3.7/dist-packages (3.2.2)\n",
+            "Requirement already satisfied: pyparsing!=2.0.4,!=2.1.2,!=2.1.6,>=2.0.1 in /usr/local/lib/python3.7/dist-packages (from matplotlib) (3.0.9)\n",
+            "Requirement already satisfied: cycler>=0.10 in /usr/local/lib/python3.7/dist-packages (from matplotlib) (0.11.0)\n",
+            "Requirement already satisfied: python-dateutil>=2.1 in /usr/local/lib/python3.7/dist-packages (from matplotlib) (2.8.2)\n",
+            "Requirement already satisfied: kiwisolver>=1.0.1 in /usr/local/lib/python3.7/dist-packages (from matplotlib) (1.4.3)\n",
+            "Requirement already satisfied: numpy>=1.11 in /usr/local/lib/python3.7/dist-packages (from matplotlib) (1.21.6)\n",
+            "Requirement already satisfied: typing-extensions in /usr/local/lib/python3.7/dist-packages (from kiwisolver>=1.0.1->matplotlib) (4.1.1)\n",
+            "Requirement already satisfied: six>=1.5 in /usr/local/lib/python3.7/dist-packages (from python-dateutil>=2.1->matplotlib) (1.15.0)\n"
+          ]
+        }
+      ],
+      "source": [
+        "%pip install matplotlib"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 37,
       "metadata": {
         "colab": {
           "base_uri": "https://localhost:8080/",
           "height": 265
         },
         "id": "9cI-4ngzFR32",
-        "outputId": "e69f2959-7cea-4b35-d32b-af7d8e622c98"
+        "outputId": "3f4fcdda-88ac-4780-ea2d-c01cef696aaf"
       },
-      "source": [
-        " a = np.random.randn(1000)\n",
-        "\n",
-        "import matplotlib.pyplot as plt\n",
-        "plt.hist(a, bins=100)\n",
-        "plt.show()"
-      ],
-      "execution_count": null,
       "outputs": [
         {
-          "output_type": "display_data",
           "data": {
-            "image/png": "iVBORw0KGgoAAAANSUhEUgAAAXAAAAD4CAYAAAD1jb0+AAAABHNCSVQICAgIfAhkiAAAAAlwSFlzAAALEgAACxIB0t1+/AAAADh0RVh0U29mdHdhcmUAbWF0cGxvdGxpYiB2ZXJzaW9uMy4yLjIsIGh0dHA6Ly9tYXRwbG90bGliLm9yZy+WH4yJAAAN4klEQVR4nO3df4hld3nH8ffHNFYxFpUMYRszXbHBNpS6KUNqUST1V1dbmgRsaSiaUssoGJpAShsUqrYVlFYtlCKuJLiFVCvGkNCmrWkasEKN3aSrbrJaU4mYsGaTmpCEQssmT/+Ys3UZZ/beuT/mzjP7fsFlzjn33DnPzt757HfPee73pKqQJPXznEUXIEmajAEuSU0Z4JLUlAEuSU0Z4JLU1I9s58HOPffc2rt373YeUpLau+eeex6rqqX127c1wPfu3cuhQ4e285CS1F6S72y03VMoktSUAS5JTRngktSUAS5JTRngktSUAS5JTRngktSUAS5JTRngktTUtn4SU+pm7/V/9//LD37ol7f99dLpOAKXpKYMcElqygCXpKYMcElqygCXpKYMcElqygCXpKYMcElqamSAJ3lekq8k+WqS+5J8YNj+siR3J3kgyd8kee78y5UknTTOCPx/gNdV1SuBfcD+JK8CPgx8rKp+EngceMf8ypQkrTcywGvN08Pq2cOjgNcBnxu2HwQun0uFkqQNjXUOPMlZSQ4Dx4E7gP8EnqiqE8MuDwHnz6dESdJGxgrwqnqmqvYBLwUuAX5q3AMkWU1yKMmhRx99dMIyJUnrbakLpaqeAO4CfgF4UZKTsxm+FHh4k9ccqKqVqlpZWlqaqlhJ0g+M04WylORFw/LzgTcCR1kL8rcOu10F3DqvIiVJP2yc+cD3AAeTnMVa4H+2qv42yf3AZ5L8CfDvwA1zrFOStM7IAK+qrwEXb7D926ydD5ckLYCfxJSkprylmnY9b2um3coRuCQ1ZYBLUlMGuCQ1ZYBLUlMGuCQ1ZYBLUlO2EeqMNW17oe2JWjRH4JLUlAEuSU0Z4JLUlAEuSU0Z4JLUlF0o0gxstSPFDhbNgiNwSWrKAJekpgxwSWrKAJekpgxwSWrKAJekpmwjlMZ0auuftBM4ApekpgxwSWpqZIAnuSDJXUnuT3JfkmuG7e9P8nCSw8PjLfMvV5J00jjnwE8A11XVvUleCNyT5I7huY9V1Z/NrzxJ0mZGBnhVHQOODctPJTkKnD/vwiRJp7elLpQke4GLgbuBVwNXJ3k7cIi1UfrjG7xmFVgFWF5enrJcnamc/En6YWNfxExyDnAzcG1VPQl8HHg5sI+1EfpHNnpdVR2oqpWqWllaWppByZIkGDPAk5zNWnjfVFWfB6iqR6rqmap6FvgkcMn8ypQkrTdOF0qAG4CjVfXRU7bvOWW3K4Ajsy9PkrSZcc6Bvxp4G/D1JIeHbe8BrkyyDyjgQeCdc6lQkrShcbpQvgRkg6dun305kqRxOReKWtusO8V5S3Qm8KP0ktSUAS5JTRngktSUAS5JTRngktSUAS5JTRngktSUAS5JTRngktSUAS5JTRngktSUAS5JTTmZldTYNLea8zZ1/TkCl6SmDHBJasoAl6SmDHBJasoAl6SmDHBJaso2QrUz7/tdbvf9NLd6PFv+dJIjcElqygCXpKZGBniSC5LcleT+JPcluWbY/pIkdyT51vD1xfMvV5J00jgj8BPAdVV1EfAq4N1JLgKuB+6sqguBO4d1SdI2GRngVXWsqu4dlp8CjgLnA5cBB4fdDgKXz6tISdIP21IXSpK9wMXA3cB5VXVseOp7wHmbvGYVWAVYXl6etE7tYk6qtDXb3SWjnWvsi5hJzgFuBq6tqidPfa6qCqiNXldVB6pqpapWlpaWpipWkvQDYwV4krNZC++bqurzw+ZHkuwZnt8DHJ9PiZKkjYzThRLgBuBoVX30lKduA64alq8Cbp19eZKkzYxzDvzVwNuAryc5PGx7D/Ah4LNJ3gF8B/j1+ZQoSdrIyACvqi8B2eTp18+2HEnSuPwkpiQ15WRW2jVsrxvNn9Hu4ghckpoywCWpKQNckpoywCWpKQNckpqyC0ULsZu7IXbCn80Jws4MjsAlqSkDXJKaMsAlqSkDXJKaMsAlqSkDXJKaso1QE+vYqrbIFr95H3sntC9qezkCl6SmDHBJasoAl6SmDHBJasoAl6Sm7ELRXHXpVLGDQx05ApekpgxwSWrKAJekpkYGeJIbkxxPcuSUbe9P8nCSw8PjLfMtU5K03jgj8E8B+zfY/rGq2jc8bp9tWZKkUUYGeFV9Efj+NtQiSdqCadoIr07yduAQcF1VPb7RTklWgVWA5eXlKQ6nLqZpybOdb/b8me5ek17E/DjwcmAfcAz4yGY7VtWBqlqpqpWlpaUJDydJWm+iAK+qR6rqmap6FvgkcMlsy5IkjTJRgCfZc8rqFcCRzfaVJM3HyHPgST4NXAqcm+Qh4H3ApUn2AQU8CLxzjjVKkjYwMsCr6soNNt8wh1okSVvgZFbaNnZD9NNlMrIzlR+ll6SmDHBJasoAl6SmDHBJasoAl6SmDHBJasoAl6SmDHBJasoAl6SmDHBJasoAl6SmDHBJasoAl6SmDHBJasoAl6SmDHBJasoAl6SmDHBJasoAl6SmvCemZsL7Xe4e0/5deh/N7eMIXJKaMsAlqamRAZ7kxiTHkxw5ZdtLktyR5FvD1xfPt0xJ0nrjjMA/Bexft+164M6quhC4c1iXJG2jkQFeVV8Evr9u82XAwWH5IHD5jOuSJI0waRfKeVV1bFj+HnDeZjsmWQVWAZaXlyc8nLbT+i4EOwmknWnqi5hVVUCd5vkDVbVSVStLS0vTHk6SNJg0wB9Jsgdg+Hp8diVJksYxaYDfBlw1LF8F3DqbciRJ4xqnjfDTwL8Cr0jyUJJ3AB8C3pjkW8AbhnVJ0jYaeRGzqq7c5KnXz7gWSdIW+ElMSWrKyazOYJNMOuSkVbvTNH+vk7zWCa9mwxG4JDVlgEtSUwa4JDVlgEtSUwa4JDVlF8oO49V57VTb0YHk+39rHIFLUlMGuCQ1ZYBLUlMGuCQ1ZYBLUlMGuCQ1ZRvhLrVZO9ZmrWBOUiX14whckpoywCWpKQNckpoywCWpKQNckpqyC0Uj2aEi7UyOwCWpKQNckpqa6hRKkgeBp4BngBNVtTKLoiRJo83iHPgvVtVjM/g+kqQt8BSKJDU17Qi8gC8kKeATVXVg/Q5JVoFVgOXl5SkPtzvZ5aHdapxbpPn+n9y0I/DXVNXPAW8G3p3ktet3qKoDVbVSVStLS0tTHk6SdNJUAV5VDw9fjwO3AJfMoihJ0mgTB3iSFyR54cll4E3AkVkVJkk6vWnOgZ8H3JLk5Pf566r6h5lUJUkaaeIAr6pvA6+cYS2SpC2wjVCSmnIyq200TkvVTvieknpwBC5JTRngktSUAS5JTRngktSUAS5JTdmFsoNttcNks0mBnCxI3W32Ht7JnVfra55HrY7AJakpA1ySmjLAJakpA1ySmjLAJakpA1ySmrKNcEGmae2zLVAdbfV96/t8NEfgktSUAS5JTRngktSUAS5JTRngktRUmy6UaSZ2GncSmXFes9k+855sxyvy0vi2+nt6qq3+7i+SI3BJasoAl6SmDHBJamqqAE+yP8k3kzyQ5PpZFSVJGm3iAE9yFvCXwJuBi4Ark1w0q8IkSac3zQj8EuCBqvp2Vf0v8BngstmUJUkaJVU12QuTtwL7q+p3hvW3AT9fVVev228VWB1WXwF8c/Jy5+Jc4LFFFzGhrrV3rRusfRG61g2zq/0nqmpp/ca594FX1QHgwLyPM6kkh6pqZdF1TKJr7V3rBmtfhK51w/xrn+YUysPABaesv3TYJknaBtME+L8BFyZ5WZLnAr8B3DabsiRJo0x8CqWqTiS5GvhH4Czgxqq6b2aVbZ8de3pnDF1r71o3WPsidK0b5lz7xBcxJUmL5ScxJakpA1ySmjLAgSR/nORrSQ4n+UKSH190TeNI8qdJvjHUfkuSFy26pnEl+bUk9yV5NkmLFrGuU0ckuTHJ8SRHFl3LViS5IMldSe4f3ivXLLqmcSV5XpKvJPnqUPsH5nIcz4FDkh+rqieH5d8FLqqqdy24rJGSvAn45+GC8ocBquoPFlzWWJL8NPAs8Ang96rq0IJLOq1h6oj/AN4IPMRaF9aVVXX/QgsbQ5LXAk8Df1VVP7PoesaVZA+wp6ruTfJC4B7g8iY/8wAvqKqnk5wNfAm4pqq+PMvjOAIHTob34AVAi3/VquoLVXViWP0ya734LVTV0araaZ/KPZ22U0dU1ReB7y+6jq2qqmNVde+w/BRwFDh/sVWNp9Y8PayePTxmnisG+CDJB5N8F/hN4A8XXc8Efhv4+0UXsYudD3z3lPWHaBImu0GSvcDFwN2LrWR8Sc5Kchg4DtxRVTOv/YwJ8CT/lOTIBo/LAKrqvVV1AXATcPXpv9v2GVX3sM97gROs1b5jjFO7NEqSc4CbgWvX/W95R6uqZ6pqH2v/M74kycxPX7W5J+a0quoNY+56E3A78L45ljO2UXUn+S3gV4DX1w67oLGFn3kHTh2xAMP545uBm6rq84uuZxJV9USSu4D9wEwvJJ8xI/DTSXLhKauXAd9YVC1bkWQ/8PvAr1bVfy+6nl3OqSO22XAh8AbgaFV9dNH1bEWSpZNdYUmez9rF75nnil0oQJKbWZvq9lngO8C7qmrHj66SPAD8KPBfw6Yvd+ieAUhyBfAXwBLwBHC4qn5psVWdXpK3AH/OD6aO+OCCSxpLkk8Dl7I2tekjwPuq6oaFFjWGJK8B/gX4Omu/mwDvqarbF1fVeJL8LHCQtffKc4DPVtUfzfw4Brgk9eQpFElqygCXpKYMcElqygCXpKYMcElqygCXpKYMcElq6v8A2vnG7wLpP3UAAAAASUVORK5CYII=\n",
+            "image/png": "iVBORw0KGgoAAAANSUhEUgAAAXAAAAD4CAYAAAD1jb0+AAAABHNCSVQICAgIfAhkiAAAAAlwSFlzAAALEgAACxIB0t1+/AAAADh0RVh0U29mdHdhcmUAbWF0cGxvdGxpYiB2ZXJzaW9uMy4yLjIsIGh0dHA6Ly9tYXRwbG90bGliLm9yZy+WH4yJAAAOyUlEQVR4nO3dcYhl5XnH8e9Ps4miFiNeZKtONySSVEKzluk2xRCsxnSTlqqQlkoxllomQqQKto01UGNbwdBGCyWEbNC6BWsqUVES02qNYIWqXe2qq2uqtUqUjatVUSlYVp/+MWfNZpyZe2fm3rn3nfl+4DLnvPfcOc+uMz/fPee5701VIUlqz0HjLkCStDwGuCQ1ygCXpEYZ4JLUKANckhr1ntU82dFHH12bNm1azVNKUvMefPDBl6qqN3d8VQN806ZN7NixYzVPKUnNS/LsfONeQpGkRhngktQoA1ySGmWAS1KjDHBJapQBLkmN6hvgSQ5J8kCSh5M8luTybvy6JP+dZGf32Dz6ciVJ+w3SB/4mcGpVvZFkA3Bvku93z/1xVX1ndOVJkhbSN8BrdsHwN7rdDd3DRcQlacwGugae5OAkO4G9wJ1VdX/31BVJHklydZL3LfDamSQ7kux48cUXh1S2tHKbLvneOw+pRQMFeFW9VVWbgeOALUk+Cvwp8BHgl4CjgC8t8NptVTVdVdO93rveyi9JWqYldaFU1avA3cDWqtpTs94E/g7YMooCJUnzG6QLpZfkyG77UOB04IkkG7uxAGcCu0ZZqCTppw3ShbIR2J7kYGYD/8aq+m6SHyTpAQF2AuePsE5J0hyDdKE8Apw0z/ipI6lIkjQQ34kpSY0ywCWpUQa4JDXKAJekRhngktQoA1ySGmWAS1KjDHBJapQBLkmNMsAlqVEGuCQ1ygCXpEYZ4JLUKANckhplgEtSowxwSWqUAS5JjTLAJalRBrgkNcoAl6RG9Q3wJIckeSDJw0keS3J5N/6BJPcneSrJPyZ57+jLlSTtN8gM/E3g1Kr6GLAZ2Jrk48BXgaur6kPAK8B5oytTkjRX3wCvWW90uxu6RwGnAt/pxrcDZ46kQknSvN4zyEFJDgYeBD4EfB34L+DVqtrXHfIccOwCr50BZgCmpqZWWq+0oE2XfO+d7Weu/PW+x0itG+gmZlW9VVWbgeOALcBHBj1BVW2rqumqmu71esssU5I015K6UKrqVeBu4FeAI5Psn8EfBzw/5NokSYsYpAull+TIbvtQ4HRgN7NB/rnusHOBW0dVpCTp3Qa5Br4R2N5dBz8IuLGqvpvkceDbSf4S+A/gmhHWKUmao2+AV9UjwEnzjD/N7PVwSdIYDNSFIq1Xg3S2SOPiW+klqVEGuCQ1ygCXpEYZ4JLUKANckhplF4qaM4mdIZNYk9Y+Z+CS1CgDXJIaZYBLUqMMcElqlAEuSY2yC0Vr0mp0hYzi033sZtFSOAOXpEYZ4JLUKANckhplgEtSowxwSWqUAS5JjTLAJalRBrgkNapvgCc5PsndSR5P8liSC7vxryR5PsnO7vHZ0ZcrSdpvkHdi7gMurqqHkhwBPJjkzu65q6vqr0dXniRpIX0DvKr2AHu67deT7AaOHXVhkqTFLWktlCSbgJOA+4GTgQuSfB7Ywews/ZV5XjMDzABMTU2tsFxpfJaz9olrm2iUBr6JmeRw4Cbgoqp6DfgG8EFgM7Mz9K/N97qq2lZV01U13ev1hlCyJAkGDPAkG5gN7+ur6maAqnqhqt6qqreBbwFbRlemJGmuQbpQAlwD7K6qqw4Y33jAYWcBu4ZfniRpIYNcAz8ZOAd4NMnObuxS4Owkm4ECngG+MJIKJUnzGqQL5V4g8zx1+/DLkSQNyk/k0dCNovNioQ6QYX0qzig+XUcaNd9KL0mNMsAlqVEGuCQ1ygCXpEYZ4JLUKLtQpFXiuigaNmfgktQoA1ySGmWAS1KjDHBJapQBLkmNsgtFa95qr3PiuipaLc7AJalRBrgkNcoAl6RGGeCS1CgDXJIaZReK1ADXUdF8nIFLUqP6BniS45PcneTxJI8lubAbPyrJnUme7L6+f/TlSpL2G2QGvg+4uKpOBD4OfDHJicAlwF1VdQJwV7cvSVolfQO8qvZU1UPd9uvAbuBY4Axge3fYduDMURUpSXq3Jd3ETLIJOAm4HzimqvZ0T/0YOGaB18wAMwBTU1PLrVNrwEJvMT/wppw366TBDXwTM8nhwE3ARVX12oHPVVUBNd/rqmpbVU1X1XSv11tRsZKknxgowJNsYDa8r6+qm7vhF5Js7J7fCOwdTYmSpPkM0oUS4Bpgd1VddcBTtwHndtvnArcOvzxJ0kIGuQZ+MnAO8GiSnd3YpcCVwI1JzgOeBX57NCVKkubTN8Cr6l4gCzx92nDLkSQNyrfSa+zW+wcgrPc/v5bPt9JLUqMMcElqlAEuSY0ywCWpUQa4JDXKLhQNxSg6KezOGA7Xl1m7nIFLUqMMcElqlAEuSY0ywCWpUQa4JDXKLhSNlJ0kq8duk/XHGbgkNcoAl6RGGeCS1CgDXJIaZYBLUqPsQpHWoIW6f+xUWVucgUtSowxwSWpU3wBPcm2SvUl2HTD2lSTPJ9nZPT472jIlSXMNMgO/Dtg6z/jVVbW5e9w+3LIkSf30DfCqugd4eRVqkSQtwUq6UC5I8nlgB3BxVb0y30FJZoAZgKmpqRWcTtJco/4kJDtVJttyb2J+A/ggsBnYA3xtoQOraltVTVfVdK/XW+bpJElzLSvAq+qFqnqrqt4GvgVsGW5ZkqR+lhXgSTYesHsWsGuhYyVJo9H3GniSG4BTgKOTPAdcBpySZDNQwDPAF0ZYoyRpHn0DvKrOnmf4mhHUIklaAtdC0bL5aTuj5d+v+vGt9JLUKANckhplgEtSowxwSWqUAS5JjbILRRqDlXSYjHr9E7XDGbgkNcoAl6RGGeCS1CgDXJIaZYBLUqPsQpG0Kvykn+FzBi5JjTLAJalRBrgkNcoAl6RGGeCS1Ci7ULQkrpmxdvjfsn3OwCWpUX0DPMm1SfYm2XXA2FFJ7kzyZPf1/aMtU5I01yAz8OuArXPGLgHuqqoTgLu6fUnSKuob4FV1D/DynOEzgO3d9nbgzCHXJUnqY7nXwI+pqj3d9o+BY4ZUjyRpQCvuQqmqSlILPZ9kBpgBmJqaWunpNCKuUyG1Z7kz8BeSbATovu5d6MCq2lZV01U13ev1lnk6SdJcyw3w24Bzu+1zgVuHU44kaVCDtBHeAPwb8OEkzyU5D7gSOD3Jk8Cnun1J0irqew28qs5e4KnThlyLJGkJfCemJDXKtVDWGbtNpLXDGbgkNcoAl6RGGeCS1CgDXJIa5U1MvYsL/UttcAYuSY0ywCWpUQa4JDXKAJekRhngktQou1DWAbtKtFwLLb3gkgyTwRm4JDXKAJekRhngktQoA1ySGmWAS1Kj7EJp0CAdAHaeSGufM3BJapQBLkmNWtEllCTPAK8DbwH7qmp6GEVJkvobxjXwX62ql4bwfSRJS+AlFElq1Epn4AXckaSAb1bVtrkHJJkBZgCmpqZWeDpJ42Jn0+RZ6Qz8E1X1i8BngC8m+eTcA6pqW1VNV9V0r9db4ekkSfutKMCr6vnu617gFmDLMIqSJPW37ABPcliSI/ZvA58Gdg2rMEnS4lZyDfwY4JYk+7/PP1TVPw2lKklSX8sO8Kp6GvjYEGuRJC2Ba6GsopV8islCHQB+Moq0ftkHLkmNMsAlqVEGuCQ1ygCXpEYZ4JLUqGa6UNZyt8Ww/mxLXavCtS00Civ5uVrLv+ej4AxckhplgEtSowxwSWqUAS5JjTLAJalRzXShrBd2hmi9Wck6P5PctTL3zzWK+pyBS1KjDHBJapQBLkmNMsAlqVEGuCQ1ak11oSx0R3qhu9yD3hUepDNkkPMt9XtKLVjOz/Iofv4H+f0fZLwlzsAlqVEGuCQ1akUBnmRrkh8meSrJJcMqSpLU37IDPMnBwNeBzwAnAmcnOXFYhUmSFreSGfgW4Kmqerqq/g/4NnDGcMqSJPWTqlreC5PPAVur6g+6/XOAX66qC+YcNwPMdLsfBn64/HKH5mjgpXEXsUTWPHqt1QvWvBomod6fq6re3MGRtxFW1TZg26jPsxRJdlTV9LjrWAprHr3W6gVrXg2TXO9KLqE8Dxx/wP5x3ZgkaRWsJMD/HTghyQeSvBf4HeC24ZQlSepn2ZdQqmpfkguAfwYOBq6tqseGVtloTdQlnQFZ8+i1Vi9Y82qY2HqXfRNTkjRevhNTkhplgEtSo9ZtgCf5iySPJNmZ5I4kPzvumvpJ8ldJnujqviXJkeOuaTFJfivJY0neTjKRbVj7tbYsRJJrk+xNsmvctQwiyfFJ7k7yePczceG4a+onySFJHkjycFfz5eOuaa51ew08yc9U1Wvd9h8CJ1bV+WMua1FJPg38oLuB/FWAqvrSmMtaUJKfB94Gvgn8UVXtGHNJ8+qWhfhP4HTgOWY7rM6uqsfHWtgiknwSeAP4+6r66Ljr6SfJRmBjVT2U5AjgQeDMCf87DnBYVb2RZANwL3BhVd035tLesW5n4PvDu3MYMPH/J6uqO6pqX7d7H7O99xOrqnZX1SS887af5paFqKp7gJfHXcegqmpPVT3Ubb8O7AaOHW9Vi6tZb3S7G7rHROXEug1wgCRXJPkR8LvAn427niX6feD74y5ijTgW+NEB+88x4eHSsiSbgJOA+8dbSX9JDk6yE9gL3FlVE1Xzmg7wJP+SZNc8jzMAqurLVXU8cD1wweLfbXX0q7k75svAPmbrHqtB6pX2S3I4cBNw0Zx/BU+kqnqrqjYz+6/dLUkm6nLVmvpItbmq6lMDHno9cDtw2QjLGUi/mpP8HvAbwGk1ATcwlvB3PMlcFmIVdNeRbwKur6qbx13PUlTVq0nuBrYCE3PjeE3PwBeT5IQDds8AnhhXLYNKshX4E+A3q+p/x13PGuKyECPW3RC8BthdVVeNu55BJOnt7/RKciizN7knKifWcxfKTcwub/s28CxwflVN9KwryVPA+4D/6Ybum+TOmSRnAX8L9IBXgZ1V9WvjrWp+ST4L/A0/WRbiijGXtKgkNwCnMLvU6QvAZVV1zViLWkSSTwD/CjzK7O8cwKVVdfv4qlpckl8AtjP7M3EQcGNV/fl4q/pp6zbAJal16/YSiiS1zgCXpEYZ4JLUKANckhplgEtSowxwSWqUAS5Jjfp/p3AbxYX2dEkAAAAASUVORK5CYII=",
             "text/plain": [
               "<Figure size 432x288 with 1 Axes>"
             ]
           },
           "metadata": {
-            "tags": [],
             "needs_background": "light"
-          }
+          },
+          "output_type": "display_data"
         }
+      ],
+      "source": [
+        "a = np.random.randn(1000)\n",
+        "\n",
+        "import matplotlib.pyplot as plt\n",
+        "plt.hist(a, bins=100)\n",
+        "plt.show()"
       ]
     },
     {
@@ -1414,19 +1423,60 @@
         "id": "QImdRykDNwAw"
       },
       "source": [
-        "## random.noraml() - 특정 평균 분산의 자연분포"
+        "## random.normal() - 특정 평균 분산의 자연분포"
       ]
     },
     {
       "cell_type": "code",
+      "execution_count": 38,
       "metadata": {
         "colab": {
           "base_uri": "https://localhost:8080/",
-          "height": 547
+          "height": 548
         },
         "id": "Jv5hb4eCKZEd",
-        "outputId": "4557721c-e631-4163-fa62-4326d0d07b5c"
+        "outputId": "b1f8f3fe-75b0-4600-e10f-08b2acff1927"
       },
+      "outputs": [
+        {
+          "name": "stdout",
+          "output_type": "stream",
+          "text": [
+            "(30, 40)\n"
+          ]
+        },
+        {
+          "data": {
+            "image/png": "iVBORw0KGgoAAAANSUhEUgAAAXAAAAD4CAYAAAD1jb0+AAAABHNCSVQICAgIfAhkiAAAAAlwSFlzAAALEgAACxIB0t1+/AAAADh0RVh0U29mdHdhcmUAbWF0cGxvdGxpYiB2ZXJzaW9uMy4yLjIsIGh0dHA6Ly9tYXRwbG90bGliLm9yZy+WH4yJAAAPnklEQVR4nO3df4xldX3G8fcjLmIUg5YbsgWma5TYElOXZkJtMMai2BWNYGIbibE0pRlNJMXUVlGT+qM1wbSKTWOMa5e6JlQlIsEotlLEWJKK3cUVF1YrpRghK6tVIqSJzcKnf8zZOp2d2Xvm/pg735n3K7mZe849d+7D7OzDd8/3/EhVIUlqz5NmHUCSNBoLXJIaZYFLUqMscElqlAUuSY168np+2Omnn147duxYz4+UpObt37//x1U1WL5+XQt8x44d7Nu3bz0/UpKal+T7K613F4okNcoCl6RGWeCS1CgLXJIaZYFLUqMscElqVO8CT3JSkm8m+UK3/Owkdya5L8lnkpw8vZiSpOXWMgK/Cji0ZPkDwLVV9Vzgp8AVkwwmSTqxXgWe5CzglcDfdcsBLgQ+222yF7h0GgElSSvreybmh4G3Aad2y78EPFJVR7vlB4EzV3pjkgVgAWBubm70pNKIdlz9xf97/sA1rxx5G2mjGToCT/Iq4EhV7R/lA6pqd1XNV9X8YHDcqfySpBH1GYFfALw6ycXAKcAzgL8BTkvy5G4Ufhbw0PRiSpKWGzoCr6p3VNVZVbUDeB3wlap6PXA78Npus8uBm6eWUpJ0nHGOA3878CdJ7mNxn/ieyUSSJPWxpsvJVtVXga92z+8Hzp98JElSH56JKUmNssAlqVEWuCQ1ygKXpEZZ4JLUKAtckhplgUtSoyxwSWqUBS5JjbLAJalRFrgkNcoCl6RGWeCS1CgLXJIaZYFLUqMscElqVJ+bGp+S5BtJvpXkniTv7dZ/Isl/JjnQPXZOP64k6Zg+d+T5OXBhVT2WZBtwR5Ivda/9WVV9dnrxJEmrGVrgVVXAY93itu5R0wwlSRqu1z7wJCclOQAcAW6tqju7l96f5O4k1yZ5ytRSSpKO0+umxlX1OLAzyWnATUmeD7wD+CFwMrCbxbvUv2/5e5MsAAsAc3NzE4otndiOq7846wjS1K3pKJSqegS4HdhVVYdr0c+Bv2eVO9RX1e6qmq+q+cFgMH5iSRLQ7yiUQTfyJslTgYuA7yTZ3q0LcClwcJpBJUn/X59dKNuBvUlOYrHwb6iqLyT5SpIBEOAA8KYp5pQkLdPnKJS7gfNWWH/hVBJJknrxTExJapQFLkmNssAlqVEWuCQ1ygKXpEb1OhNT2kiWnmX5wDWvnGGS4VrKqvY4ApekRlngktQoC1ySGmWBS1KjnMTUltJnUtGJR7XCEbgkNcoCl6RGWeCS1CgLXJIa5SSmNAHeg1Oz4AhckhrV556YpyT5RpJvJbknyXu79c9OcmeS+5J8JsnJ048rSTqmzwj858CFVfUCYCewK8kLgQ8A11bVc4GfAldML6YkabmhBV6LHusWt3WPAi4EPtut38vineklSeuk1yRmd0f6/cBzgY8A/wE8UlVHu00eBM5c5b0LwALA3NzcuHm1yW3msyA383+bZqPXJGZVPV5VO4GzgPOBX+37AVW1u6rmq2p+MBiMGFOStNyajkKpqkeA24HfAk5LcmwEfxbw0ISzSZJOoM9RKIMkp3XPnwpcBBxischf2212OXDztEJKko7XZx/4dmBvtx/8ScANVfWFJPcCn07yl8A3gT1TzClJWmZogVfV3cB5K6y/n8X94ZKkGfBUek3VWq+/PanPkrYCT6WXpEZZ4JLUKAtckhplgUtSoyxwSWqUBS5JjbLAJalRFrgkNcoCl6RGeSam1o3Xw549/ww2F0fgktQoC1ySGmWBS1KjLHBJapSTmNKIvHytZs0RuCQ1qs89Mc9OcnuSe5Pck+Sqbv17kjyU5ED3uHj6cSVJx/TZhXIUeGtV3ZXkVGB/klu7166tqr+eXjxJ0mr63BPzMHC4e/5okkPAmdMOJkk6sTVNYibZweINju8ELgCuTPL7wD4WR+k/XeE9C8ACwNzc3JhxpdmZ5KTlat/LsyO1Fr0nMZM8HbgReEtV/Qz4KPAcYCeLI/QPrvS+qtpdVfNVNT8YDCYQWZIEPQs8yTYWy/v6qvocQFU9XFWPV9UTwMeB86cXU5K0XJ+jUALsAQ5V1YeWrN++ZLPXAAcnH0+StJo++8AvAN4AfDvJgW7dO4HLkuwECngAeONUEkqSVtTnKJQ7gKzw0i2TjyNJ6sszMSWpURa4JDXKApekRlngktQoC1ySGuX1wKUTWO9rfnvTYa2FI3BJapQFLkmNssAlqVEWuCQ1yklMrclmmmRr6abEm+nnrslxBC5JjbLAJalRFrgkNcoCl6RGOYmpDcuJu+H8GW1tjsAlqVF97ol5dpLbk9yb5J4kV3Xrn5Xk1iTf674+c/pxJUnH9BmBHwXeWlXnAi8E3pzkXOBq4LaqOge4rVuWJK2ToQVeVYer6q7u+aPAIeBM4BJgb7fZXuDSaYWUJB1vTZOYSXYA5wF3AmdU1eHupR8CZ6zyngVgAWBubm7UnNKWs9YzRZ3Q3Hp6T2ImeTpwI/CWqvrZ0teqqoBa6X1Vtbuq5qtqfjAYjBVWkvQLvQo8yTYWy/v6qvpct/rhJNu717cDR6YTUZK0kj5HoQTYAxyqqg8teenzwOXd88uBmycfT5K0mj77wC8A3gB8O8mBbt07gWuAG5JcAXwf+L3pRJQkrWRogVfVHUBWefmlk40jrU1Ll4RdT05obg2eiSlJjbLAJalRFrgkNcoCl6RGWeCS1CivB77FTOvohGkf9eDRJtLxHIFLUqMscElqlAUuSY2ywCWpUU5i6jjLJww9FXtjcUJXxzgCl6RGWeCS1CgLXJIaZYFLUqOcxNTE9ZlkcyJOGp8jcElqVJ97Yl6X5EiSg0vWvSfJQ0kOdI+LpxtTkrRcnxH4J4BdK6y/tqp2do9bJhtLkjTM0AKvqq8BP1mHLJKkNRhnH/iVSe7udrE8c7WNkiwk2Zdk349+9KMxPk6StNSoBf5R4DnATuAw8MHVNqyq3VU1X1Xzg8FgxI+TJC03UoFX1cNV9XhVPQF8HDh/srEkScOMVOBJti9ZfA1wcLVtJUnTMfREniSfAl4CnJ7kQeDdwEuS7AQKeAB44xQzSpJWMLTAq+qyFVbvmUIWSdIaeCamJDXKApekRlngktQoC1ySGuXlZDWUl37dupb+2Xtv1I3HEbgkNcoCl6RGWeCS1CgLXJIaZYFLUqM8CkXa5CZ1k2mPSNl4HIFLUqMscElqlAUuSY2ywCWpUU5ibgGrTVA5KSW1zRG4JDVqaIEnuS7JkSQHl6x7VpJbk3yv+/rM6caUJC3XZwT+CWDXsnVXA7dV1TnAbd2yJGkdDS3wqvoa8JNlqy8B9nbP9wKXTjiXJGmIUScxz6iqw93zHwJnrLZhkgVgAWBubm7Ej5O0kTgBvjGMPYlZVQXUCV7fXVXzVTU/GAzG/ThJUmfUAn84yXaA7uuRyUWSJPUxaoF/Hri8e345cPNk4kiS+upzGOGngH8FnpfkwSRXANcAFyX5HvCyblmStI6GTmJW1WWrvPTSCWfRmMaZWPLGxVJ7PBNTkhplgUtSoyxwSWqUBS5JjfJyspLGsnwCfOkEep+Jdc/qHJ0jcElqlAUuSY2ywCWpURa4JDXKApekRnkUikbm6fdaC482mTxH4JLUKAtckhplgUtSoyxwSWqUk5iblBOMGsbfkfY5ApekRo01Ak/yAPAo8DhwtKrmJxFKkjTcJHah/HZV/XgC30eStAbuQpGkRo07Ai/gy0kK+FhV7V6+QZIFYAFgbm5uzI/bujyLTdJy447AX1RVvwG8Anhzkhcv36CqdlfVfFXNDwaDMT9OknTMWAVeVQ91X48ANwHnTyKUJGm4kQs8ydOSnHrsOfBy4OCkgkmSTmycfeBnADclOfZ9/qGq/nEiqSRJQ41c4FV1P/CCCWbRMp4ppxb1+b1dbZtxJuu34kS/hxFKUqMscElqlAUuSY2ywCWpUV5OdoNZ68SlE53arFablPR3/hccgUtSoyxwSWqUBS5JjbLAJalRm2oSc61nYi2fDBnlPWt576Q4iSOd2EY4o3OUflkrR+CS1CgLXJIaZYFLUqMscElqlAUuSY1q5iiUjX6t3z75PHpEGs04f3cmdeTYRuwgR+CS1KixCjzJriTfTXJfkqsnFUqSNNw4NzU+CfgI8ArgXOCyJOdOKpgk6cTGGYGfD9xXVfdX1f8AnwYumUwsSdIwqarR3pi8FthVVX/ULb8B+M2qunLZdgvAQrf4POC7o8cd2+nAj2f4+aMy9/pqNTe0m93cJ/YrVTVYvnLqR6FU1W5g97Q/p48k+6pqftY51src66vV3NBudnOPZpxdKA8BZy9ZPqtbJ0laB+MU+L8B5yR5dpKTgdcBn59MLEnSMCPvQqmqo0muBP4JOAm4rqrumViy6dgQu3JGYO711WpuaDe7uUcw8iSmJGm2PBNTkhplgUtSo7ZcgSf5iyR3JzmQ5MtJfnnWmfpI8ldJvtNlvynJabPO1EeS301yT5Inkmz4w8RavDxEkuuSHElycNZZ1iLJ2UluT3Jv9zty1awz9ZHklCTfSPKtLvd7Z5Zlq+0DT/KMqvpZ9/yPgXOr6k0zjjVUkpcDX+kmjz8AUFVvn3GsoZL8GvAE8DHgT6tq34wjraq7PMS/AxcBD7J4pNVlVXXvTIMNkeTFwGPAJ6vq+bPO01eS7cD2qroryanAfuDSBn7eAZ5WVY8l2QbcAVxVVV9f7yxbbgR+rLw7TwOa+D9YVX25qo52i19n8bj7Da+qDlXVLM++XYsmLw9RVV8DfjLrHGtVVYer6q7u+aPAIeDM2aYarhY91i1u6x4z6ZEtV+AASd6f5AfA64E/n3WeEfwh8KVZh9iEzgR+sGT5QRoolM0gyQ7gPODO2SbpJ8lJSQ4AR4Bbq2omuTdlgSf55yQHV3hcAlBV76qqs4HrgStP/N3Wz7Dc3TbvAo6ymH1D6JNbWk2SpwM3Am9Z9i/kDauqHq+qnSz+S/j8JDPZddXMHXnWoqpe1nPT64FbgHdPMU5vw3In+QPgVcBLawNNXqzh573ReXmIddbtQ74RuL6qPjfrPGtVVY8kuR3YBaz7JPKmHIGfSJJzlixeAnxnVlnWIsku4G3Aq6vqv2edZ5Py8hDrqJsM3AMcqqoPzTpPX0kGx44CS/JUFie9Z9IjW/EolBtZvKztE8D3gTdV1YYfZSW5D3gK8F/dqq83cvTMa4C/BQbAI8CBqvqd2aZaXZKLgQ/zi8tDvH/GkYZK8ingJSxe2vRh4N1VtWemoXpI8iLgX4Bvs/j3EeCdVXXL7FINl+TXgb0s/o48Cbihqt43kyxbrcAlabPYcrtQJGmzsMAlqVEWuCQ1ygKXpEZZ4JLUKAtckhplgUtSo/4XU4RueCosEpYAAAAASUVORK5CYII=",
+            "text/plain": [
+              "<Figure size 432x288 with 1 Axes>"
+            ]
+          },
+          "metadata": {
+            "needs_background": "light"
+          },
+          "output_type": "display_data"
+        },
+        {
+          "name": "stdout",
+          "output_type": "stream",
+          "text": [
+            "(30, 40)\n"
+          ]
+        },
+        {
+          "data": {
+            "image/png": "iVBORw0KGgoAAAANSUhEUgAAAXAAAAD4CAYAAAD1jb0+AAAABHNCSVQICAgIfAhkiAAAAAlwSFlzAAALEgAACxIB0t1+/AAAADh0RVh0U29mdHdhcmUAbWF0cGxvdGxpYiB2ZXJzaW9uMy4yLjIsIGh0dHA6Ly9tYXRwbG90bGliLm9yZy+WH4yJAAAPw0lEQVR4nO3df4xlZX3H8fdHhGIUg5YbsmWZrlFiQ4wuzWSLoWksilnBCDa2kVikKc3YRBJMSS1oUrWtCcYqNqmxXYWyiVQlKsGgVimuISYW3dUVF1YrpRghKxsjREgTmoVv/5izOh1m5p65P+bOs/t+JZO959xz534yO/vJs+c5z7mpKiRJ7XnWrANIkkZjgUtSoyxwSWqUBS5JjbLAJalRz97INzvttNNq27ZtG/mWktS8ffv2/ayqBsv3b2iBb9u2jb17927kW0pS85L8eKX9nkKRpEZZ4JLUKAtckhplgUtSoyxwSWqUBS5Jjepd4ElOSPLdJLd32y9KcneS+5N8JslJ04spSVpuPSPwq4CDS7Y/AFxfVS8BHgWumGQwSdLaehV4kq3ARcAnuu0A5wOf7Q7ZDVwyjYCSpJX1XYn5EeCdwCnd9q8Dj1XVkW77IeCMlV6YZAFYAJibmxs9qbSCbdd88ZePH7zuohkmkTbe0BF4ktcDh6tq3yhvUFW7qmq+quYHg2cs5ZckjajPCPw84A1JLgROBp4P/ANwapJnd6PwrcDD04spSVpu6Ai8qq6tqq1VtQ14M/C1qnoLsAd4U3fY5cBtU0spSXqGca4D/yvgL5Lcz+I58RsmE0mS1Me6bidbVV8Hvt49fgDYMflIkqQ+XIkpSY2ywCWpURa4JDXKApekRm3oZ2JK6+EqS2ltjsAlqVEWuCQ1ygKXpEZZ4JLUKAtckhplgUtSoyxwSWqUBS5JjbLAJalRFrgkNcoCl6RG9flQ45OTfCvJ95Lcm+R93f6bkvx3kv3d1/bpx5UkHdXnZlZPAudX1RNJTgS+keTL3XN/WVWfnV48SdJqhhZ4VRXwRLd5YvdV0wwlSRqu1znwJCck2Q8cBu6oqru7p96f5J4k1yf5tamllCQ9Q6/7gVfVU8D2JKcCtyZ5GXAt8FPgJGAXi59S/zfLX5tkAVgAmJubm1BsHW/GuTf4aq/1fuNq3bquQqmqx4A9wM6qOlSLngT+hVU+ob6qdlXVfFXNDwaD8RNLkoB+V6EMupE3SZ4DXAD8IMmWbl+AS4AD0wwqSfr/+pxC2QLsTnICi4V/S1XdnuRrSQZAgP3An08xpyRpmT5XodwDnLPC/vOnkkiS1IsrMSWpURa4JDXKApekRlngktQoC1ySGtVrJaZ0rHNVplrkCFySGmWBS1KjLHBJapQFLkmNchJTMzGp28NKxzNH4JLUKAtckhplgUtSoyxwSWqUk5iaKlc4StPjCFySGtXnMzFPTvKtJN9Lcm+S93X7X5Tk7iT3J/lMkpOmH1eSdFSfEfiTwPlV9QpgO7AzybnAB4Drq+olwKPAFdOLKUlabmiB16Inus0Tu68Czgc+2+3fzeIn00uSNkivSczuE+n3AS8BPgr8F/BYVR3pDnkIOGOV1y4ACwBzc3Pj5pVW5QpNHW96TWJW1VNVtR3YCuwAfqvvG1TVrqqar6r5wWAwYkxJ0nLrugqlqh4D9gCvBE5NcnQEvxV4eMLZJElr6HMVyiDJqd3j5wAXAAdZLPI3dYddDtw2rZCSpGfqcw58C7C7Ow/+LOCWqro9yX3Ap5P8HfBd4IYp5pQkLTO0wKvqHuCcFfY/wOL5cEnSDLgSU5IaZYFLUqMscElqlAUuSY2ywCWpUd4PXBvmWFvq7r3ONWuOwCWpURa4JDXKApekRlngktQoJzE1smlM4h1rE53jcJJUwzgCl6RGWeCS1CgLXJIaZYFLUqOcxNTMbbaJSycP1QpH4JLUqD6fiXlmkj1J7ktyb5Kruv3vTfJwkv3d14XTjytJOqrPKZQjwNVV9Z0kpwD7ktzRPXd9Vf399OJJklbT5zMxDwGHusePJzkInDHtYJKkta1rEjPJNhY/4Phu4DzgyiRvBfayOEp/dIXXLAALAHNzc2PGlWZnlMlWJ0Q1Tb0nMZM8D/gc8I6q+gXwMeDFwHYWR+gfWul1VbWrquaran4wGEwgsiQJehZ4khNZLO+bq+rzAFX1SFU9VVVPAx8HdkwvpiRpuT5XoQS4AThYVR9esn/LksPeCByYfDxJ0mr6nAM/D7gM+H6S/d2+dwGXJtkOFPAg8LapJJQkrajPVSjfALLCU1+afBxJUl8updfEbbal8dKxyqX0ktQoC1ySGmWBS1KjLHBJapSTmJoIJy5/ZZyfhT9HrYcjcElqlAUuSY2ywCWpURa4JDXKSUyti5Ns0ubhCFySGmWBS1KjLHBJapQFLkmNssAlqVEWuCQ1qs9nYp6ZZE+S+5Lcm+Sqbv8Lk9yR5Efdny+YflxJ0lF9RuBHgKur6mzgXODtSc4GrgHurKqzgDu7bUnSBhla4FV1qKq+0z1+HDgInAFcDOzuDtsNXDKtkJKkZ1rXSswk24BzgLuB06vqUPfUT4HTV3nNArAAMDc3N2pOzZCrL4db789o6fEPXnfRpOPoONF7EjPJ84DPAe+oql8sfa6qCqiVXldVu6pqvqrmB4PBWGElSb/Sq8CTnMhied9cVZ/vdj+SZEv3/Bbg8HQiSpJW0ucqlAA3AAer6sNLnvoCcHn3+HLgtsnHkyStps858POAy4DvJ9nf7XsXcB1wS5IrgB8DfzSdiJKklQwt8Kr6BpBVnn71ZONoM3DSUmqDKzElqVEWuCQ1ygKXpEZZ4JLUKAtckhqVxUWUG2N+fr727t27Ye+n0XgVyubjcvvjW5J9VTW/fL8jcElqlAUuSY2ywCWpURa4JDVqXfcDV/u8D7V07HAELkmNssAlqVEWuCQ1ygKXpEZZ4JLUKAtckhrV5zMxb0xyOMmBJfvem+ThJPu7rwunG1OStFyfEfhNwM4V9l9fVdu7ry9NNpYkaZihBV5VdwE/34AskqR1GGcl5pVJ3grsBa6uqkdXOijJArAAMDc3N8bbSccvV9BqJaNOYn4MeDGwHTgEfGi1A6tqV1XNV9X8YDAY8e0kScuNVOBV9UhVPVVVTwMfB3ZMNpYkaZiRCjzJliWbbwQOrHasJGk6hp4DT/Ip4FXAaUkeAt4DvCrJdqCAB4G3TTGjJGkFQwu8qi5dYfcNU8iiDeZnX0ptcyWmJDXKApekRlngktQoC1ySGuVnYh5DVlut52Tl8cHVmscfR+CS1CgLXJIaZYFLUqMscElqlAUuSY3yKpQGebWBJs3fqTY5ApekRlngktQoC1ySGmWBS1KjnMQ8Rrl8/tjV5++2z20VnKxsnyNwSWrU0AJPcmOSw0kOLNn3wiR3JPlR9+cLphtTkrRcnxH4TcDOZfuuAe6sqrOAO7ttSdIGGlrgVXUX8PNluy8GdnePdwOXTDiXJGmIUScxT6+qQ93jnwKnr3ZgkgVgAWBubm7Et9NqE1dOVkrHr7EnMauqgFrj+V1VNV9V84PBYNy3kyR1Ri3wR5JsAej+PDy5SJKkPkYt8C8Al3ePLwdum0wcSVJffS4j/BTwTeClSR5KcgVwHXBBkh8Br+m2JUkbaOgkZlVduspTr55wlmOSK980a050H7tciSlJjbLAJalRFrgkNcoCl6RGWeCS1CgLXJIaZYFLUqMscElqlAUuSY2ywCWpUX6o8QZabUnzakvsXQKtWfNWEJubI3BJapQFLkmNssAlqVEWuCQ1yknMTcDJSrVs+e+vk50bxxG4JDVqrBF4kgeBx4GngCNVNT+JUJKk4SZxCuX3q+pnE/g+kqR18BSKJDVq3BF4AV9NUsA/V9Wu5QckWQAWAObm5sZ8u+kaZ9WZK9bUmtUmz51Ub8e4I/DfrarfBl4HvD3J7y0/oKp2VdV8Vc0PBoMx306SdNRYBV5VD3d/HgZuBXZMIpQkabiRCzzJc5OccvQx8FrgwKSCSZLWNs458NOBW5Mc/T7/WlX/NpFUkqShRi7wqnoAeMUEszTByUodr/zd33y8jFCSGmWBS1KjLHBJapQFLkmNOq5vJ9t3xdl6V6y5kk1a1Gfi08nR0TkCl6RGWeCS1CgLXJIaZYFLUqOO60nMtTgRKY1mUv92nNwczhG4JDXKApekRlngktQoC1ySGmWBS1KjmrkKZbUZ6XH2SxrNtP4d9fm+qx3T59//Rlqecxo5HIFLUqPGKvAkO5P8MMn9Sa6ZVChJ0nDjfKjxCcBHgdcBZwOXJjl7UsEkSWsbZwS+A7i/qh6oqv8FPg1cPJlYkqRhUlWjvTB5E7Czqv6s274M+J2qunLZcQvAQrf5UuCHI2Y9DfjZiK+dFTNPX2t5wcwbpbXMa+X9zaoaLN859atQqmoXsGvc75Nkb1XNTyDShjHz9LWWF8y8UVrLPErecU6hPAycuWR7a7dPkrQBxinwbwNnJXlRkpOANwNfmEwsSdIwI59CqaojSa4EvgKcANxYVfdOLNkzjX0aZgbMPH2t5QUzb5TWMq8778iTmJKk2XIlpiQ1ygKXpEY1VeBJ/jbJPUn2J/lqkt+YdaZhknwwyQ+63LcmOXXWmdaS5A+T3Jvk6SSb+hKs1m7lkOTGJIeTHJh1lr6SnJlkT5L7ut+Lq2adaS1JTk7yrSTf6/K+b9aZ+kpyQpLvJrm972uaKnDgg1X18qraDtwO/PWsA/VwB/Cyqno58J/AtTPOM8wB4A+Au2YdZC2N3srhJmDnrEOs0xHg6qo6GzgXePsm/zk/CZxfVa8AtgM7k5w740x9XQUcXM8LmirwqvrFks3nApt+BraqvlpVR7rN/2DxevlNq6oOVtWoq2U3UnO3cqiqu4CfzzrHelTVoar6Tvf4cRYL5ozZplpdLXqi2zyx+9r0PZFkK3AR8In1vK6pAgdI8v4kPwHeQhsj8KX+FPjyrEMcI84AfrJk+yE2cbEcC5JsA84B7p5tkrV1pyL2A4eBO6pqU+ftfAR4J/D0el606Qo8yb8nObDC18UAVfXuqjoTuBm4cu3vtjGGZe6OeTeL/x29eXZJf5llaF5pqSTPAz4HvGPZ/4Q3nap6qjvNuhXYkeRls860liSvBw5X1b71vnbTfSJPVb2m56E3A18C3jPFOL0My5zkT4DXA6+uTXDh/Tp+xpuZt3LYIElOZLG8b66qz886T19V9ViSPSzOO2zmiePzgDckuRA4GXh+kk9W1R8Pe+GmG4GvJclZSzYvBn4wqyx9JdnJ4n+N3lBV/zPrPMcQb+WwAZIEuAE4WFUfnnWeYZIMjl7pleQ5wAVs8p6oqmuramtVbWPx9/hrfcobGitw4Lruv/r3AK9lcdZ2s/tH4BTgju7yx3+adaC1JHljkoeAVwJfTPKVWWdaSTcxfPRWDgeBW6Z8K4exJfkU8E3gpUkeSnLFrDP1cB5wGXB+9/u7vxspblZbgD1dR3ybxXPgvS/La41L6SWpUa2NwCVJHQtckhplgUtSoyxwSWqUBS5JjbLAJalRFrgkNer/ADH+aURd+ue4AAAAAElFTkSuQmCC",
+            "text/plain": [
+              "<Figure size 432x288 with 1 Axes>"
+            ]
+          },
+          "metadata": {
+            "needs_background": "light"
+          },
+          "output_type": "display_data"
+        }
+      ],
       "source": [
         "a = np.random.randn(30,40)\n",
         "print(a.shape)\n",
@@ -1437,49 +1487,6 @@
         "print(a.shape)\n",
         "plt.hist(a.flatten(), bins=100)\n",
         "plt.show()\n"
-      ],
-      "execution_count": null,
-      "outputs": [
-        {
-          "output_type": "stream",
-          "text": [
-            "(30, 40)\n"
-          ],
-          "name": "stdout"
-        },
-        {
-          "output_type": "display_data",
-          "data": {
-            "image/png": "iVBORw0KGgoAAAANSUhEUgAAAXAAAAD4CAYAAAD1jb0+AAAABHNCSVQICAgIfAhkiAAAAAlwSFlzAAALEgAACxIB0t1+/AAAADh0RVh0U29mdHdhcmUAbWF0cGxvdGxpYiB2ZXJzaW9uMy4yLjIsIGh0dHA6Ly9tYXRwbG90bGliLm9yZy+WH4yJAAAMuUlEQVR4nO3df4hl91nH8fena2JLq6Q1Q1izWTfQoAbRBJZYqUhJrK62NBFiaShlxchSMJii0sYWDFULCUJbEf9wMcEVQtPQVBJqxcY0pfaPpG7StE2yrV1DQxPS7NY2tEFQtnn8Y86aZTKz98yP++OZeb9gmHPOPffeJ7Ozn3z3+5zvuakqJEn9vGLeBUiSNsYAl6SmDHBJasoAl6SmDHBJaupHZvlm559/fu3bt2+WbylJ7T388MPfqaqllcdnGuD79u3j6NGjs3xLSWovyVOrHXcKRZKaMsAlqSkDXJKaMsAlqSkDXJKaMsAlqSkDXJKaMsAlqSkDXJKamulKTGlW9t30T/+//c1b3jLHSqTpcQQuSU0Z4JLUlAEuSU0Z4JLUlAEuSU0Z4JLUlAEuSU0Z4JLUlAt5tFBcgCON5whckpoywCWpKQNckpoywCWpKQNckpoaHeBJdiX5UpJPDfsXJ3koyfEkH09y7vTKlCSttJ4R+I3AsTP2bwU+UlWvB74HXL+VhUmSzm5UgCfZA7wF+LthP8CVwCeGU44A10yjQEnS6saOwD8KvBd4cdj/CeD5qjo17D8NXLjFtUmSzmJigCd5K3Ciqh7eyBskOZTkaJKjJ0+e3MhLSJJWMWYE/kbgbUm+CdzJ8tTJXwHnJTm9FH8P8MxqT66qw1W1v6r2Ly0tbUHJkiQYEeBV9SdVtaeq9gHvAD5bVe8EHgCuHU47CNwztSolSS+zmevA3wf8YZLjLM+J37Y1JUmSxljX3Qir6nPA54btJ4Ertr4kaXq826G2E1diSlJTBrgkNWWAS1JTBrgkNWWAS1JTBrgkNWWAS1JTBrgkNWWAS1JT61qJKXV05upLaTtxBC5JTRngktSUAS5JTTkHrta8u6B2MkfgktSUAS5JTRngktSUAS5JTRngktSUAS5JTRngktSUAS5JTRngktSUAS5JTRngktSUAS5JTRngktSUdyPUwlqEOw0uQg3SWhyBS1JTBrgkNWWAS1JTBrgkNWUTUy3YTJRezhG4JDVlgEtSUwa4JDVlgEtSUzYxNXdnNigXoQabpOpi4gg8ySuTfDHJl5M8nuSDw/GLkzyU5HiSjyc5d/rlSpJOGzOF8j/AlVX1C8BlwIEkbwBuBT5SVa8HvgdcP70yJUkrTQzwWvbCsHvO8FXAlcAnhuNHgGumUqEkaVWjmphJdiV5FDgB3Af8J/B8VZ0aTnkauHA6JUqSVjMqwKvqh1V1GbAHuAL4mbFvkORQkqNJjp48eXKDZUqSVlrXZYRV9TzwAPBLwHlJTl/Fsgd4Zo3nHK6q/VW1f2lpaVPFSpJeMuYqlKUk5w3brwLeDBxjOcivHU47CNwzrSIlSS835jrw3cCRJLtYDvy7qupTSZ4A7kzyF8CXgNumWKckaYWJAV5VXwEuX+X4kyzPh0s7jgt/tAhcSi9JTRngktSUAS5JTRngktSUdyOUVliEuyNKYzgCl6SmDHBJasoAl6SmDHBJasompqbKFYur8+eireAIXJKaMsAlqSkDXJKacg5c28a0F+C4wEeLxhG4JDVlgEtSUwa4JDVlgEtSUzYxtWMtYlPSBT5aD0fgktSUAS5JTRngktSUAS5JTdnE1MzYoJO2liNwSWrKAJekpgxwSWrKAJekpmxiakust0G5iKsgN+ps/y02azVNjsAlqSkDXJKaMsAlqSnnwAW4yGYWttO8vxaDI3BJasoAl6SmDHBJasoAl6SmbGJqy027WWczUFrmCFySmpoY4EkuSvJAkieSPJ7kxuH465Lcl+Qbw/fXTr9cSdJpY0bgp4A/qqpLgTcAv5/kUuAm4P6qugS4f9iXJM3IxACvqmer6pFh+wfAMeBC4GrgyHDaEeCaaRUpSXq5dTUxk+wDLgceAi6oqmeHh74NXLDGcw4BhwD27t270To1Q2OahK7WHMeGq6ZpdBMzyWuAu4H3VNX3z3ysqgqo1Z5XVYeran9V7V9aWtpUsZKkl4wK8CTnsBzed1TVJ4fDzyXZPTy+GzgxnRIlSasZcxVKgNuAY1X14TMeuhc4OGwfBO7Z+vIkSWsZMwf+RuBdwFeTPDocez9wC3BXkuuBp4C3T6dESWN4R8mdZ2KAV9UXgKzx8FVbW44kaSxXYkpSUwa4JDVlgEtSU96NUJozF/tooxyBS1JTBrgkNWWAS1JTBrgkNWWAS1JTBrgkNWWAS1JTBrgkNeVCHqkxFwHtbI7AJakpA1ySmjLAJakpA1ySmrKJKS2otT4izcalTnMELklNGeCS1JQBLklNGeCS1JQBLklNGeCS1JQBLklNGeCS1JQBLklNuRKzuTGr9c48Lmn7cAQuSU0Z4JLUlAEuSU05By41sN47ENoD2RkcgUtSUwa4JDVlgEtSUwa4JDVlE3MH86O5dp4xf+ZrNT1tjC4eR+CS1NTEAE9ye5ITSR4749jrktyX5BvD99dOt0xJ0kpjRuB/DxxYcewm4P6qugS4f9iXJM3QxACvqs8D311x+GrgyLB9BLhmi+uSJE2w0SbmBVX17LD9beCCtU5Mcgg4BLB3794Nvp22io3LnWczf+b+viy2TTcxq6qAOsvjh6tqf1XtX1pa2uzbSZIGGw3w55LsBhi+n9i6kiRJY2w0wO8FDg7bB4F7tqYcSdJYE+fAk3wMeBNwfpKngZuBW4C7klwPPAW8fZpFavE4NyrN38QAr6rr1njoqi2uRZK0Dq7ElKSmDHBJasoAl6SmvBvhNrJWY9GGo7Q9OQKXpKYMcElqygCXpKYMcElqyibmDI35SKr1niNp53IELklNGeCS1JQBLklNGeCS1JRNzAVms1IdjGm8d36/ReYIXJKaMsAlqSkDXJKacg58TpzH06Ky99KHI3BJasoAl6SmDHBJasoAl6SmbGJKmisb+hvnCFySmjLAJakpA1ySmjLAJakpm5gLwJVv6mat39m1GpIrz9/MRwrqJY7AJakpA1ySmjLAJakp58AHa83prZyHGzNf7dyddPa/K+vt+9gnWp0jcElqygCXpKYMcElqygCXpKbaNDE308SYdVPRhos0e5u5wGDsRQwbrWFaGeQIXJKa2lSAJzmQ5OtJjie5aauKkiRNtuEAT7IL+BvgN4BLgeuSXLpVhUmSzm4zI/ArgONV9WRV/S9wJ3D11pQlSZokVbWxJybXAgeq6veG/XcBv1hVN6w47xBwaNj9aeDrGy93VecD39ni15wF656tjnV3rBmsexp+qqqWVh6c+lUoVXUYODyt109ytKr2T+v1p8W6Z6tj3R1rBuuepc1MoTwDXHTG/p7hmCRpBjYT4P8OXJLk4iTnAu8A7t2asiRJk2x4CqWqTiW5AfgXYBdwe1U9vmWVjTe16Zkps+7Z6lh3x5rBumdmw01MSdJ8uRJTkpoywCWpqW0R4En+PMlXkjya5DNJfnLeNY2R5C+TfG2o/R+TnDfvmsZI8ttJHk/yYpKFvuyq4+0ektye5ESSx+Zdy3okuSjJA0meGH4/bpx3TWMkeWWSLyb58lD3B+dd01jbYg48yY9X1feH7T8ALq2qd8+5rImS/Brw2aEhfCtAVb1vzmVNlORngReBvwX+uKqOzrmkVQ23e/gP4M3A0yxfOXVdVT0x18ImSPIrwAvAP1TVz827nrGS7AZ2V9UjSX4MeBi4psHPO8Crq+qFJOcAXwBurKoH51zaRNtiBH46vAevBlr8X6mqPlNVp4bdB1m+ln7hVdWxqtrqFbXT0PJ2D1X1eeC7865jvarq2ap6ZNj+AXAMuHC+VU1Wy14Yds8ZvlpkyLYIcIAkH0ryLeCdwJ/Ou54N+F3gn+ddxDZzIfCtM/afpkGgbAdJ9gGXAw/Nt5JxkuxK8ihwArivqlrU3SbAk/xrksdW+boaoKo+UFUXAXcAN5z91WZnUt3DOR8ATrFc+0IYU7e0miSvAe4G3rPiX8cLq6p+WFWXsfyv4CuStJi6avOJPFX1qyNPvQP4NHDzFMsZbVLdSX4HeCtwVS1QQ2IdP+9F5u0eZmyYQ74buKOqPjnvetarqp5P8gBwAFj4JnKbEfjZJLnkjN2rga/Nq5b1SHIAeC/wtqr673nXsw15u4cZGpqBtwHHqurD865nrCRLp68AS/IqlpvePTJkgQZ9G5bkbpZvVfsi8BTw7qpa+JFWkuPAjwL/NRx6sMnVM78F/DWwBDwPPFpVvz7fqlaX5DeBj/LS7R4+NOeSJkryMeBNLN/e9Dng5qq6ba5FjZDkl4F/A77K8t9FgPdX1afnV9VkSX4eOMLy78grgLuq6s/mW9U42yLAJWkn2hZTKJK0ExngktSUAS5JTRngktSUAS5JTRngktSUAS5JTf0fJSBA1hX3ih8AAAAASUVORK5CYII=\n",
-            "text/plain": [
-              "<Figure size 432x288 with 1 Axes>"
-            ]
-          },
-          "metadata": {
-            "tags": [],
-            "needs_background": "light"
-          }
-        },
-        {
-          "output_type": "stream",
-          "text": [
-            "(30, 40)\n"
-          ],
-          "name": "stdout"
-        },
-        {
-          "output_type": "display_data",
-          "data": {
-            "image/png": "iVBORw0KGgoAAAANSUhEUgAAAXEAAAD4CAYAAAAaT9YAAAAABHNCSVQICAgIfAhkiAAAAAlwSFlzAAALEgAACxIB0t1+/AAAADh0RVh0U29mdHdhcmUAbWF0cGxvdGxpYiB2ZXJzaW9uMy4yLjIsIGh0dHA6Ly9tYXRwbG90bGliLm9yZy+WH4yJAAAPt0lEQVR4nO3df4xlZX3H8fdHhGIUg5YbsmWZrlFiQ4wuzYRiaBqLYlY0go1tJBZpSjM2kQRTUgVNqrY1wVjFJjW2q1A2kapEJRjU6hbXEBOLsrriwmqlFOOSlY0RIqQJzcK3f8zBTtc7e8/M/TXPzvuVTPaec8+d+8nuzCfPnuc856aqkCS16RnzDiBJWj9LXJIaZolLUsMscUlqmCUuSQ175izf7LTTTqtt27bN8i0lqXl79+79WVUNhj030xLftm0bd9999yzfUpKal+THqz3n6RRJapglLkkNs8QlqWGWuCQ1zBKXpIZZ4pLUsN4lnuSEJN9Ncnu3/YIkdyW5P8lnkpw0vZiSpGHWMhK/CjiwYvsDwPVV9SLgEeCKSQaTJI3Wq8STbAVeC3yi2w5wAfDZ7pBdwCXTCChJWl3fFZsfAd4BnNJt/zrwaFUd6bYPAmcMe2GSJWAJYGFhYf1JpTnYds0Xf/n4weteO8ck0nAjR+JJXgccrqq963mDqtpZVYtVtTgYDF36L0lapz4j8fOB1ye5CDgZeC7w98CpSZ7Zjca3Ag9NL6YkaZiRI/GquraqtlbVNuBNwNeq6s3AHuCN3WGXA7dNLaUkaahxrhN/J/AXSe5n+Rz5DZOJJEnqa023oq2qrwNf7x4/AJw7+UhqXZ/JQCcMpclwxaYkNcwSl6SGWeKS1DBLXJIaNtPP2JQmzQlSbXaOxCWpYZa4JDXMEpekhlniktQwS1ySGmaJS1LDLHFJapglLkkNs8QlqWGu2NSG5WpMaTRH4pLUsD4flHxykm8l+V6Se5O8r9t/U5L/SrKv+9o+/biSpJX6nE55Arigqh5PciLwjSRf7p77y6r67PTiSZKOZWSJV1UBj3ebJ3ZfNc1QkqR+ep0TT3JCkn3AYWB3Vd3VPfX+JPckuT7Jr00tpSRpqF5Xp1TVk8D2JKcCtyZ5CXAt8FPgJGAn8E7gr49+bZIlYAlgYWFhQrG1ma28amUa39MrYdSSNV2dUlWPAnuAHVV1qJY9Afwzq3zyfVXtrKrFqlocDAbjJ5Yk/VKfq1MG3QicJM8CLgR+kGRLty/AJcD+aQaVJP2qPqdTtgC7kpzAcunfUlW3J/lakgEQYB/w51PMKUkaos/VKfcA5wzZf8FUEkmSenPFpiQ1zBKXpIZZ4pLUMEtckhpmiUtSw7yfuOZuXqslp7HyU5o1R+KS1DBLXJIaZolLUsMscUlqmBObOm54O1ltRo7EJalhlrgkNcwSl6SGWeKS1DAnNqV1ciJVG4EjcUlqWJ/P2Dw5ybeSfC/JvUne1+1/QZK7ktyf5DNJTpp+XEnSSn1G4k8AF1TVy4DtwI4k5wEfAK6vqhcBjwBXTC+mJGmYkSVeyx7vNk/svgq4APhst38Xy594L0maoV4Tm90n3e8FXgR8FPhP4NGqOtIdchA4Y5XXLgFLAAsLC+PmlebmWLeudZJT89JrYrOqnqyq7cBW4Fzgt/q+QVXtrKrFqlocDAbrjClJGmZNV6dU1aPAHuDlwKlJnh7JbwUemnA2SdIIfa5OGSQ5tXv8LOBC4ADLZf7G7rDLgdumFVKSNFyfc+JbgF3defFnALdU1e1J7gM+neRvge8CN0wxpyRpiJElXlX3AOcM2f8Ay+fHJUlz4rJ7HZe8WkSbhcvuJalhlrgkNcwSl6SGWeKS1DAnNjURqy1Jd4JRmi5H4pLUMEtckhpmiUtSwyxxSWqYJS5JDbPEJalhlrgkNcwSl6SGWeKS1DBXbEoz4upVTYMjcUlqWJ/P2DwzyZ4k9yW5N8lV3f73Jnkoyb7u66Lpx5UkrdTndMoR4Oqq+k6SU4C9SXZ3z11fVX83vXiSpGPp8xmbh4BD3ePHkhwAzph2MEnSaGua2EyyjeUPTb4LOB+4MslbgLtZHq0/MuQ1S8ASwMLCwphxtVmtdqtbabPrPbGZ5DnA54C3V9UvgI8BLwS2szxS/9Cw11XVzqparKrFwWAwgciSpKf1KvEkJ7Jc4DdX1ecBqurhqnqyqp4CPg6cO72YkqRh+lydEuAG4EBVfXjF/i0rDnsDsH/y8SRJx9LnnPj5wGXA95Ps6/a9C7g0yXaggAeBt04loSRpVX2uTvkGkCFPfWnycSRJa+Gye63JOEvH53WFicvddTxz2b0kNcwSl6SGWeKS1DBLXJIaZolLUsMscUlqmCUuSQ2zxCWpYZa4JDXMFZsaaZYrLaf9Xn2+v/cuV0sciUtSwyxxSWqYJS5JDbPEJalhTmxKU+QkqabNkbgkNazPZ2yemWRPkvuS3Jvkqm7/85PsTvKj7s/nTT+uJGmlPiPxI8DVVXU2cB7wtiRnA9cAd1TVWcAd3bYkaYZGlnhVHaqq73SPHwMOAGcAFwO7usN2AZdMK6Qkabg1TWwm2QacA9wFnF5Vh7qnfgqcvsprloAlgIWFhfXm1BSs9tmTTsZJ7eg9sZnkOcDngLdX1S9WPldVBdSw11XVzqparKrFwWAwVlhJ0v/Xq8STnMhygd9cVZ/vdj+cZEv3/Bbg8HQiSpJW0+fqlAA3AAeq6sMrnvoCcHn3+HLgtsnHkyQdS59z4ucDlwHfT7Kv2/cu4DrgliRXAD8G/mg6ESVJqxlZ4lX1DSCrPP3KycaRNrfVJpul1bhiU5IaZolLUsMscUlqmCUuSQ2zxCWpYZa4JDXMEpekhlniktQwS1ySGmaJS1LD/KBkaYNyCb76cCQuSQ2zxCWpYZa4JDXMEpekhjmx2aA+E16zmBTzA5WH8+9Fs+RIXJIa1uczNm9McjjJ/hX73pvkoST7uq+LphtTkjRMn5H4TcCOIfuvr6rt3deXJhtLktTHyBKvqjuBn88giyRpjcaZ2LwyyVuAu4Grq+qRYQclWQKWABYWFsZ4O02Tk3Ebm6s3tZr1Tmx+DHghsB04BHxotQOramdVLVbV4mAwWOfbSZKGWVeJV9XDVfVkVT0FfBw4d7KxJEl9rKvEk2xZsfkGYP9qx0qSpmfkOfEknwJeAZyW5CDwHuAVSbYDBTwIvHWKGSVJqxhZ4lV16ZDdN0whi7RpTGqi0glPuWJTkhpmiUtSwyxxSWqYJS5JDfNWtMcRV122yX83jcORuCQ1zBKXpIZZ4pLUMEtckhpmiUtSw7w6ZYOZxjJql2ZvDv47b06OxCWpYZa4JDXMEpekhlniktQwJzY3GZd4S8cXR+KS1LCRJZ7kxiSHk+xfse/5SXYn+VH35/OmG1OSNEyfkfhNwI6j9l0D3FFVZwF3dNuSpBkbWeJVdSfw86N2Xwzs6h7vAi6ZcC5JUg/rndg8vaoOdY9/Cpy+2oFJloAlgIWFhXW+naSnOTmtlcae2KyqAuoYz++sqsWqWhwMBuO+nSRphfWW+MNJtgB0fx6eXCRJUl/rLfEvAJd3jy8HbptMHEnSWvS5xPBTwDeBFyc5mOQK4DrgwiQ/Al7VbUuSZmzkxGZVXbrKU6+ccJZNpc9tQ721qKRRXLEpSQ2zxCWpYZa4JDXMEpekhnkr2hkaZ6Xdaq919Z60uTkSl6SGWeKS1DBLXJIaZolLUsMscUlqmFenSMe5cW7f4K0fNj5H4pLUMEtckhpmiUtSwyxxSWqYE5tT5rJ4tcCf03Y5Epekho01Ek/yIPAY8CRwpKoWJxFKktTPJE6n/H5V/WwC30eStEaeTpGkho07Ei/gq0kK+Keq2nn0AUmWgCWAhYWFMd9uPly1ptbM8v7zR39Pf0dma9yR+O9W1W8DrwHeluT3jj6gqnZW1WJVLQ4GgzHfTpK00lglXlUPdX8eBm4Fzp1EKElSP+su8STPTnLK04+BVwP7JxVMkjTaOOfETwduTfL09/mXqvrXiaSSJPWy7hKvqgeAl00wy6blajm1YD0/p14UMH1eYihJDbPEJalhlrgkNcwSl6SGbbpb0U5yomW17+VEpTS+1X6PVvtd26wTp47EJalhlrgkNcwSl6SGWeKS1LDjamJz3EmOPhOSs7zFp9Qifxdmy5G4JDXMEpekhlniktQwS1ySGmaJS1LDmrk6ZRrLa51Fl2anz+/b8bR0flYfIO1IXJIaNlaJJ9mR5IdJ7k9yzaRCSZL6GeeDkk8APgq8BjgbuDTJ2ZMKJkkabZyR+LnA/VX1QFX9D/Bp4OLJxJIk9ZGqWt8LkzcCO6rqz7rty4DfqaorjzpuCVjqNl8M/HCdWU8DfrbO185Li5mhzdxmno0WM0ObuVdm/s2qGgw7aOpXp1TVTmDnuN8nyd1VtTiBSDPTYmZoM7eZZ6PFzNBm7r6Zxzmd8hBw5ortrd0+SdKMjFPi3wbOSvKCJCcBbwK+MJlYkqQ+1n06paqOJLkS+ApwAnBjVd07sWS/auxTMnPQYmZoM7eZZ6PFzNBm7l6Z1z2xKUmaP1dsSlLDLHFJalhTJZ7kb5Lck2Rfkq8m+Y15ZxolyQeT/KDLfWuSU+edaZQkf5jk3iRPJdnQl2W1eOuHJDcmOZxk/7yz9JXkzCR7ktzX/WxcNe9MoyQ5Ocm3knyvy/y+eWfqK8kJSb6b5PZRxzZV4sAHq+qlVbUduB34q3kH6mE38JKqeinwH8C1c87Tx37gD4A75x3kWBq+9cNNwI55h1ijI8DVVXU2cB7wtgb+rp8ALqiqlwHbgR1Jzptzpr6uAg70ObCpEq+qX6zYfDaw4Wdlq+qrVXWk2/x3lq+n39Cq6kBVrXdl7Sw1eeuHqroT+Pm8c6xFVR2qqu90jx9juWDOmG+qY6tlj3ebJ3ZfG74zkmwFXgt8os/xTZU4QJL3J/kJ8GbaGImv9KfAl+cd4jhyBvCTFdsH2eDFcjxIsg04B7hrvklG605L7AMOA7urasNnBj4CvAN4qs/BG67Ek/xbkv1Dvi4GqKp3V9WZwM3Alcf+brMxKnN3zLtZ/i/pzfNL+n/6ZJaOluQ5wOeAtx/1P+MNqaqe7E6/bgXOTfKSeWc6liSvAw5X1d6+r9lwn+xTVa/qeejNwJeA90wxTi+jMif5E+B1wCtrg1yYv4a/543MWz/MUJITWS7wm6vq8/POsxZV9WiSPSzPRWzkCeXzgdcnuQg4GXhukk9W1R+v9oINNxI/liRnrdi8GPjBvLL0lWQHy/81en1V/fe88xxnvPXDjCQJcANwoKo+PO88fSQZPH01WJJnAReywTujqq6tqq1VtY3ln+evHavAobESB67r/st/D/BqlmdwN7p/AE4BdneXRv7jvAONkuQNSQ4CLwe+mOQr8840TDdh/PStHw4At0z51g8TkeRTwDeBFyc5mOSKeWfq4XzgMuCC7ud4Xzda3Mi2AHu6vvg2y+fER16y1xqX3UtSw1obiUuSVrDEJalhlrgkNcwSl6SGWeKS1DBLXJIaZolLUsP+FztyYU7W4YyWAAAAAElFTkSuQmCC\n",
-            "text/plain": [
-              "<Figure size 432x288 with 1 Axes>"
-            ]
-          },
-          "metadata": {
-            "tags": [],
-            "needs_background": "light"
-          }
-        }
       ]
     },
     {
@@ -1501,28 +1508,23 @@
       "source": [
         "# 슬라이싱\n",
         "\n",
-        "![대체 텍스트](https://github.com/dhrim/cau_2022_summer/raw/main/material/library/images/slice1.png)\n",
+        "![대체 텍스트](https://github.com/dhrim/cau_2022_summer/raw/master/material/library/images/slice1.png)\n",
         "image from http://taewan.kim/post/numpy_cheat_sheet/"
       ]
     },
     {
       "cell_type": "code",
+      "execution_count": 39,
       "metadata": {
         "colab": {
           "base_uri": "https://localhost:8080/"
         },
         "id": "Dl_6GEc3K90G",
-        "outputId": "cafabcd7-271e-4309-bb5b-8e49898892ed"
+        "outputId": "c604e888-dbc7-45c8-8233-0e4a47f7d53c"
       },
-      "source": [
-        "a = np.arange(20).reshape(4,5)\n",
-        "pa(a)\n",
-        "\n",
-        "pa(a[1:3], \"a[1:3]\")"
-      ],
-      "execution_count": null,
       "outputs": [
         {
+          "name": "stdout",
           "output_type": "stream",
           "text": [
             "[[ 0  1  2  3  4]\n",
@@ -1534,29 +1536,29 @@
             "[[ 5  6  7  8  9]\n",
             " [10 11 12 13 14]]\n",
             "\n"
-          ],
-          "name": "stdout"
+          ]
         }
+      ],
+      "source": [
+        "a = np.arange(20).reshape(4,5)\n",
+        "pa(a)\n",
+        "\n",
+        "pa(a[1:3], \"a[1:3]\")"
       ]
     },
     {
       "cell_type": "code",
+      "execution_count": 40,
       "metadata": {
         "colab": {
           "base_uri": "https://localhost:8080/"
         },
         "id": "vk8VEk6bMzI8",
-        "outputId": "a0bb4cec-e83f-4c4c-d711-041f3c609464"
+        "outputId": "9afeec5a-82d3-4b74-930a-d86bee912200"
       },
-      "source": [
-        "a = np.arange(20).reshape(4,5)\n",
-        "pa(a)\n",
-        "\n",
-        "pa(a[:,1:3], \"a[:,1:3]\")"
-      ],
-      "execution_count": null,
       "outputs": [
         {
+          "name": "stdout",
           "output_type": "stream",
           "text": [
             "[[ 0  1  2  3  4]\n",
@@ -1570,29 +1572,29 @@
             " [11 12]\n",
             " [16 17]]\n",
             "\n"
-          ],
-          "name": "stdout"
+          ]
         }
+      ],
+      "source": [
+        "a = np.arange(20).reshape(4,5)\n",
+        "pa(a)\n",
+        "\n",
+        "pa(a[:,1:3], \"a[:,1:3]\")"
       ]
     },
     {
       "cell_type": "code",
+      "execution_count": 41,
       "metadata": {
         "colab": {
           "base_uri": "https://localhost:8080/"
         },
         "id": "EWeZAgqpO9SE",
-        "outputId": "bc4295ad-0712-4cbe-d29b-63442afe512f"
+        "outputId": "56ae0143-d9f1-452b-dd7c-ec04d59dc268"
       },
-      "source": [
-        "a = np.arange(20).reshape(4,5)\n",
-        "pa(a)\n",
-        "\n",
-        "pa(a[1:3,1:3], \"a[1:3,1:3]\")"
-      ],
-      "execution_count": null,
       "outputs": [
         {
+          "name": "stdout",
           "output_type": "stream",
           "text": [
             "[[ 0  1  2  3  4]\n",
@@ -1604,31 +1606,29 @@
             "[[ 6  7]\n",
             " [11 12]]\n",
             "\n"
-          ],
-          "name": "stdout"
+          ]
         }
+      ],
+      "source": [
+        "a = np.arange(20).reshape(4,5)\n",
+        "pa(a)\n",
+        "\n",
+        "pa(a[1:3,1:3], \"a[1:3,1:3]\")"
       ]
     },
     {
       "cell_type": "code",
+      "execution_count": 42,
       "metadata": {
         "colab": {
           "base_uri": "https://localhost:8080/"
         },
         "id": "nIRL_3rgPAy1",
-        "outputId": "4e863c26-42b0-4893-e046-9be4a6cf1548"
+        "outputId": "a9e3f0dc-777c-4d6f-a74b-9810ae341499"
       },
-      "source": [
-        "a = np.arange(20).reshape(4,5)\n",
-        "pa(a)\n",
-        "\n",
-        "pa(a[1:3], \"a[1:3]\")\n",
-        "\n",
-        "pa(a[1:3][1:3], \"a[1:3][1:3]\")"
-      ],
-      "execution_count": null,
       "outputs": [
         {
+          "name": "stdout",
           "output_type": "stream",
           "text": [
             "[[ 0  1  2  3  4]\n",
@@ -1643,9 +1643,16 @@
             "a[1:3][1:3]\n",
             "[[10 11 12 13 14]]\n",
             "\n"
-          ],
-          "name": "stdout"
+          ]
         }
+      ],
+      "source": [
+        "a = np.arange(20).reshape(4,5)\n",
+        "pa(a)\n",
+        "\n",
+        "pa(a[1:3], \"a[1:3]\")\n",
+        "\n",
+        "pa(a[1:3][1:3], \"a[1:3][1:3]\")"
       ]
     },
     {
@@ -1659,29 +1666,17 @@
     },
     {
       "cell_type": "code",
+      "execution_count": 43,
       "metadata": {
         "colab": {
           "base_uri": "https://localhost:8080/"
         },
         "id": "E4Hy0qrEPUNo",
-        "outputId": "216e2e71-d69d-4791-f4ff-b311ec5e2924"
+        "outputId": "63630b42-ca58-4ed2-9612-fcb71cdb78da"
       },
-      "source": [
-        "a = np.arange(20).reshape(4,5)\n",
-        "pa(a)\n",
-        "\n",
-        "pa(a[1:3], \"a[1:3]\")\n",
-        "\n",
-        "b = a[1:3]\n",
-        "pa(b, \"b = a[1:3]\")\n",
-        "\n",
-        "pa(b[1:3], \"b[1:3] = a[1:3][1:3]\")\n",
-        "\n",
-        "pa(a[1:31:3], \"a[1:31:3]\")"
-      ],
-      "execution_count": null,
       "outputs": [
         {
+          "name": "stdout",
           "output_type": "stream",
           "text": [
             "[[ 0  1  2  3  4]\n",
@@ -1703,9 +1698,21 @@
             "a[1:31:3]\n",
             "[[5 6 7 8 9]]\n",
             "\n"
-          ],
-          "name": "stdout"
+          ]
         }
+      ],
+      "source": [
+        "a = np.arange(20).reshape(4,5)\n",
+        "pa(a)\n",
+        "\n",
+        "pa(a[1:3], \"a[1:3]\")\n",
+        "\n",
+        "b = a[1:3]\n",
+        "pa(b, \"b = a[1:3]\")\n",
+        "\n",
+        "pa(b[1:3], \"b[1:3] = a[1:3][1:3]\")\n",
+        "\n",
+        "pa(a[1:31:3], \"a[1:31:3]\")"
       ]
     },
     {
@@ -1730,32 +1737,17 @@
     },
     {
       "cell_type": "code",
+      "execution_count": 44,
       "metadata": {
         "colab": {
           "base_uri": "https://localhost:8080/"
         },
         "id": "CDEpsuSYQ_2G",
-        "outputId": "a6ac4f1d-65fd-427d-fa6d-bcabfd0269be"
+        "outputId": "ac1262f4-4d3c-41e8-9972-827265dcbddf"
       },
-      "source": [
-        "a = np.arange(12).reshape(3,4)\n",
-        "pa(a)\n",
-        "\n",
-        "a[1,2] = -1\n",
-        "pa(a, \"a[1,2] = -1\")\n",
-        "\n",
-        "a[1,1:3] = -1\n",
-        "pa(a, \"a[1:3] = -1\")\n",
-        "\n",
-        "a[1] = -1\n",
-        "pa(a, \"a[1] = -1\")\n",
-        "\n",
-        "a[1:] = -1\n",
-        "pa(a, \"a[:1] = -1\")\n"
-      ],
-      "execution_count": null,
       "outputs": [
         {
+          "name": "stdout",
           "output_type": "stream",
           "text": [
             "[[ 0  1  2  3]\n",
@@ -1782,33 +1774,39 @@
             " [-1 -1 -1 -1]\n",
             " [-1 -1 -1 -1]]\n",
             "\n"
-          ],
-          "name": "stdout"
+          ]
         }
+      ],
+      "source": [
+        "a = np.arange(12).reshape(3,4)\n",
+        "pa(a)\n",
+        "\n",
+        "a[1,2] = -1\n",
+        "pa(a, \"a[1,2] = -1\")\n",
+        "\n",
+        "a[1,1:3] = -1\n",
+        "pa(a, \"a[1:3] = -1\")\n",
+        "\n",
+        "a[1] = -1\n",
+        "pa(a, \"a[1] = -1\")\n",
+        "\n",
+        "a[1:] = -1\n",
+        "pa(a, \"a[:1] = -1\")\n"
       ]
     },
     {
       "cell_type": "code",
+      "execution_count": 45,
       "metadata": {
         "colab": {
           "base_uri": "https://localhost:8080/"
         },
         "id": "YP_MQoyBRe2Y",
-        "outputId": "9b723400-d933-4510-938b-14ef0bb995c7"
+        "outputId": "3d308088-1525-425c-de14-dd7f55e1dcd1"
       },
-      "source": [
-        "a = np.arange(12).reshape(3,4)\n",
-        "pa(a)\n",
-        "\n",
-        "a[:,1] = -1\n",
-        "pa(a, \"pa[:,1] = -1\")\n",
-        "\n",
-        "a[:,1:3] = -1\n",
-        "pa(a, \"pa[:,1:3] = -1\")\n"
-      ],
-      "execution_count": null,
       "outputs": [
         {
+          "name": "stdout",
           "output_type": "stream",
           "text": [
             "[[ 0  1  2  3]\n",
@@ -1825,30 +1823,33 @@
             " [ 4 -1 -1  7]\n",
             " [ 8 -1 -1 11]]\n",
             "\n"
-          ],
-          "name": "stdout"
+          ]
         }
+      ],
+      "source": [
+        "a = np.arange(12).reshape(3,4)\n",
+        "pa(a)\n",
+        "\n",
+        "a[:,1] = -1\n",
+        "pa(a, \"pa[:,1] = -1\")\n",
+        "\n",
+        "a[:,1:3] = -1\n",
+        "pa(a, \"pa[:,1:3] = -1\")\n"
       ]
     },
     {
       "cell_type": "code",
+      "execution_count": 46,
       "metadata": {
         "colab": {
           "base_uri": "https://localhost:8080/"
         },
         "id": "e5Lqf5tyRskx",
-        "outputId": "f4172111-fd99-4189-a070-b2bdd644bc65"
+        "outputId": "634304fd-1e7b-4f52-d919-a8f51d6b3236"
       },
-      "source": [
-        "a = np.arange(12).reshape(3,4)\n",
-        "pa(a)\n",
-        "\n",
-        "a[1:2,1:3] = -1\n",
-        "pa(a, \"pa[1:2,1:3] = -1\")"
-      ],
-      "execution_count": null,
       "outputs": [
         {
+          "name": "stdout",
           "output_type": "stream",
           "text": [
             "[[ 0  1  2  3]\n",
@@ -1860,9 +1861,15 @@
             " [ 4 -1 -1  7]\n",
             " [ 8  9 10 11]]\n",
             "\n"
-          ],
-          "name": "stdout"
+          ]
         }
+      ],
+      "source": [
+        "a = np.arange(12).reshape(3,4)\n",
+        "pa(a)\n",
+        "\n",
+        "a[1:2,1:3] = -1\n",
+        "pa(a, \"pa[1:2,1:3] = -1\")"
       ]
     },
     {
@@ -1883,21 +1890,17 @@
     },
     {
       "cell_type": "code",
+      "execution_count": 47,
       "metadata": {
         "colab": {
           "base_uri": "https://localhost:8080/"
         },
         "id": "zv9zaDq_TakR",
-        "outputId": "a511322d-353b-4bfa-89f8-286c39fdc68a"
+        "outputId": "497fb2d3-3f42-427f-a765-6a6e32985687"
       },
-      "source": [
-        "a = np.ones((5,5))\n",
-        "a[1:4,1:4] = 0\n",
-        "pa(a)"
-      ],
-      "execution_count": null,
       "outputs": [
         {
+          "name": "stdout",
           "output_type": "stream",
           "text": [
             "[[1. 1. 1. 1. 1.]\n",
@@ -1906,9 +1909,13 @@
             " [1. 0. 0. 0. 1.]\n",
             " [1. 1. 1. 1. 1.]]\n",
             "\n"
-          ],
-          "name": "stdout"
+          ]
         }
+      ],
+      "source": [
+        "a = np.ones((5,5))\n",
+        "a[1:4,1:4] = 0\n",
+        "pa(a)"
       ]
     },
     {
@@ -1929,23 +1936,17 @@
     },
     {
       "cell_type": "code",
+      "execution_count": 48,
       "metadata": {
         "colab": {
           "base_uri": "https://localhost:8080/"
         },
         "id": "_4Cw4tAxTi3q",
-        "outputId": "0a620553-18b7-486d-a37e-e05971d03e6c"
+        "outputId": "4d2090c7-daa4-4d9b-9e0f-a76b71e1ef05"
       },
-      "source": [
-        "a = np.arange(20).reshape(5,4)\n",
-        "pa(a)\n",
-        "\n",
-        "a[::2] = 0\n",
-        "pa(a)"
-      ],
-      "execution_count": null,
       "outputs": [
         {
+          "name": "stdout",
           "output_type": "stream",
           "text": [
             "[[ 0  1  2  3]\n",
@@ -1960,9 +1961,15 @@
             " [12 13 14 15]\n",
             " [ 0  0  0  0]]\n",
             "\n"
-          ],
-          "name": "stdout"
+          ]
         }
+      ],
+      "source": [
+        "a = np.arange(20).reshape(5,4)\n",
+        "pa(a)\n",
+        "\n",
+        "a[::2] = 0\n",
+        "pa(a)"
       ]
     },
     {
@@ -1979,28 +1986,28 @@
     },
     {
       "cell_type": "code",
+      "execution_count": 49,
       "metadata": {
         "colab": {
           "base_uri": "https://localhost:8080/"
         },
         "id": "iQX1l2iXT6bG",
-        "outputId": "8f323284-0c8f-4025-c540-2c9c0ab50162"
+        "outputId": "1d6d080b-f0bd-4597-feff-7e4dc4c788a5"
       },
-      "source": [
-        "a = np.zeros(8)\n",
-        "a[1::2] = 1\n",
-        "pa(a)"
-      ],
-      "execution_count": null,
       "outputs": [
         {
+          "name": "stdout",
           "output_type": "stream",
           "text": [
             "[0. 1. 0. 1. 0. 1. 0. 1.]\n",
             "\n"
-          ],
-          "name": "stdout"
+          ]
         }
+      ],
+      "source": [
+        "a = np.zeros(8)\n",
+        "a[1::2] = 1\n",
+        "pa(a)"
       ]
     },
     {
@@ -2014,35 +2021,17 @@
     },
     {
       "cell_type": "code",
+      "execution_count": 50,
       "metadata": {
         "colab": {
           "base_uri": "https://localhost:8080/"
         },
         "id": "fNt6HyQ4UGiR",
-        "outputId": "412765c0-9eb1-459d-d476-a3e142da30e6"
+        "outputId": "620bbbd0-aca6-42c2-de33-69fe80ef1085"
       },
-      "source": [
-        "a = np.array([\n",
-        "    [ 0,  0,  0],\n",
-        "    [10, 10, 10],\n",
-        "    [20, 20, 20],\n",
-        "    [30, 30, 30]\n",
-        "])\n",
-        "b = np.array([\n",
-        "    [ 0,  1,  2],\n",
-        "    [ 0,  1,  2],\n",
-        "    [ 0,  1,  2],\n",
-        "    [ 0,  1,  2]    \n",
-        "])\n",
-        "\n",
-        "pa(a, \"a\")\n",
-        "pa(b, \"b\")\n",
-        "\n",
-        "pa(a+b, \"a+b\")"
-      ],
-      "execution_count": null,
       "outputs": [
         {
+          "name": "stdout",
           "output_type": "stream",
           "text": [
             "a\n",
@@ -2063,20 +2052,9 @@
             " [20 21 22]\n",
             " [30 31 32]]\n",
             "\n"
-          ],
-          "name": "stdout"
+          ]
         }
-      ]
-    },
-    {
-      "cell_type": "code",
-      "metadata": {
-        "colab": {
-          "base_uri": "https://localhost:8080/"
-        },
-        "id": "TgqLNL9XUwnS",
-        "outputId": "4dd2deb5-9de1-4b06-d6de-b1a3ee7fc99d"
-      },
+      ],
       "source": [
         "a = np.array([\n",
         "    [ 0,  0,  0],\n",
@@ -2094,13 +2072,22 @@
         "pa(a, \"a\")\n",
         "pa(b, \"b\")\n",
         "\n",
-        "pa(a-b, \"a-b\")\n",
-        "\n",
-        "pa(a*b, \"a*b\")\n"
-      ],
-      "execution_count": null,
+        "pa(a+b, \"a+b\")"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 51,
+      "metadata": {
+        "colab": {
+          "base_uri": "https://localhost:8080/"
+        },
+        "id": "TgqLNL9XUwnS",
+        "outputId": "efeab924-4f5b-4452-a613-5d1283b0e016"
+      },
       "outputs": [
         {
+          "name": "stdout",
           "output_type": "stream",
           "text": [
             "a\n",
@@ -2127,20 +2114,9 @@
             " [ 0 20 40]\n",
             " [ 0 30 60]]\n",
             "\n"
-          ],
-          "name": "stdout"
+          ]
         }
-      ]
-    },
-    {
-      "cell_type": "code",
-      "metadata": {
-        "colab": {
-          "base_uri": "https://localhost:8080/"
-        },
-        "id": "guxXeMCsWre2",
-        "outputId": "2c26fde2-dd4b-4933-f58a-7829bcbf7195"
-      },
+      ],
       "source": [
         "a = np.array([\n",
         "    [ 0,  0,  0],\n",
@@ -2158,11 +2134,24 @@
         "pa(a, \"a\")\n",
         "pa(b, \"b\")\n",
         "\n",
-        "pa(a/b, \"a/b\")\n"
-      ],
-      "execution_count": null,
+        "pa(a-b, \"a-b\")\n",
+        "\n",
+        "pa(a*b, \"a*b\")\n"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 52,
+      "metadata": {
+        "colab": {
+          "base_uri": "https://localhost:8080/"
+        },
+        "id": "guxXeMCsWre2",
+        "outputId": "3df43541-3187-43ca-d48a-2662b5ff7e41"
+      },
       "outputs": [
         {
+          "name": "stdout",
           "output_type": "stream",
           "text": [
             "a\n",
@@ -2183,17 +2172,35 @@
             " [inf 20. 10.]\n",
             " [inf 30. 15.]]\n",
             "\n"
-          ],
-          "name": "stdout"
+          ]
         },
         {
+          "name": "stderr",
           "output_type": "stream",
           "text": [
             "/usr/local/lib/python3.7/dist-packages/ipykernel_launcher.py:17: RuntimeWarning: divide by zero encountered in true_divide\n",
             "/usr/local/lib/python3.7/dist-packages/ipykernel_launcher.py:17: RuntimeWarning: invalid value encountered in true_divide\n"
-          ],
-          "name": "stderr"
+          ]
         }
+      ],
+      "source": [
+        "a = np.array([\n",
+        "    [ 0,  0,  0],\n",
+        "    [10, 10, 10],\n",
+        "    [20, 20, 20],\n",
+        "    [30, 30, 30]\n",
+        "])\n",
+        "b = np.array([\n",
+        "    [ 0,  1,  2],\n",
+        "    [ 0,  1,  2],\n",
+        "    [ 0,  1,  2],\n",
+        "    [ 0,  1,  2]    \n",
+        "])\n",
+        "\n",
+        "pa(a, \"a\")\n",
+        "pa(b, \"b\")\n",
+        "\n",
+        "pa(a/b, \"a/b\")\n"
       ]
     },
     {
@@ -2207,37 +2214,17 @@
     },
     {
       "cell_type": "code",
+      "execution_count": 53,
       "metadata": {
         "colab": {
           "base_uri": "https://localhost:8080/"
         },
         "id": "l99b6UpJXKgf",
-        "outputId": "201a0bbf-5369-4e2d-8e9e-a664e1fb12a1"
+        "outputId": "9c2ba598-9228-4858-e487-8a92ee173e6d"
       },
-      "source": [
-        "a = np.array([\n",
-        "    [ 0,  0,  0],\n",
-        "    [10, 10, 10],\n",
-        "    [20, 20, 20],\n",
-        "    [30, 30, 30]\n",
-        "])\n",
-        "b = np.array([\n",
-        "    [ 1,  2,  3 ],\n",
-        "    [ 4,  5,  6],\n",
-        "    [ 7,  8,  9],\n",
-        "    [ 10, 12, 12]    \n",
-        "])\n",
-        "\n",
-        "pa(a, \"a\")\n",
-        "pa(b, \"b\")\n",
-        "\n",
-        "pa(a//b, \"a//b\")\n",
-        "\n",
-        "pa(a%b, \"a%b\")\n"
-      ],
-      "execution_count": null,
       "outputs": [
         {
+          "name": "stdout",
           "output_type": "stream",
           "text": [
             "a\n",
@@ -2264,21 +2251,39 @@
             " [6 4 2]\n",
             " [0 6 6]]\n",
             "\n"
-          ],
-          "name": "stdout"
+          ]
         }
+      ],
+      "source": [
+        "a = np.array([\n",
+        "    [ 0,  0,  0],\n",
+        "    [10, 10, 10],\n",
+        "    [20, 20, 20],\n",
+        "    [30, 30, 30]\n",
+        "])\n",
+        "b = np.array([\n",
+        "    [ 1,  2,  3 ],\n",
+        "    [ 4,  5,  6],\n",
+        "    [ 7,  8,  9],\n",
+        "    [ 10, 12, 12]    \n",
+        "])\n",
+        "\n",
+        "pa(a, \"a\")\n",
+        "pa(b, \"b\")\n",
+        "\n",
+        "pa(a//b, \"a//b\")\n",
+        "\n",
+        "pa(a%b, \"a%b\")\n"
       ]
     },
     {
       "cell_type": "code",
+      "execution_count": 53,
       "metadata": {
         "id": "iW7-aTNif1bX"
       },
-      "source": [
-        ""
-      ],
-      "execution_count": null,
-      "outputs": []
+      "outputs": [],
+      "source": []
     },
     {
       "cell_type": "markdown",
@@ -2311,7 +2316,7 @@
         "- 비교 연산\n",
         "  >, <, >=, <=, ==, !=\n",
         "  greater(), greater_equal(), less(), less_equal(), equal(), not_equal()\n",
-        "  maximum(), minmum(), ..\n",
+        "  maximum(), minimum(), ..\n",
         "- 실수 연산?\n",
         "  isfinite(), isnan(), abs(), round(), floor(), ceil(), ...\n",
         "- 통계\n",
@@ -2321,13 +2326,27 @@
     },
     {
       "cell_type": "code",
+      "execution_count": 54,
       "metadata": {
         "colab": {
           "base_uri": "https://localhost:8080/"
         },
         "id": "bx6zD0pST-e9",
-        "outputId": "2c2b5de9-aaf1-417f-9bc5-47de7d9b8440"
+        "outputId": "13505b36-bc86-4a4e-a563-218ae2464b25"
       },
+      "outputs": [
+        {
+          "name": "stdout",
+          "output_type": "stream",
+          "text": [
+            "[[False False False]\n",
+            " [ True  True  True]\n",
+            " [ True  True  True]\n",
+            " [ True  True  True]]\n",
+            "\n"
+          ]
+        }
+      ],
       "source": [
         "a = np.array([\n",
         "    [ 0,  0,  0],\n",
@@ -2343,31 +2362,35 @@
         "])\n",
         "\n",
         "pa(a>b)"
-      ],
-      "execution_count": null,
-      "outputs": [
-        {
-          "output_type": "stream",
-          "text": [
-            "[[False False False]\n",
-            " [ True  True  True]\n",
-            " [ True  True  True]\n",
-            " [ True  True  True]]\n",
-            "\n"
-          ],
-          "name": "stdout"
-        }
       ]
     },
     {
       "cell_type": "code",
+      "execution_count": 55,
       "metadata": {
         "colab": {
           "base_uri": "https://localhost:8080/"
         },
         "id": "-tRH_rl3T-bU",
-        "outputId": "675f5c64-63c4-43a9-c6d2-48ba950fffd1"
+        "outputId": "a8ef21cf-d342-4b60-8485-6f886f9b231b"
       },
+      "outputs": [
+        {
+          "name": "stdout",
+          "output_type": "stream",
+          "text": [
+            "np.maximum(a,b)\n",
+            "[[ 1  2  3]\n",
+            " [10 10 10]\n",
+            " [20 20 20]\n",
+            " [30 30 30]]\n",
+            "\n",
+            "np.max(a)\n",
+            "30\n",
+            "\n"
+          ]
+        }
+      ],
       "source": [
         "a = np.array([\n",
         "    [ 0,  0,  0],\n",
@@ -2382,27 +2405,9 @@
         "    [ 10, 12, 12]    \n",
         "])\n",
         "\n",
-        "pa(np.maximum(a,b), \"np.maxiumn(a,b)\")\n",
+        "pa(np.maximum(a,b), \"np.maximum(a,b)\")\n",
         "\n",
         "pa(np.max(a), \"np.max(a)\")"
-      ],
-      "execution_count": null,
-      "outputs": [
-        {
-          "output_type": "stream",
-          "text": [
-            "np.maxiumn(a,b)\n",
-            "[[ 1  2  3]\n",
-            " [10 10 10]\n",
-            " [20 20 20]\n",
-            " [30 30 30]]\n",
-            "\n",
-            "np.max(a)\n",
-            "30\n",
-            "\n"
-          ],
-          "name": "stdout"
-        }
       ]
     },
     {
@@ -2416,30 +2421,17 @@
     },
     {
       "cell_type": "code",
+      "execution_count": 56,
       "metadata": {
         "colab": {
           "base_uri": "https://localhost:8080/"
         },
         "id": "wcXGbYV9T-X8",
-        "outputId": "32cf4900-9aa4-47ea-dd3e-4169ca97ed7a"
+        "outputId": "6d552ac5-0a89-4028-fd94-a514e7985cc9"
       },
-      "source": [
-        "a = np.arange(6).reshape(2,3)\n",
-        "b = np.arange(12).reshape(3,4)\n",
-        "\n",
-        "print(a.shape)\n",
-        "pa(a)\n",
-        "\n",
-        "print(b.shape)\n",
-        "pa(b)\n",
-        "\n",
-        "print(np.matmul(a,b).shape)\n",
-        "pa(np.matmul(a,b), \"np.matmul(a,b)\")\n",
-        "pa(np.dot(a,b))"
-      ],
-      "execution_count": null,
       "outputs": [
         {
+          "name": "stdout",
           "output_type": "stream",
           "text": [
             "(2, 3)\n",
@@ -2459,9 +2451,22 @@
             "[[20 23 26 29]\n",
             " [56 68 80 92]]\n",
             "\n"
-          ],
-          "name": "stdout"
+          ]
         }
+      ],
+      "source": [
+        "a = np.arange(6).reshape(2,3)\n",
+        "b = np.arange(12).reshape(3,4)\n",
+        "\n",
+        "print(a.shape)\n",
+        "pa(a)\n",
+        "\n",
+        "print(b.shape)\n",
+        "pa(b)\n",
+        "\n",
+        "print(np.matmul(a,b).shape)\n",
+        "pa(np.matmul(a,b), \"np.matmul(a,b)\")\n",
+        "pa(np.dot(a,b))"
       ]
     },
     {
@@ -2472,19 +2477,33 @@
       "source": [
         "# 브로드캐스팅\n",
         "\n",
-        "![대체 텍스트](https://github.com/dhrim/cau_2022_summer/raw/main/material/library/images/broadcasting.png)\n",
+        "![대체 텍스트](https://raw.githubusercontent.com/dhrim/cau_2022_summer/master/material/library/images/broadcasting.png)\n",
         "image from http://taewan.kim/post/numpy_cheat_sheet/"
       ]
     },
     {
       "cell_type": "code",
+      "execution_count": 57,
       "metadata": {
         "colab": {
           "base_uri": "https://localhost:8080/"
         },
         "id": "ZpwxnqJsT-pJ",
-        "outputId": "f89af11d-37dc-4cdc-cc6e-ecfcea5af6e8"
+        "outputId": "88ef4e4a-72b9-498a-cd73-e5ea0a31dc4e"
       },
+      "outputs": [
+        {
+          "name": "stdout",
+          "output_type": "stream",
+          "text": [
+            "[[ 0  1  2]\n",
+            " [10 11 12]\n",
+            " [20 21 22]\n",
+            " [30 31 32]]\n",
+            "\n"
+          ]
+        }
+      ],
       "source": [
         "a = np.array([\n",
         "    [ 0,  0,  0],\n",
@@ -2497,31 +2516,31 @@
         "])\n",
         "\n",
         "pa(a+b)"
-      ],
-      "execution_count": null,
-      "outputs": [
-        {
-          "output_type": "stream",
-          "text": [
-            "[[ 0  1  2]\n",
-            " [10 11 12]\n",
-            " [20 21 22]\n",
-            " [30 31 32]]\n",
-            "\n"
-          ],
-          "name": "stdout"
-        }
       ]
     },
     {
       "cell_type": "code",
+      "execution_count": 58,
       "metadata": {
         "colab": {
           "base_uri": "https://localhost:8080/"
         },
         "id": "kal-zjxPT-UT",
-        "outputId": "8d8176ed-6b2b-4ddb-f8f3-a7086e71520d"
+        "outputId": "b51cb283-9e52-4f4f-9c26-fb555b58b873"
       },
+      "outputs": [
+        {
+          "name": "stdout",
+          "output_type": "stream",
+          "text": [
+            "[[ 1  1  1]\n",
+            " [12 12 12]\n",
+            " [23 23 23]\n",
+            " [34 34 34]]\n",
+            "\n"
+          ]
+        }
+      ],
       "source": [
         "a = np.array([\n",
         "    [ 0,  0,  0],\n",
@@ -2537,20 +2556,6 @@
         "])\n",
         "\n",
         "pa(a+b)"
-      ],
-      "execution_count": null,
-      "outputs": [
-        {
-          "output_type": "stream",
-          "text": [
-            "[[ 1  1  1]\n",
-            " [12 12 12]\n",
-            " [23 23 23]\n",
-            " [34 34 34]]\n",
-            "\n"
-          ],
-          "name": "stdout"
-        }
       ]
     },
     {
@@ -2566,22 +2571,17 @@
     },
     {
       "cell_type": "code",
+      "execution_count": 59,
       "metadata": {
         "colab": {
           "base_uri": "https://localhost:8080/"
         },
         "id": "uerSzhv2T-PV",
-        "outputId": "9d591d67-7559-4a4a-ec68-70db9808c016"
+        "outputId": "2be8440f-a64f-4537-b8e1-07064a39afee"
       },
-      "source": [
-        "a = np.arange(12).reshape(3,4)\n",
-        "pa(a)\n",
-        "\n",
-        "pa(a%2==0, \"a%2==0\")"
-      ],
-      "execution_count": null,
       "outputs": [
         {
+          "name": "stdout",
           "output_type": "stream",
           "text": [
             "[[ 0  1  2  3]\n",
@@ -2593,9 +2593,14 @@
             " [ True False  True False]\n",
             " [ True False  True False]]\n",
             "\n"
-          ],
-          "name": "stdout"
+          ]
         }
+      ],
+      "source": [
+        "a = np.arange(12).reshape(3,4)\n",
+        "pa(a)\n",
+        "\n",
+        "pa(a%2==0, \"a%2==0\")"
       ]
     },
     {
@@ -2614,28 +2619,17 @@
     },
     {
       "cell_type": "code",
+      "execution_count": 60,
       "metadata": {
         "colab": {
           "base_uri": "https://localhost:8080/"
         },
         "id": "-kYgcvr2eL6C",
-        "outputId": "d4af1dc3-7ab9-4fa4-bf8e-5a899f567211"
+        "outputId": "721436a5-c009-4824-d71c-633a89bf5ac0"
       },
-      "source": [
-        "a = np.arange(12).reshape(3,4)\n",
-        "pa(a)\n",
-        "\n",
-        "mask = a%2==0\n",
-        "pa(mask, \"mask\")\n",
-        "\n",
-        "pa(a*mask, \"a*mask\")\n",
-        "\n",
-        "print(np.sum(a*mask))\n",
-        "\n"
-      ],
-      "execution_count": null,
       "outputs": [
         {
+          "name": "stdout",
           "output_type": "stream",
           "text": [
             "[[ 0  1  2  3]\n",
@@ -2653,9 +2647,20 @@
             " [ 8  0 10  0]]\n",
             "\n",
             "30\n"
-          ],
-          "name": "stdout"
+          ]
         }
+      ],
+      "source": [
+        "a = np.arange(12).reshape(3,4)\n",
+        "pa(a)\n",
+        "\n",
+        "mask = a%2==0\n",
+        "pa(mask, \"mask\")\n",
+        "\n",
+        "pa(a*mask, \"a*mask\")\n",
+        "\n",
+        "print(np.sum(a*mask))\n",
+        "\n"
       ]
     },
     {
@@ -2674,28 +2679,17 @@
     },
     {
       "cell_type": "code",
+      "execution_count": 61,
       "metadata": {
         "colab": {
           "base_uri": "https://localhost:8080/"
         },
         "id": "4GQpwbMCiaYD",
-        "outputId": "740cba3c-f30b-4fdd-f1fd-90163884ff10"
+        "outputId": "558e22f6-1ae1-48e0-d3be-0677d747eb43"
       },
-      "source": [
-        "a = np.arange(12).reshape(3,4)\n",
-        "pa(a)\n",
-        "\n",
-        "mask = (a%2==0) & (a>5)\n",
-        "pa(mask, \"mask\")\n",
-        "\n",
-        "pa(a*mask, \"a*mask\")\n",
-        "\n",
-        "print(np.sum(a*mask))\n",
-        "\n"
-      ],
-      "execution_count": null,
       "outputs": [
         {
+          "name": "stdout",
           "output_type": "stream",
           "text": [
             "[[ 0  1  2  3]\n",
@@ -2713,9 +2707,20 @@
             " [ 8  0 10  0]]\n",
             "\n",
             "24\n"
-          ],
-          "name": "stdout"
+          ]
         }
+      ],
+      "source": [
+        "a = np.arange(12).reshape(3,4)\n",
+        "pa(a)\n",
+        "\n",
+        "mask = (a%2==0) & (a>5)\n",
+        "pa(mask, \"mask\")\n",
+        "\n",
+        "pa(a*mask, \"a*mask\")\n",
+        "\n",
+        "print(np.sum(a*mask))\n",
+        "\n"
       ]
     },
     {
@@ -2736,28 +2741,17 @@
     },
     {
       "cell_type": "code",
+      "execution_count": 62,
       "metadata": {
         "colab": {
           "base_uri": "https://localhost:8080/"
         },
         "id": "TQRVBeBbjLcj",
-        "outputId": "538456ed-6319-4bf9-e91d-2e3e3136f346"
+        "outputId": "55e5c11f-22b0-4695-ded2-79e84147c866"
       },
-      "source": [
-        "a = np.arange(25).reshape(5,5)\n",
-        "pa(a)\n",
-        "\n",
-        "mask = np.eye(5)\n",
-        "pa(mask, \"mask\")\n",
-        "\n",
-        "pa(a*mask, \"a*mask\")\n",
-        "\n",
-        "print(np.mean(a*mask))\n",
-        "\n"
-      ],
-      "execution_count": null,
       "outputs": [
         {
+          "name": "stdout",
           "output_type": "stream",
           "text": [
             "[[ 0  1  2  3  4]\n",
@@ -2781,9 +2775,20 @@
             " [ 0.  0.  0.  0. 24.]]\n",
             "\n",
             "2.4\n"
-          ],
-          "name": "stdout"
+          ]
         }
+      ],
+      "source": [
+        "a = np.arange(25).reshape(5,5)\n",
+        "pa(a)\n",
+        "\n",
+        "mask = np.eye(5)\n",
+        "pa(mask, \"mask\")\n",
+        "\n",
+        "pa(a*mask, \"a*mask\")\n",
+        "\n",
+        "print(np.mean(a*mask))\n",
+        "\n"
       ]
     },
     {
@@ -2802,13 +2807,26 @@
     },
     {
       "cell_type": "code",
+      "execution_count": 63,
       "metadata": {
         "colab": {
           "base_uri": "https://localhost:8080/"
         },
         "id": "oq4Ako5ySGvr",
-        "outputId": "6563e595-8194-493f-9b7b-a77938bde0c7"
+        "outputId": "f115c611-dab1-48e3-d61c-53ea488ca39f"
       },
+      "outputs": [
+        {
+          "name": "stdout",
+          "output_type": "stream",
+          "text": [
+            "[0, 1, 2, 3, 4]\n",
+            "[0, 1, 2, 3, 4, 9]\n",
+            "[0, 9, 1, 2, 3, 4, 9]\n",
+            "[0, 9, 2, 3, 4, 9]\n"
+          ]
+        }
+      ],
       "source": [
         "l = [0,1,2,3,4]\n",
         "print(l)\n",
@@ -2821,19 +2839,6 @@
         "\n",
         "l.pop(2)\n",
         "print(l)"
-      ],
-      "execution_count": null,
-      "outputs": [
-        {
-          "output_type": "stream",
-          "text": [
-            "[0, 1, 2, 3, 4]\n",
-            "[0, 1, 2, 3, 4, 9]\n",
-            "[0, 9, 1, 2, 3, 4, 9]\n",
-            "[0, 9, 2, 3, 4, 9]\n"
-          ],
-          "name": "stdout"
-        }
       ]
     },
     {
@@ -2847,23 +2852,17 @@
     },
     {
       "cell_type": "code",
+      "execution_count": 64,
       "metadata": {
         "colab": {
           "base_uri": "https://localhost:8080/"
         },
         "id": "oDIm46xzggrw",
-        "outputId": "4c6072ba-bc7a-432b-f194-320701634b4b"
+        "outputId": "6bcc5190-3498-4165-d532-1e8958d399a1"
       },
-      "source": [
-        "a = np.arange(12).reshape(3,4)\n",
-        "pa(a, \"a\")\n",
-        "\n",
-        "b = np.append(a, [[-1,-2,-3,-4]], axis=0)\n",
-        "pa(b, \"b\")\n"
-      ],
-      "execution_count": null,
       "outputs": [
         {
+          "name": "stdout",
           "output_type": "stream",
           "text": [
             "a\n",
@@ -2877,9 +2876,15 @@
             " [ 8  9 10 11]\n",
             " [-1 -2 -3 -4]]\n",
             "\n"
-          ],
-          "name": "stdout"
+          ]
         }
+      ],
+      "source": [
+        "a = np.arange(12).reshape(3,4)\n",
+        "pa(a, \"a\")\n",
+        "\n",
+        "b = np.append(a, [[-1,-2,-3,-4]], axis=0)\n",
+        "pa(b, \"b\")\n"
       ]
     },
     {
@@ -2893,23 +2898,17 @@
     },
     {
       "cell_type": "code",
+      "execution_count": 65,
       "metadata": {
         "colab": {
           "base_uri": "https://localhost:8080/"
         },
         "id": "csRM_DH8P5PU",
-        "outputId": "51a17788-ce42-4386-b7f3-f4b9623dccd8"
+        "outputId": "e839de7d-13ba-4fa6-f381-a9916c4bb1e1"
       },
-      "source": [
-        "a = np.arange(12).reshape(3,4)\n",
-        "pa(a, \"a\")\n",
-        "\n",
-        "b = np.insert(a, 1, [[-1,-2,-3,-4]], axis=0)\n",
-        "pa(b, \"b\")\n"
-      ],
-      "execution_count": null,
       "outputs": [
         {
+          "name": "stdout",
           "output_type": "stream",
           "text": [
             "a\n",
@@ -2923,9 +2922,15 @@
             " [ 4  5  6  7]\n",
             " [ 8  9 10 11]]\n",
             "\n"
-          ],
-          "name": "stdout"
+          ]
         }
+      ],
+      "source": [
+        "a = np.arange(12).reshape(3,4)\n",
+        "pa(a, \"a\")\n",
+        "\n",
+        "b = np.insert(a, 1, [[-1,-2,-3,-4]], axis=0)\n",
+        "pa(b, \"b\")\n"
       ]
     },
     {
@@ -2939,23 +2944,17 @@
     },
     {
       "cell_type": "code",
+      "execution_count": 66,
       "metadata": {
         "colab": {
           "base_uri": "https://localhost:8080/"
         },
         "id": "mC8TQP3WSePp",
-        "outputId": "f6587534-b191-4cb6-d043-848655a549aa"
+        "outputId": "0b5c5789-1011-4f67-96ce-ce1e51539a5e"
       },
-      "source": [
-        "a = np.arange(12).reshape(3,4)\n",
-        "pa(a, \"a\")\n",
-        "\n",
-        "b = np.delete(a, 1, axis=0)\n",
-        "pa(b, \"b\")\n"
-      ],
-      "execution_count": null,
       "outputs": [
         {
+          "name": "stdout",
           "output_type": "stream",
           "text": [
             "a\n",
@@ -2967,9 +2966,15 @@
             "[[ 0  1  2  3]\n",
             " [ 8  9 10 11]]\n",
             "\n"
-          ],
-          "name": "stdout"
+          ]
         }
+      ],
+      "source": [
+        "a = np.arange(12).reshape(3,4)\n",
+        "pa(a, \"a\")\n",
+        "\n",
+        "b = np.delete(a, 1, axis=0)\n",
+        "pa(b, \"b\")\n"
       ]
     },
     {
@@ -2983,23 +2988,17 @@
     },
     {
       "cell_type": "code",
+      "execution_count": 67,
       "metadata": {
         "colab": {
           "base_uri": "https://localhost:8080/"
         },
         "id": "Zj9lrI5kSeLy",
-        "outputId": "312c4778-4aff-4227-c55c-28c4f1b83ef2"
+        "outputId": "2773b369-a3a1-428a-9ead-44bba986008d"
       },
-      "source": [
-        "a = np.arange(12).reshape(3,4)\n",
-        "pa(a, \"a\")\n",
-        "\n",
-        "b = np.delete(a, 1, axis=1)\n",
-        "pa(b, \"b\")\n"
-      ],
-      "execution_count": null,
       "outputs": [
         {
+          "name": "stdout",
           "output_type": "stream",
           "text": [
             "a\n",
@@ -3012,54 +3011,52 @@
             " [ 4  6  7]\n",
             " [ 8 10 11]]\n",
             "\n"
-          ],
-          "name": "stdout"
+          ]
         }
+      ],
+      "source": [
+        "a = np.arange(12).reshape(3,4)\n",
+        "pa(a, \"a\")\n",
+        "\n",
+        "b = np.delete(a, 1, axis=1)\n",
+        "pa(b, \"b\")\n"
       ]
     },
     {
       "cell_type": "code",
+      "execution_count": 67,
       "metadata": {
         "id": "kNBBtAzHjx2R"
       },
-      "source": [
-        ""
-      ],
-      "execution_count": null,
-      "outputs": []
+      "outputs": [],
+      "source": []
     },
     {
       "cell_type": "code",
+      "execution_count": 67,
       "metadata": {
         "id": "FNTVZ-Kdjxzp"
       },
-      "source": [
-        ""
-      ],
-      "execution_count": null,
-      "outputs": []
+      "outputs": [],
+      "source": []
     },
     {
       "cell_type": "code",
+      "execution_count": 67,
       "metadata": {
         "id": "4ULBhPgvjxxA"
       },
-      "source": [
-        ""
-      ],
-      "execution_count": null,
-      "outputs": []
+      "outputs": [],
+      "source": []
     },
     {
       "cell_type": "code",
+      "execution_count": 67,
       "metadata": {
         "id": "fPW2o5abjxtV"
       },
-      "source": [
-        ""
-      ],
-      "execution_count": null,
-      "outputs": []
+      "outputs": [],
+      "source": []
     },
     {
       "cell_type": "markdown",
@@ -3072,23 +3069,17 @@
     },
     {
       "cell_type": "code",
+      "execution_count": 68,
       "metadata": {
         "colab": {
           "base_uri": "https://localhost:8080/"
         },
         "id": "HJajFDsyj99U",
-        "outputId": "97eee594-a096-4f1e-cccb-4d7b8734ad2a"
+        "outputId": "c2c71d3b-b473-4e1a-db5a-3c91083a2c21"
       },
-      "source": [
-        "a = np.arange(12).reshape(3,4)\n",
-        "\n",
-        "paf(a)\n",
-        "\n",
-        "paf(a.reshape(3,4,1))"
-      ],
-      "execution_count": null,
       "outputs": [
         {
+          "name": "stdout",
           "output_type": "stream",
           "text": [
             "shape=(3, 4), dimension=2, dtype=int64\n",
@@ -3112,26 +3103,30 @@
             "  [10]\n",
             "  [11]]]\n",
             "\n"
-          ],
-          "name": "stdout"
+          ]
         }
+      ],
+      "source": [
+        "a = np.arange(12).reshape(3,4)\n",
+        "\n",
+        "paf(a)\n",
+        "\n",
+        "paf(a.reshape(3,4,1))"
       ]
     },
     {
       "cell_type": "code",
+      "execution_count": 69,
       "metadata": {
         "colab": {
           "base_uri": "https://localhost:8080/"
         },
         "id": "1z6155jLlQ9i",
-        "outputId": "adea29ec-dbf5-4944-a1f8-7645ebce9d69"
+        "outputId": "8a222b6c-124b-4b20-c0e1-af7b8bbafb53"
       },
-      "source": [
-        "print(a.reshape(3,1,4))"
-      ],
-      "execution_count": null,
       "outputs": [
         {
+          "name": "stdout",
           "output_type": "stream",
           "text": [
             "[[[ 0  1  2  3]]\n",
@@ -3139,34 +3134,36 @@
             " [[ 4  5  6  7]]\n",
             "\n",
             " [[ 8  9 10 11]]]\n"
-          ],
-          "name": "stdout"
+          ]
         }
+      ],
+      "source": [
+        "print(a.reshape(3,1,4))"
       ]
     },
     {
       "cell_type": "code",
+      "execution_count": 70,
       "metadata": {
         "colab": {
           "base_uri": "https://localhost:8080/"
         },
         "id": "O-ZhKoWflSkh",
-        "outputId": "3fedfcf7-6b20-44db-b574-24eaaff05970"
+        "outputId": "ad120059-cfcd-4448-8f7e-505474292f98"
       },
-      "source": [
-        "print(a.reshape(1,3,4))"
-      ],
-      "execution_count": null,
       "outputs": [
         {
+          "name": "stdout",
           "output_type": "stream",
           "text": [
             "[[[ 0  1  2  3]\n",
             "  [ 4  5  6  7]\n",
             "  [ 8  9 10 11]]]\n"
-          ],
-          "name": "stdout"
+          ]
         }
+      ],
+      "source": [
+        "print(a.reshape(1,3,4))"
       ]
     },
     {
@@ -3180,23 +3177,17 @@
     },
     {
       "cell_type": "code",
+      "execution_count": 71,
       "metadata": {
         "colab": {
           "base_uri": "https://localhost:8080/"
         },
         "id": "Bn1CAkY0lU8S",
-        "outputId": "0d52bb72-4797-4b03-b3da-2ce8353bd9a0"
+        "outputId": "f16803f6-4522-434c-e32d-5cf726f6af4b"
       },
-      "source": [
-        "a = np.arange(12).reshape(3,4)\n",
-        "pa(a)\n",
-        "\n",
-        "b = np.expand_dims(a, axis=0)\n",
-        "print(b.shape)\n"
-      ],
-      "execution_count": null,
       "outputs": [
         {
+          "name": "stdout",
           "output_type": "stream",
           "text": [
             "[[ 0  1  2  3]\n",
@@ -3204,30 +3195,30 @@
             " [ 8  9 10 11]]\n",
             "\n",
             "(1, 3, 4)\n"
-          ],
-          "name": "stdout"
+          ]
         }
+      ],
+      "source": [
+        "a = np.arange(12).reshape(3,4)\n",
+        "pa(a)\n",
+        "\n",
+        "b = np.expand_dims(a, axis=0)\n",
+        "print(b.shape)\n"
       ]
     },
     {
       "cell_type": "code",
+      "execution_count": 72,
       "metadata": {
         "colab": {
           "base_uri": "https://localhost:8080/"
         },
         "id": "P7emJVqplcAY",
-        "outputId": "ef110b9d-c5cf-465c-d71a-e692d2325ceb"
+        "outputId": "f49311e8-3e97-4818-d5ae-e26d5b7bf1a3"
       },
-      "source": [
-        "a = np.arange(12).reshape(3,4)\n",
-        "pa(a)\n",
-        "\n",
-        "b = np.expand_dims(a, axis=1)\n",
-        "print(b.shape)\n"
-      ],
-      "execution_count": null,
       "outputs": [
         {
+          "name": "stdout",
           "output_type": "stream",
           "text": [
             "[[ 0  1  2  3]\n",
@@ -3235,30 +3226,61 @@
             " [ 8  9 10 11]]\n",
             "\n",
             "(3, 1, 4)\n"
-          ],
-          "name": "stdout"
+          ]
         }
+      ],
+      "source": [
+        "a = np.arange(12).reshape(3,4)\n",
+        "pa(a)\n",
+        "\n",
+        "b = np.expand_dims(a, axis=1)\n",
+        "print(b.shape)\n"
       ]
     },
     {
       "cell_type": "code",
+      "execution_count": 73,
       "metadata": {
         "colab": {
           "base_uri": "https://localhost:8080/"
         },
         "id": "1jGp51u1lhGp",
-        "outputId": "cc3e6a8c-2ec8-4f71-e0a3-b56c9de341a5"
+        "outputId": "586f5fc9-ed09-497b-9f9a-5d57138ceec2"
       },
+      "outputs": [
+        {
+          "name": "stdout",
+          "output_type": "stream",
+          "text": [
+            "[[ 0  1  2  3]\n",
+            " [ 4  5  6  7]\n",
+            " [ 8  9 10 11]]\n",
+            "\n",
+            "(3, 4, 1)\n"
+          ]
+        }
+      ],
       "source": [
         "a = np.arange(12).reshape(3,4)\n",
         "pa(a)\n",
         "\n",
         "b = np.expand_dims(a, axis=2)\n",
         "print(b.shape)\n"
-      ],
-      "execution_count": null,
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 74,
+      "metadata": {
+        "colab": {
+          "base_uri": "https://localhost:8080/"
+        },
+        "id": "ErV2TGXCli_G",
+        "outputId": "b450e957-fe84-4a21-a940-23a490cbc0c7"
+      },
       "outputs": [
         {
+          "name": "stdout",
           "output_type": "stream",
           "text": [
             "[[ 0  1  2  3]\n",
@@ -3266,40 +3288,15 @@
             " [ 8  9 10 11]]\n",
             "\n",
             "(3, 4, 1)\n"
-          ],
-          "name": "stdout"
+          ]
         }
-      ]
-    },
-    {
-      "cell_type": "code",
-      "metadata": {
-        "colab": {
-          "base_uri": "https://localhost:8080/"
-        },
-        "id": "ErV2TGXCli_G",
-        "outputId": "89fc2c1b-f2ce-4ff7-a97a-6412123b3616"
-      },
+      ],
       "source": [
         "a = np.arange(12).reshape(3,4)\n",
         "pa(a)\n",
         "\n",
         "b = np.expand_dims(a, axis=-1)\n",
         "print(b.shape)\n"
-      ],
-      "execution_count": null,
-      "outputs": [
-        {
-          "output_type": "stream",
-          "text": [
-            "[[ 0  1  2  3]\n",
-            " [ 4  5  6  7]\n",
-            " [ 8  9 10 11]]\n",
-            "\n",
-            "(3, 4, 1)\n"
-          ],
-          "name": "stdout"
-        }
       ]
     },
     {
@@ -3313,83 +3310,83 @@
     },
     {
       "cell_type": "code",
+      "execution_count": 75,
       "metadata": {
         "colab": {
           "base_uri": "https://localhost:8080/"
         },
         "id": "EjDq6YA9l0KM",
-        "outputId": "4165ca93-d05c-4ddb-d831-29f606dae812"
+        "outputId": "1e71cdb9-913b-4181-f7a7-a45f440701a2"
       },
+      "outputs": [
+        {
+          "name": "stdout",
+          "output_type": "stream",
+          "text": [
+            "(3, 4, 1)\n",
+            "(3, 4)\n"
+          ]
+        }
+      ],
       "source": [
         "a = np.arange(12).reshape(3,4,1)\n",
         "print(a.shape)\n",
         "\n",
         "print(a.reshape(3,4).shape)\n"
-      ],
-      "execution_count": null,
-      "outputs": [
-        {
-          "output_type": "stream",
-          "text": [
-            "(3, 4, 1)\n",
-            "(3, 4)\n"
-          ],
-          "name": "stdout"
-        }
       ]
     },
     {
       "cell_type": "code",
+      "execution_count": 76,
       "metadata": {
         "colab": {
           "base_uri": "https://localhost:8080/"
         },
         "id": "PLmpGImmlwC1",
-        "outputId": "9986f4a4-85a4-44ae-e182-7bcd22207c65"
+        "outputId": "6735930f-2386-429d-ded0-67ab931c2eec"
       },
+      "outputs": [
+        {
+          "name": "stdout",
+          "output_type": "stream",
+          "text": [
+            "(3, 4, 1)\n",
+            "(3, 4)\n"
+          ]
+        }
+      ],
       "source": [
         "a = np.arange(12).reshape(3,4,1)\n",
         "print(a.shape)\n",
         "\n",
         "print(np.squeeze(a).shape)\n"
-      ],
-      "execution_count": null,
-      "outputs": [
-        {
-          "output_type": "stream",
-          "text": [
-            "(3, 4, 1)\n",
-            "(3, 4)\n"
-          ],
-          "name": "stdout"
-        }
       ]
     },
     {
       "cell_type": "code",
+      "execution_count": 77,
       "metadata": {
         "colab": {
           "base_uri": "https://localhost:8080/"
         },
         "id": "e2Odx4pxl8nj",
-        "outputId": "88e5262f-c19f-4c07-bad8-4352493ebff4"
+        "outputId": "727bd00c-afb9-4f0f-fb2d-a4da4f7ce456"
       },
+      "outputs": [
+        {
+          "name": "stdout",
+          "output_type": "stream",
+          "text": [
+            "(3, 1, 4)\n",
+            "(3, 4)\n"
+          ]
+        }
+      ],
       "source": [
         "a = np.arange(12).reshape(3,1,4)\n",
         "print(a.shape)\n",
         "\n",
         "print(np.squeeze(a).shape)\n"
-      ],
-      "execution_count": null,
-      "outputs": [
-        {
-          "output_type": "stream",
-          "text": [
-            "(3, 1, 4)\n",
-            "(3, 4)\n"
-          ],
-          "name": "stdout"
-        }
       ]
     },
     {
@@ -3403,22 +3400,17 @@
     },
     {
       "cell_type": "code",
+      "execution_count": 78,
       "metadata": {
         "colab": {
           "base_uri": "https://localhost:8080/"
         },
         "id": "1VXfrChHmFNS",
-        "outputId": "c8b30aa1-7b02-4375-cef7-e3cd53dc8da7"
+        "outputId": "8f0dd394-fc75-4f1a-9287-7782c22fe0a0"
       },
-      "source": [
-        "a = np.arange(12).reshape(3,4)\n",
-        "pa(a, \"a\")\n",
-        "\n",
-        "pa(a.T, \"a.T\")"
-      ],
-      "execution_count": null,
       "outputs": [
         {
+          "name": "stdout",
           "output_type": "stream",
           "text": [
             "a\n",
@@ -3432,9 +3424,14 @@
             " [ 2  6 10]\n",
             " [ 3  7 11]]\n",
             "\n"
-          ],
-          "name": "stdout"
+          ]
         }
+      ],
+      "source": [
+        "a = np.arange(12).reshape(3,4)\n",
+        "pa(a, \"a\")\n",
+        "\n",
+        "pa(a.T, \"a.T\")"
       ]
     },
     {
@@ -3461,22 +3458,17 @@
     },
     {
       "cell_type": "code",
+      "execution_count": 79,
       "metadata": {
         "colab": {
           "base_uri": "https://localhost:8080/"
         },
         "id": "qE_CPN9Bmnq7",
-        "outputId": "2b5b8bf3-f1ac-441f-a480-18219738eb6a"
+        "outputId": "d654ccde-aae2-461a-fb50-b51915256c0e"
       },
-      "source": [
-        "a = np.ones((3,4))\n",
-        "pa(a)\n",
-        "\n",
-        "print(np.sum(a))"
-      ],
-      "execution_count": null,
       "outputs": [
         {
+          "name": "stdout",
           "output_type": "stream",
           "text": [
             "[[1. 1. 1. 1.]\n",
@@ -3484,31 +3476,29 @@
             " [1. 1. 1. 1.]]\n",
             "\n",
             "12.0\n"
-          ],
-          "name": "stdout"
+          ]
         }
+      ],
+      "source": [
+        "a = np.ones((3,4))\n",
+        "pa(a)\n",
+        "\n",
+        "print(np.sum(a))"
       ]
     },
     {
       "cell_type": "code",
+      "execution_count": 80,
       "metadata": {
         "colab": {
           "base_uri": "https://localhost:8080/"
         },
         "id": "r4td5iycmZJn",
-        "outputId": "595a7643-2d54-4710-c52a-3978eaaa5884"
+        "outputId": "27e80ba1-021e-4e2a-f4a3-aa7c5ed615fd"
       },
-      "source": [
-        "a = np.ones((3,4))\n",
-        "pa(a) # shape (3,4)\n",
-        "\n",
-        "paf(np.sum(a, axis=0)) # shape의 (3,4) 3을 없애고 싶다. 3은 index 0. 이 index를 axis 값으로\n",
-        "\n",
-        "paf(np.sum(a, axis=1)) # shape의 (3,4) 4을 없애고 싶다. 4는 index 1. 이 index를 axis 값으로\n"
-      ],
-      "execution_count": null,
       "outputs": [
         {
+          "name": "stdout",
           "output_type": "stream",
           "text": [
             "[[1. 1. 1. 1.]\n",
@@ -3521,33 +3511,31 @@
             "shape=(3,), dimension=1, dtype=float64\n",
             "[4. 4. 4.]\n",
             "\n"
-          ],
-          "name": "stdout"
+          ]
         }
+      ],
+      "source": [
+        "a = np.ones((3,4))\n",
+        "pa(a) # shape (3,4)\n",
+        "\n",
+        "paf(np.sum(a, axis=0)) # shape의 (3,4) 3을 없애고 싶다. 3은 index 0. 이 index를 axis 값으로\n",
+        "\n",
+        "paf(np.sum(a, axis=1)) # shape의 (3,4) 4을 없애고 싶다. 4는 index 1. 이 index를 axis 값으로\n"
       ]
     },
     {
       "cell_type": "code",
+      "execution_count": 81,
       "metadata": {
         "colab": {
           "base_uri": "https://localhost:8080/"
         },
         "id": "MVGTP5mKnXdS",
-        "outputId": "c350d445-7ca2-4e4d-b5ef-41a60b589d9c"
+        "outputId": "8d06af48-d3a0-4c20-8049-21e5c36be088"
       },
-      "source": [
-        "a = np.ones((3,4,2))\n",
-        "pa(a.shape) # shape (3,4,2)\n",
-        "\n",
-        "paf(np.sum(a, axis=0)) # 원 shape (3,4,2)에서 index 0 축이 제거되어 (  4,2)가 된다.\n",
-        "\n",
-        "paf(np.sum(a, axis=1)) # 원 shape (3,4,2)에서 index 1 축이 제거되어 (3  ,2)가 된다.\n",
-        "\n",
-        "paf(np.sum(a, axis=2)) # 원 shape (3,4,2)에서 index 2 축이 제거되어 (3,4  )가 된다."
-      ],
-      "execution_count": null,
       "outputs": [
         {
+          "name": "stdout",
           "output_type": "stream",
           "text": [
             "(3, 4, 2)\n",
@@ -3568,9 +3556,18 @@
             " [2. 2. 2. 2.]\n",
             " [2. 2. 2. 2.]]\n",
             "\n"
-          ],
-          "name": "stdout"
+          ]
         }
+      ],
+      "source": [
+        "a = np.ones((3,4,2))\n",
+        "pa(a.shape) # shape (3,4,2)\n",
+        "\n",
+        "paf(np.sum(a, axis=0)) # 원 shape (3,4,2)에서 index 0 축이 제거되어 (  4,2)가 된다.\n",
+        "\n",
+        "paf(np.sum(a, axis=1)) # 원 shape (3,4,2)에서 index 1 축이 제거되어 (3  ,2)가 된다.\n",
+        "\n",
+        "paf(np.sum(a, axis=2)) # 원 shape (3,4,2)에서 index 2 축이 제거되어 (3,4  )가 된다."
       ]
     },
     {
@@ -3586,26 +3583,17 @@
     },
     {
       "cell_type": "code",
+      "execution_count": 82,
       "metadata": {
         "colab": {
           "base_uri": "https://localhost:8080/"
         },
         "id": "QKJ6dVqZoRr9",
-        "outputId": "409bfbad-ac8b-4fd7-b7d4-c07de2e9d699"
+        "outputId": "83284b35-0a72-4c47-ca87-b7d04a058edc"
       },
-      "source": [
-        "a = np.arange(24).reshape(3,4,2)\n",
-        "pa(a.shape) # shape (3,4,2)\n",
-        "\n",
-        "paf(np.mean(a, axis=0)) # 원 shape (3,4,2)에서 index 0 축이 제거되어 (  4,2)가 된다.\n",
-        "\n",
-        "paf(np.mean(a, axis=1)) # 원 shape (3,4,2)에서 index 1 축이 제거되어 (3  ,2)가 된다.\n",
-        "\n",
-        "paf(np.mean(a, axis=2)) # 원 shape (3,4,2)에서 index 2 축이 제거되어 (3,4  )가 된다."
-      ],
-      "execution_count": null,
       "outputs": [
         {
+          "name": "stdout",
           "output_type": "stream",
           "text": [
             "(3, 4, 2)\n",
@@ -3626,9 +3614,18 @@
             " [ 8.5 10.5 12.5 14.5]\n",
             " [16.5 18.5 20.5 22.5]]\n",
             "\n"
-          ],
-          "name": "stdout"
+          ]
         }
+      ],
+      "source": [
+        "a = np.arange(24).reshape(3,4,2)\n",
+        "pa(a.shape) # shape (3,4,2)\n",
+        "\n",
+        "paf(np.mean(a, axis=0)) # 원 shape (3,4,2)에서 index 0 축이 제거되어 (  4,2)가 된다.\n",
+        "\n",
+        "paf(np.mean(a, axis=1)) # 원 shape (3,4,2)에서 index 1 축이 제거되어 (3  ,2)가 된다.\n",
+        "\n",
+        "paf(np.mean(a, axis=2)) # 원 shape (3,4,2)에서 index 2 축이 제거되어 (3,4  )가 된다."
       ]
     },
     {
@@ -3664,13 +3661,30 @@
     },
     {
       "cell_type": "code",
+      "execution_count": 83,
       "metadata": {
         "colab": {
           "base_uri": "https://localhost:8080/"
         },
         "id": "1inFe9xrpQGT",
-        "outputId": "a4184b65-ce44-4ce0-971e-a1765caf69b1"
+        "outputId": "fd59bc8e-b589-4478-9a3b-2c0391aa615c"
       },
+      "outputs": [
+        {
+          "name": "stdout",
+          "output_type": "stream",
+          "text": [
+            "org : [3, 5, 2, 5, 9]\n",
+            "sorted scores : [9, 5, 5, 3, 2]\n",
+            "[4, 1, 3, 0, 2]\n",
+            "hank\n",
+            "jerry\n",
+            "bob\n",
+            "tom\n",
+            "brute\n"
+          ]
+        }
+      ],
       "source": [
         "scores = [ 3, 5, 2, 5, 9 ]\n",
         "names = [ \"tom\", \"jerry\", \"brute\", \"bob\", \"hank\" ]\n",
@@ -3695,23 +3709,6 @@
         "\n",
         "for i in indexes:\n",
         "  print(names[i])\n"
-      ],
-      "execution_count": null,
-      "outputs": [
-        {
-          "output_type": "stream",
-          "text": [
-            "org : [3, 5, 2, 5, 9]\n",
-            "sorted scores : [9, 5, 5, 3, 2]\n",
-            "[4, 1, 3, 0, 2]\n",
-            "hank\n",
-            "jerry\n",
-            "bob\n",
-            "tom\n",
-            "brute\n"
-          ],
-          "name": "stdout"
-        }
       ]
     },
     {
@@ -3727,7 +3724,7 @@
         "\n",
         "소팅된 scores 9, 5, 5, 3, 2의 원 자리 index가 필요하다.\n",
         "```\n",
-        "sored_index : [4, 1, 3, 0, 2]\n",
+        "sorted_index : [4, 1, 3, 0, 2]\n",
         "```\n",
         "\n",
         "argsort()가 이러한 연산을 한다.\n"
@@ -3735,13 +3732,23 @@
     },
     {
       "cell_type": "code",
+      "execution_count": 84,
       "metadata": {
         "colab": {
           "base_uri": "https://localhost:8080/"
         },
         "id": "nn2Iqr1_qCwD",
-        "outputId": "daf6301a-2447-49f9-df80-d9d4f2e24514"
+        "outputId": "f3a4e8a4-cc08-4389-bfde-9883a41a6378"
       },
+      "outputs": [
+        {
+          "name": "stdout",
+          "output_type": "stream",
+          "text": [
+            "sorted_indexes= [4 3 1 0 2]\n"
+          ]
+        }
+      ],
       "source": [
         "scores = [ 3, 5, 2, 5, 9 ]\n",
         "names = [ \"tom\", \"jerry\", \"brute\", \"bob\", \"hank\" ]\n",
@@ -3750,16 +3757,6 @@
         "sorted_indexes = np.argsort(a)[::-1]\n",
         "\n",
         "print(\"sorted_indexes=\",sorted_indexes)"
-      ],
-      "execution_count": null,
-      "outputs": [
-        {
-          "output_type": "stream",
-          "text": [
-            "sorted_indexes= [4 3 1 0 2]\n"
-          ],
-          "name": "stdout"
-        }
       ]
     },
     {
@@ -3773,27 +3770,17 @@
     },
     {
       "cell_type": "code",
+      "execution_count": 85,
       "metadata": {
         "colab": {
           "base_uri": "https://localhost:8080/"
         },
         "id": "WvYSdrYcqlKv",
-        "outputId": "e8226bc2-6e48-45ab-bdd7-fcf15f5f7bae"
+        "outputId": "d06ce8b4-0433-4470-f91e-c07125d05d77"
       },
-      "source": [
-        "np.random.seed(seed=31)\n",
-        "a = np.random.randint(100, size=12).reshape(3,4)\n",
-        "pa(a, \"a\")\n",
-        "\n",
-        "max_index = np.argmax(a, axis=1)\n",
-        "pa(max_index, \"np.argmax(a, axis=1)\")\n",
-        "\n",
-        "max_index = np.argmax(a, axis=0)\n",
-        "pa(max_index, \"np.argmax(a, axis=0)\")\n"
-      ],
-      "execution_count": null,
       "outputs": [
         {
+          "name": "stdout",
           "output_type": "stream",
           "text": [
             "a\n",
@@ -3807,9 +3794,19 @@
             "np.argmax(a, axis=0)\n",
             "[2 0 2 0]\n",
             "\n"
-          ],
-          "name": "stdout"
+          ]
         }
+      ],
+      "source": [
+        "np.random.seed(seed=31)\n",
+        "a = np.random.randint(100, size=12).reshape(3,4)\n",
+        "pa(a, \"a\")\n",
+        "\n",
+        "max_index = np.argmax(a, axis=1)\n",
+        "pa(max_index, \"np.argmax(a, axis=1)\")\n",
+        "\n",
+        "max_index = np.argmax(a, axis=0)\n",
+        "pa(max_index, \"np.argmax(a, axis=0)\")\n"
       ]
     },
     {
@@ -3841,29 +3838,17 @@
     },
     {
       "cell_type": "code",
+      "execution_count": 86,
       "metadata": {
         "colab": {
           "base_uri": "https://localhost:8080/"
         },
         "id": "tqPoINi6SeHB",
-        "outputId": "7ff0329b-8148-4194-a529-bbfd25a0eeaa"
+        "outputId": "9a76fdb5-3627-43a3-a219-91d7e391a3a5"
       },
-      "source": [
-        "a = np.arange(6).reshape(2,3)\n",
-        "b = np.arange(6,12).reshape(2,3)\n",
-        "\n",
-        "pa(a, \"a\")\n",
-        "pa(b, \"b\")\n",
-        "\n",
-        "pa(np.r_[a,b], \"np.r_[a,b]\")\n",
-        "\n",
-        "pa(np.vstack([a,b]), \"np.vstack([a,b])\")\n",
-        "\n",
-        "pa(np.concatenate([a,b], axis=0), \"np.concatenate([a,b], axis=0)\")"
-      ],
-      "execution_count": null,
       "outputs": [
         {
+          "name": "stdout",
           "output_type": "stream",
           "text": [
             "a\n",
@@ -3892,9 +3877,21 @@
             " [ 6  7  8]\n",
             " [ 9 10 11]]\n",
             "\n"
-          ],
-          "name": "stdout"
+          ]
         }
+      ],
+      "source": [
+        "a = np.arange(6).reshape(2,3)\n",
+        "b = np.arange(6,12).reshape(2,3)\n",
+        "\n",
+        "pa(a, \"a\")\n",
+        "pa(b, \"b\")\n",
+        "\n",
+        "pa(np.r_[a,b], \"np.r_[a,b]\")\n",
+        "\n",
+        "pa(np.vstack([a,b]), \"np.vstack([a,b])\")\n",
+        "\n",
+        "pa(np.concatenate([a,b], axis=0), \"np.concatenate([a,b], axis=0)\")"
       ]
     },
     {
@@ -3908,29 +3905,17 @@
     },
     {
       "cell_type": "code",
+      "execution_count": 87,
       "metadata": {
         "colab": {
           "base_uri": "https://localhost:8080/"
         },
         "id": "Pw6D6jUoxks0",
-        "outputId": "02936952-9dd2-4b74-923d-a4a25a7312b7"
+        "outputId": "3245c8fe-96f2-44b1-e1cf-cea988d425c7"
       },
-      "source": [
-        "a = np.arange(6).reshape(3,2)\n",
-        "b = np.arange(6,12).reshape(3,2)\n",
-        "\n",
-        "pa(a, \"a\")\n",
-        "pa(b, \"b\")\n",
-        "\n",
-        "pa(np.c_[a,b], \"np.r_[a,b]\")\n",
-        "\n",
-        "pa(np.hstack([a,b]), \"np.hstack([a,b])\")\n",
-        "\n",
-        "pa(np.concatenate([a,b], axis=1), \"np.concatenate([a,b], axis=1)\")"
-      ],
-      "execution_count": null,
       "outputs": [
         {
+          "name": "stdout",
           "output_type": "stream",
           "text": [
             "a\n",
@@ -3958,9 +3943,21 @@
             " [ 2  3  8  9]\n",
             " [ 4  5 10 11]]\n",
             "\n"
-          ],
-          "name": "stdout"
+          ]
         }
+      ],
+      "source": [
+        "a = np.arange(6).reshape(3,2)\n",
+        "b = np.arange(6,12).reshape(3,2)\n",
+        "\n",
+        "pa(a, \"a\")\n",
+        "pa(b, \"b\")\n",
+        "\n",
+        "pa(np.c_[a,b], \"np.r_[a,b]\")\n",
+        "\n",
+        "pa(np.hstack([a,b]), \"np.hstack([a,b])\")\n",
+        "\n",
+        "pa(np.concatenate([a,b], axis=1), \"np.concatenate([a,b], axis=1)\")"
       ]
     },
     {
@@ -3974,22 +3971,17 @@
     },
     {
       "cell_type": "code",
+      "execution_count": 88,
       "metadata": {
         "colab": {
           "base_uri": "https://localhost:8080/"
         },
         "id": "_qnD0KmTzQq-",
-        "outputId": "8ca0ef01-04b1-4a16-b000-516977fe1506"
+        "outputId": "57d17ce6-7d59-4101-ced4-1d5846b8d903"
       },
-      "source": [
-        "a = np.arange(12).reshape(3,4)\n",
-        "paf(a)\n",
-        "\n",
-        "np.savetxt(\"data.csv\", a, delimiter=',')"
-      ],
-      "execution_count": null,
       "outputs": [
         {
+          "name": "stdout",
           "output_type": "stream",
           "text": [
             "shape=(3, 4), dimension=2, dtype=int64\n",
@@ -3997,59 +3989,61 @@
             " [ 4  5  6  7]\n",
             " [ 8  9 10 11]]\n",
             "\n"
-          ],
-          "name": "stdout"
+          ]
         }
+      ],
+      "source": [
+        "a = np.arange(12).reshape(3,4)\n",
+        "paf(a)\n",
+        "\n",
+        "np.savetxt(\"data.csv\", a, delimiter=',')"
       ]
     },
     {
       "cell_type": "code",
+      "execution_count": 89,
       "metadata": {
         "colab": {
           "base_uri": "https://localhost:8080/"
         },
         "id": "VO-KRs4yzaD4",
-        "outputId": "1cb56481-f7e2-4470-9d54-61b6602152b9"
+        "outputId": "ee31f3bd-5f11-4263-82c5-270410ad03e3"
       },
-      "source": [
-        "!ls -al \n",
-        "!cat data.csv"
-      ],
-      "execution_count": null,
       "outputs": [
         {
+          "name": "stdout",
           "output_type": "stream",
           "text": [
             "total 20\n",
-            "drwxr-xr-x 1 root root 4096 May 17 00:37 .\n",
-            "drwxr-xr-x 1 root root 4096 May 17 00:36 ..\n",
-            "drwxr-xr-x 4 root root 4096 May  6 13:43 .config\n",
-            "-rw-r--r-- 1 root root  300 May 17 00:37 data.csv\n",
-            "drwxr-xr-x 1 root root 4096 May  6 13:44 sample_data\n",
+            "drwxr-xr-x 1 root root 4096 Jul 13 08:55 .\n",
+            "drwxr-xr-x 1 root root 4096 Jul 13 08:54 ..\n",
+            "drwxr-xr-x 4 root root 4096 Jul  6 13:21 .config\n",
+            "-rw-r--r-- 1 root root  300 Jul 13 08:55 data.csv\n",
+            "drwxr-xr-x 1 root root 4096 Jul  6 13:22 sample_data\n",
             "0.000000000000000000e+00,1.000000000000000000e+00,2.000000000000000000e+00,3.000000000000000000e+00\n",
             "4.000000000000000000e+00,5.000000000000000000e+00,6.000000000000000000e+00,7.000000000000000000e+00\n",
             "8.000000000000000000e+00,9.000000000000000000e+00,1.000000000000000000e+01,1.100000000000000000e+01\n"
-          ],
-          "name": "stdout"
+          ]
         }
+      ],
+      "source": [
+        "!ls -al \n",
+        "!cat data.csv"
       ]
     },
     {
       "cell_type": "code",
+      "execution_count": 90,
       "metadata": {
         "colab": {
           "base_uri": "https://localhost:8080/"
         },
         "id": "QUnpKUygzZdd",
-        "outputId": "6e1d6c7e-bba0-4a1e-dfce-16bcb6b7d538"
+        "outputId": "d73b696f-3823-45dc-c567-5e23812c59c1"
       },
-      "source": [
-        "b = np.loadtxt(\"data.csv\", delimiter=',')\n",
-        "paf(b)"
-      ],
-      "execution_count": null,
       "outputs": [
         {
+          "name": "stdout",
           "output_type": "stream",
           "text": [
             "shape=(3, 4), dimension=2, dtype=float64\n",
@@ -4057,9 +4051,12 @@
             " [ 4.  5.  6.  7.]\n",
             " [ 8.  9. 10. 11.]]\n",
             "\n"
-          ],
-          "name": "stdout"
+          ]
         }
+      ],
+      "source": [
+        "b = np.loadtxt(\"data.csv\", delimiter=',')\n",
+        "paf(b)"
       ]
     },
     {
@@ -4082,38 +4079,17 @@
     },
     {
       "cell_type": "code",
+      "execution_count": 91,
       "metadata": {
         "colab": {
           "base_uri": "https://localhost:8080/"
         },
         "id": "Ecr6MMFcsjiW",
-        "outputId": "f138c228-7058-41ef-8b49-ba99ff6c43ae"
+        "outputId": "ce4da375-1bf4-4596-cc9e-1f3bac097bd9"
       },
-      "source": [
-        "a = np.array([\n",
-        "              [0,0,0],\n",
-        "              [1,1,1],\n",
-        "              [2,2,2],\n",
-        "              [3,3,3]\n",
-        "])\n",
-        "pa(a)\n",
-        "\n",
-        "pa(a[0], \"a[0]\")\n",
-        "\n",
-        "pa(a[[0]], \"a[[0]]]\")\n",
-        "\n",
-        "indexes = [0]\n",
-        "pa(a[indexes], \"indexes = [0]\")\n",
-        "\n",
-        "indexes = [0,1,2]\n",
-        "pa(a[indexes], \"indexes = [0,1,2]\")\n",
-        "\n",
-        "indexes = [0,0,1,1,2,2]\n",
-        "pa(a[indexes], \"indexes = [0,0,1,1,2,2]\")"
-      ],
-      "execution_count": null,
       "outputs": [
         {
+          "name": "stdout",
           "output_type": "stream",
           "text": [
             "[[0 0 0]\n",
@@ -4143,21 +4119,57 @@
             " [2 2 2]\n",
             " [2 2 2]]\n",
             "\n"
-          ],
-          "name": "stdout"
+          ]
         }
+      ],
+      "source": [
+        "a = np.array([\n",
+        "              [0,0,0],\n",
+        "              [1,1,1],\n",
+        "              [2,2,2],\n",
+        "              [3,3,3]\n",
+        "])\n",
+        "pa(a)\n",
+        "\n",
+        "pa(a[0], \"a[0]\")\n",
+        "\n",
+        "pa(a[[0]], \"a[[0]]]\")\n",
+        "\n",
+        "indexes = [0]\n",
+        "pa(a[indexes], \"indexes = [0]\")\n",
+        "\n",
+        "indexes = [0,1,2]\n",
+        "pa(a[indexes], \"indexes = [0,1,2]\")\n",
+        "\n",
+        "indexes = [0,0,1,1,2,2]\n",
+        "pa(a[indexes], \"indexes = [0,0,1,1,2,2]\")"
       ]
     },
     {
       "cell_type": "code",
+      "execution_count": 91,
       "metadata": {
         "id": "N7xub7qAtd2D"
       },
-      "source": [
-        ""
-      ],
-      "execution_count": null,
-      "outputs": []
+      "outputs": [],
+      "source": []
     }
-  ]
+  ],
+  "metadata": {
+    "colab": {
+      "collapsed_sections": [],
+      "name": "numpy_for_deep_learning",
+      "provenance": [],
+      "toc_visible": true
+    },
+    "kernelspec": {
+      "display_name": "Python 3",
+      "name": "python3"
+    },
+    "language_info": {
+      "name": "python"
+    }
+  },
+  "nbformat": 4,
+  "nbformat_minor": 0
 }

--- a/material/library/pandas_for_deep_learning.ipynb
+++ b/material/library/pandas_for_deep_learning.ipynb
@@ -1,18 +1,4 @@
 {
-  "nbformat": 4,
-  "nbformat_minor": 0,
-  "metadata": {
-    "colab": {
-      "name": "pandas_for_deep_learning.ipynb",
-      "provenance": [],
-      "collapsed_sections": [],
-      "toc_visible": true
-    },
-    "kernelspec": {
-      "name": "python3",
-      "display_name": "Python 3"
-    }
-  },
   "cells": [
     {
       "cell_type": "markdown",
@@ -25,68 +11,67 @@
     },
     {
       "cell_type": "code",
+      "execution_count": 1,
       "metadata": {
-        "id": "D6V3ksncYtk6",
         "colab": {
           "base_uri": "https://localhost:8080/"
         },
-        "outputId": "896d4004-674c-4750-b946-6f5cd6a8f576"
+        "id": "D6V3ksncYtk6",
+        "outputId": "54ff5fb8-4d68-455c-8f70-3b35ea6f171c"
       },
-      "source": [
-        "!pip install panda"
-      ],
-      "execution_count": 347,
       "outputs": [
         {
-          "output_type": "stream",
           "name": "stdout",
+          "output_type": "stream",
           "text": [
-            "Requirement already satisfied: panda in /usr/local/lib/python3.7/dist-packages (0.3.1)\n",
-            "Requirement already satisfied: requests in /usr/local/lib/python3.7/dist-packages (from panda) (2.23.0)\n",
-            "Requirement already satisfied: setuptools in /usr/local/lib/python3.7/dist-packages (from panda) (57.4.0)\n",
-            "Requirement already satisfied: idna<3,>=2.5 in /usr/local/lib/python3.7/dist-packages (from requests->panda) (2.10)\n",
-            "Requirement already satisfied: certifi>=2017.4.17 in /usr/local/lib/python3.7/dist-packages (from requests->panda) (2021.10.8)\n",
-            "Requirement already satisfied: urllib3!=1.25.0,!=1.25.1,<1.26,>=1.21.1 in /usr/local/lib/python3.7/dist-packages (from requests->panda) (1.24.3)\n",
-            "Requirement already satisfied: chardet<4,>=3.0.2 in /usr/local/lib/python3.7/dist-packages (from requests->panda) (3.0.4)\n"
+            "Looking in indexes: https://pypi.org/simple, https://us-python.pkg.dev/colab-wheels/public/simple/\n",
+            "Requirement already satisfied: pandas in /usr/local/lib/python3.7/dist-packages (1.3.5)\n",
+            "Requirement already satisfied: numpy>=1.17.3 in /usr/local/lib/python3.7/dist-packages (from pandas) (1.21.6)\n",
+            "Requirement already satisfied: python-dateutil>=2.7.3 in /usr/local/lib/python3.7/dist-packages (from pandas) (2.8.2)\n",
+            "Requirement already satisfied: pytz>=2017.3 in /usr/local/lib/python3.7/dist-packages (from pandas) (2022.1)\n",
+            "Requirement already satisfied: six>=1.5 in /usr/local/lib/python3.7/dist-packages (from python-dateutil>=2.7.3->pandas) (1.15.0)\n"
           ]
         }
+      ],
+      "source": [
+        "%pip install pandas"
       ]
     },
     {
       "cell_type": "code",
+      "execution_count": 2,
       "metadata": {
-        "id": "jjC3MLqEZmVQ",
         "colab": {
           "base_uri": "https://localhost:8080/"
         },
-        "outputId": "1deed582-7973-45d3-9579-ebde7be6fba1"
+        "id": "jjC3MLqEZmVQ",
+        "outputId": "ffd31d82-f4e0-430d-c74c-d403b6b82478"
       },
+      "outputs": [
+        {
+          "name": "stdout",
+          "output_type": "stream",
+          "text": [
+            "1.3.5\n"
+          ]
+        }
+      ],
       "source": [
         "import pandas as pd\n",
         "print(pd.__version__)"
-      ],
-      "execution_count": 348,
-      "outputs": [
-        {
-          "output_type": "stream",
-          "name": "stdout",
-          "text": [
-            "1.1.5\n"
-          ]
-        }
       ]
     },
     {
       "cell_type": "code",
-      "source": [
-        "import numpy as np\n",
-        "import matplotlib.pyplot as plt"
-      ],
+      "execution_count": 3,
       "metadata": {
         "id": "N98Fcu71zxJ8"
       },
-      "execution_count": 349,
-      "outputs": []
+      "outputs": [],
+      "source": [
+        "import numpy as np\n",
+        "import matplotlib.pyplot as plt"
+      ]
     },
     {
       "cell_type": "markdown",
@@ -99,56 +84,53 @@
     },
     {
       "cell_type": "code",
+      "execution_count": 4,
       "metadata": {
-        "id": "x7_9lDXebUnt",
         "colab": {
           "base_uri": "https://localhost:8080/"
         },
-        "outputId": "b393d471-55ac-4059-db9b-e558a3f75f7d"
+        "id": "x7_9lDXebUnt",
+        "outputId": "9232c97e-af02-4a69-ead5-f8d9b5661c6e"
       },
-      "source": [
-        "!rm -rf RegularSeasonCompactResults.csv\n",
-        "!wget https://raw.githubusercontent.com/adeshpande3/Pandas-Tutorial/main/RegularSeasonCompactResults.csv\n",
-        "  "
-      ],
-      "execution_count": 350,
       "outputs": [
         {
-          "output_type": "stream",
           "name": "stdout",
+          "output_type": "stream",
           "text": [
-            "--2021-12-23 01:02:17--  https://raw.githubusercontent.com/adeshpande3/Pandas-Tutorial/main/RegularSeasonCompactResults.csv\n",
-            "Resolving raw.githubusercontent.com (raw.githubusercontent.com)... 185.199.111.133, 185.199.110.133, 185.199.108.133, ...\n",
-            "Connecting to raw.githubusercontent.com (raw.githubusercontent.com)|185.199.111.133|:443... connected.\n",
+            "--2022-07-13 08:41:12--  https://raw.githubusercontent.com/adeshpande3/Pandas-Tutorial/master/RegularSeasonCompactResults.csv\n",
+            "Resolving raw.githubusercontent.com (raw.githubusercontent.com)... 185.199.108.133, 185.199.109.133, 185.199.110.133, ...\n",
+            "Connecting to raw.githubusercontent.com (raw.githubusercontent.com)|185.199.108.133|:443... connected.\n",
             "HTTP request sent, awaiting response... 200 OK\n",
             "Length: 4115852 (3.9M) [text/plain]\n",
             "Saving to: ‘RegularSeasonCompactResults.csv’\n",
             "\n",
-            "RegularSeasonCompac 100%[===================>]   3.92M  --.-KB/s    in 0.05s   \n",
+            "\r          RegularSe   0%[                    ]       0  --.-KB/s               \rRegularSeasonCompac 100%[===================>]   3.92M  --.-KB/s    in 0.04s   \n",
             "\n",
-            "2021-12-23 01:02:17 (80.1 MB/s) - ‘RegularSeasonCompactResults.csv’ saved [4115852/4115852]\n",
+            "2022-07-13 08:41:12 (93.6 MB/s) - ‘RegularSeasonCompactResults.csv’ saved [4115852/4115852]\n",
             "\n"
           ]
         }
+      ],
+      "source": [
+        "!rm -rf RegularSeasonCompactResults.csv\n",
+        "!wget https://raw.githubusercontent.com/adeshpande3/Pandas-Tutorial/master/RegularSeasonCompactResults.csv\n",
+        "  "
       ]
     },
     {
       "cell_type": "code",
+      "execution_count": 5,
       "metadata": {
-        "id": "e0zmA0yNbjm-",
         "colab": {
           "base_uri": "https://localhost:8080/"
         },
-        "outputId": "946abebc-a589-4fe4-cafe-1c9b960a096b"
+        "id": "e0zmA0yNbjm-",
+        "outputId": "1a0bd64b-9a31-4749-a7ee-3de2c169bca1"
       },
-      "source": [
-        "!head -10 RegularSeasonCompactResults.csv"
-      ],
-      "execution_count": 351,
       "outputs": [
         {
-          "output_type": "stream",
           "name": "stdout",
+          "output_type": "stream",
           "text": [
             "Season,Daynum,Wteam,Wscore,Lteam,Lscore,Wloc,Numot\n",
             "1985,20,1228,81,1328,64,N,0\n",
@@ -162,6 +144,9 @@
             "1985,25,1260,98,1133,80,H,0\n"
           ]
         }
+      ],
+      "source": [
+        "!head -10 RegularSeasonCompactResults.csv"
       ]
     },
     {
@@ -175,36 +160,32 @@
     },
     {
       "cell_type": "code",
+      "execution_count": 6,
       "metadata": {
         "id": "IyfgKhSPZmyY"
       },
+      "outputs": [],
       "source": [
         "df = pd.read_csv('RegularSeasonCompactResults.csv')"
-      ],
-      "execution_count": 352,
-      "outputs": []
+      ]
     },
     {
       "cell_type": "code",
+      "execution_count": 7,
       "metadata": {
-        "id": "yBhyYvYOcckR",
         "colab": {
           "base_uri": "https://localhost:8080/",
-          "height": 419
+          "height": 424
         },
-        "outputId": "c914b8be-88e6-4f4c-d4db-53e3ed6034b9"
+        "id": "yBhyYvYOcckR",
+        "outputId": "d70245d6-7b74-4ff8-b1d6-ef1ba3dd58d7"
       },
-      "source": [
-        "df"
-      ],
-      "execution_count": 353,
       "outputs": [
         {
-          "output_type": "execute_result",
           "data": {
             "text/html": [
               "\n",
-              "  <div id=\"df-6e1186a6-b98a-4526-bc5d-8b668320cd8d\">\n",
+              "  <div id=\"df-184f64ef-4154-4760-aa16-2598bd9edc02\">\n",
               "    <div class=\"colab-df-container\">\n",
               "      <div>\n",
               "<style scoped>\n",
@@ -360,7 +341,7 @@
               "</table>\n",
               "<p>145289 rows × 8 columns</p>\n",
               "</div>\n",
-              "      <button class=\"colab-df-convert\" onclick=\"convertToInteractive('df-6e1186a6-b98a-4526-bc5d-8b668320cd8d')\"\n",
+              "      <button class=\"colab-df-convert\" onclick=\"convertToInteractive('df-184f64ef-4154-4760-aa16-2598bd9edc02')\"\n",
               "              title=\"Convert this dataframe to an interactive table.\"\n",
               "              style=\"display:none;\">\n",
               "        \n",
@@ -411,12 +392,12 @@
               "\n",
               "      <script>\n",
               "        const buttonEl =\n",
-              "          document.querySelector('#df-6e1186a6-b98a-4526-bc5d-8b668320cd8d button.colab-df-convert');\n",
+              "          document.querySelector('#df-184f64ef-4154-4760-aa16-2598bd9edc02 button.colab-df-convert');\n",
               "        buttonEl.style.display =\n",
               "          google.colab.kernel.accessAllowed ? 'block' : 'none';\n",
               "\n",
               "        async function convertToInteractive(key) {\n",
-              "          const element = document.querySelector('#df-6e1186a6-b98a-4526-bc5d-8b668320cd8d');\n",
+              "          const element = document.querySelector('#df-184f64ef-4154-4760-aa16-2598bd9edc02');\n",
               "          const dataTable =\n",
               "            await google.colab.kernel.invokeFunction('convertToInteractive',\n",
               "                                                     [key], {});\n",
@@ -454,32 +435,32 @@
               "[145289 rows x 8 columns]"
             ]
           },
+          "execution_count": 7,
           "metadata": {},
-          "execution_count": 353
+          "output_type": "execute_result"
         }
+      ],
+      "source": [
+        "df"
       ]
     },
     {
       "cell_type": "code",
+      "execution_count": 8,
       "metadata": {
-        "id": "FeTX6zr1bXey",
         "colab": {
           "base_uri": "https://localhost:8080/",
-          "height": 204
+          "height": 206
         },
-        "outputId": "836e1d67-5ad3-4418-80e1-4baea830c474"
+        "id": "FeTX6zr1bXey",
+        "outputId": "5f1639ed-83ad-4890-f2af-64586c383036"
       },
-      "source": [
-        "df.head()"
-      ],
-      "execution_count": 354,
       "outputs": [
         {
-          "output_type": "execute_result",
           "data": {
             "text/html": [
               "\n",
-              "  <div id=\"df-34f062ca-558b-4609-adbb-0c6dda004afd\">\n",
+              "  <div id=\"df-3161ada4-2396-4fd2-9e8a-beb749267203\">\n",
               "    <div class=\"colab-df-container\">\n",
               "      <div>\n",
               "<style scoped>\n",
@@ -568,7 +549,7 @@
               "  </tbody>\n",
               "</table>\n",
               "</div>\n",
-              "      <button class=\"colab-df-convert\" onclick=\"convertToInteractive('df-34f062ca-558b-4609-adbb-0c6dda004afd')\"\n",
+              "      <button class=\"colab-df-convert\" onclick=\"convertToInteractive('df-3161ada4-2396-4fd2-9e8a-beb749267203')\"\n",
               "              title=\"Convert this dataframe to an interactive table.\"\n",
               "              style=\"display:none;\">\n",
               "        \n",
@@ -619,12 +600,12 @@
               "\n",
               "      <script>\n",
               "        const buttonEl =\n",
-              "          document.querySelector('#df-34f062ca-558b-4609-adbb-0c6dda004afd button.colab-df-convert');\n",
+              "          document.querySelector('#df-3161ada4-2396-4fd2-9e8a-beb749267203 button.colab-df-convert');\n",
               "        buttonEl.style.display =\n",
               "          google.colab.kernel.accessAllowed ? 'block' : 'none';\n",
               "\n",
               "        async function convertToInteractive(key) {\n",
-              "          const element = document.querySelector('#df-34f062ca-558b-4609-adbb-0c6dda004afd');\n",
+              "          const element = document.querySelector('#df-3161ada4-2396-4fd2-9e8a-beb749267203');\n",
               "          const dataTable =\n",
               "            await google.colab.kernel.invokeFunction('convertToInteractive',\n",
               "                                                     [key], {});\n",
@@ -654,32 +635,32 @@
               "4    1985      25   1192      86   1447      74    H      0"
             ]
           },
+          "execution_count": 8,
           "metadata": {},
-          "execution_count": 354
+          "output_type": "execute_result"
         }
+      ],
+      "source": [
+        "df.head()"
       ]
     },
     {
       "cell_type": "code",
+      "execution_count": 9,
       "metadata": {
-        "id": "hyt8V0nzcIGF",
         "colab": {
           "base_uri": "https://localhost:8080/",
-          "height": 204
+          "height": 206
         },
-        "outputId": "ec7341cc-623a-4699-bc39-e4189be76b8f"
+        "id": "hyt8V0nzcIGF",
+        "outputId": "cf2207e9-9234-4509-a517-6f05c1f9d2ae"
       },
-      "source": [
-        "df.tail()"
-      ],
-      "execution_count": 355,
       "outputs": [
         {
-          "output_type": "execute_result",
           "data": {
             "text/html": [
               "\n",
-              "  <div id=\"df-d2baa9f6-e7b4-478b-94c9-6b0b8a88cb69\">\n",
+              "  <div id=\"df-b541ee02-e078-4ace-900f-56382329dda0\">\n",
               "    <div class=\"colab-df-container\">\n",
               "      <div>\n",
               "<style scoped>\n",
@@ -768,7 +749,7 @@
               "  </tbody>\n",
               "</table>\n",
               "</div>\n",
-              "      <button class=\"colab-df-convert\" onclick=\"convertToInteractive('df-d2baa9f6-e7b4-478b-94c9-6b0b8a88cb69')\"\n",
+              "      <button class=\"colab-df-convert\" onclick=\"convertToInteractive('df-b541ee02-e078-4ace-900f-56382329dda0')\"\n",
               "              title=\"Convert this dataframe to an interactive table.\"\n",
               "              style=\"display:none;\">\n",
               "        \n",
@@ -819,12 +800,12 @@
               "\n",
               "      <script>\n",
               "        const buttonEl =\n",
-              "          document.querySelector('#df-d2baa9f6-e7b4-478b-94c9-6b0b8a88cb69 button.colab-df-convert');\n",
+              "          document.querySelector('#df-b541ee02-e078-4ace-900f-56382329dda0 button.colab-df-convert');\n",
               "        buttonEl.style.display =\n",
               "          google.colab.kernel.accessAllowed ? 'block' : 'none';\n",
               "\n",
               "        async function convertToInteractive(key) {\n",
-              "          const element = document.querySelector('#df-d2baa9f6-e7b4-478b-94c9-6b0b8a88cb69');\n",
+              "          const element = document.querySelector('#df-b541ee02-e078-4ace-900f-56382329dda0');\n",
               "          const dataTable =\n",
               "            await google.colab.kernel.invokeFunction('convertToInteractive',\n",
               "                                                     [key], {});\n",
@@ -854,106 +835,107 @@
               "145288    2016     132   1386      87   1433      74    N      0"
             ]
           },
+          "execution_count": 9,
           "metadata": {},
-          "execution_count": 355
+          "output_type": "execute_result"
         }
+      ],
+      "source": [
+        "df.tail()"
       ]
     },
     {
       "cell_type": "code",
+      "execution_count": 10,
       "metadata": {
-        "id": "yw_DDZIicMit",
         "colab": {
           "base_uri": "https://localhost:8080/"
         },
-        "outputId": "b2d14fca-28af-4ca8-a5a1-9d34393b3472"
+        "id": "yw_DDZIicMit",
+        "outputId": "f8f7b1eb-3b96-4bb5-a37a-f3bc2b3d31bf"
       },
-      "source": [
-        "df.shape"
-      ],
-      "execution_count": 356,
       "outputs": [
         {
-          "output_type": "execute_result",
           "data": {
             "text/plain": [
               "(145289, 8)"
             ]
           },
+          "execution_count": 10,
           "metadata": {},
-          "execution_count": 356
+          "output_type": "execute_result"
         }
+      ],
+      "source": [
+        "df.shape"
       ]
     },
     {
       "cell_type": "code",
+      "execution_count": 11,
       "metadata": {
-        "id": "bF9T8oDOkuAm",
         "colab": {
           "base_uri": "https://localhost:8080/"
         },
-        "outputId": "69b750ac-2ef6-40dd-dce2-18e4c9f8ca60"
+        "id": "bF9T8oDOkuAm",
+        "outputId": "2ddf0eb9-282c-4407-88d1-2a50aa7dca3c"
       },
-      "source": [
-        "df.index"
-      ],
-      "execution_count": 357,
       "outputs": [
         {
-          "output_type": "execute_result",
           "data": {
             "text/plain": [
               "RangeIndex(start=0, stop=145289, step=1)"
             ]
           },
+          "execution_count": 11,
           "metadata": {},
-          "execution_count": 357
+          "output_type": "execute_result"
         }
+      ],
+      "source": [
+        "df.index"
       ]
     },
     {
       "cell_type": "code",
+      "execution_count": 12,
       "metadata": {
-        "id": "dfrSWFOecMlE",
         "colab": {
           "base_uri": "https://localhost:8080/"
         },
-        "outputId": "a15d0cfd-8a03-451f-8622-d16a011c59fb"
+        "id": "dfrSWFOecMlE",
+        "outputId": "ccdb8322-b1b0-45e6-a574-919436f1e54d"
       },
-      "source": [
-        "df.columns.tolist()"
-      ],
-      "execution_count": 358,
       "outputs": [
         {
-          "output_type": "execute_result",
           "data": {
             "text/plain": [
               "['Season', 'Daynum', 'Wteam', 'Wscore', 'Lteam', 'Lscore', 'Wloc', 'Numot']"
             ]
           },
+          "execution_count": 12,
           "metadata": {},
-          "execution_count": 358
+          "output_type": "execute_result"
         }
+      ],
+      "source": [
+        "df.columns.tolist()"
       ]
     },
     {
       "cell_type": "code",
+      "execution_count": 13,
       "metadata": {
-        "id": "fSze9X1ckyaW",
         "colab": {
           "base_uri": "https://localhost:8080/"
         },
-        "outputId": "1ffce112-f06f-4111-f027-944bcbc05546"
+        "id": "fSze9X1ckyaW",
+        "outputId": "670cbc1c-f7e3-4b2f-9896-8a2e0b421e8e"
       },
-      "source": [
-        "df.info()"
-      ],
-      "execution_count": 359,
       "outputs": [
         {
-          "output_type": "stream",
           "name": "stdout",
+          "output_type": "stream",
           "text": [
             "<class 'pandas.core.frame.DataFrame'>\n",
             "RangeIndex: 145289 entries, 0 to 145288\n",
@@ -972,29 +954,28 @@
             "memory usage: 8.9+ MB\n"
           ]
         }
+      ],
+      "source": [
+        "df.info()"
       ]
     },
     {
       "cell_type": "code",
+      "execution_count": 14,
       "metadata": {
-        "id": "tc5JleNDcMpj",
         "colab": {
           "base_uri": "https://localhost:8080/",
-          "height": 361
+          "height": 300
         },
-        "outputId": "caf8b741-c9b9-4b68-b447-9bedfc5bcfdc"
+        "id": "tc5JleNDcMpj",
+        "outputId": "931a81f1-92f9-49df-e1b5-48f5d0a772c5"
       },
-      "source": [
-        "df.describe()"
-      ],
-      "execution_count": 360,
       "outputs": [
         {
-          "output_type": "execute_result",
           "data": {
             "text/html": [
               "\n",
-              "  <div id=\"df-1af4fb33-77dd-49b3-a4e4-f46dddbbf73a\">\n",
+              "  <div id=\"df-4cff471a-5908-4e1b-8c98-8d93afff2642\">\n",
               "    <div class=\"colab-df-container\">\n",
               "      <div>\n",
               "<style scoped>\n",
@@ -1107,7 +1088,7 @@
               "  </tbody>\n",
               "</table>\n",
               "</div>\n",
-              "      <button class=\"colab-df-convert\" onclick=\"convertToInteractive('df-1af4fb33-77dd-49b3-a4e4-f46dddbbf73a')\"\n",
+              "      <button class=\"colab-df-convert\" onclick=\"convertToInteractive('df-4cff471a-5908-4e1b-8c98-8d93afff2642')\"\n",
               "              title=\"Convert this dataframe to an interactive table.\"\n",
               "              style=\"display:none;\">\n",
               "        \n",
@@ -1158,12 +1139,12 @@
               "\n",
               "      <script>\n",
               "        const buttonEl =\n",
-              "          document.querySelector('#df-1af4fb33-77dd-49b3-a4e4-f46dddbbf73a button.colab-df-convert');\n",
+              "          document.querySelector('#df-4cff471a-5908-4e1b-8c98-8d93afff2642 button.colab-df-convert');\n",
               "        buttonEl.style.display =\n",
               "          google.colab.kernel.accessAllowed ? 'block' : 'none';\n",
               "\n",
               "        async function convertToInteractive(key) {\n",
-              "          const element = document.querySelector('#df-1af4fb33-77dd-49b3-a4e4-f46dddbbf73a');\n",
+              "          const element = document.querySelector('#df-4cff471a-5908-4e1b-8c98-8d93afff2642');\n",
               "          const dataTable =\n",
               "            await google.colab.kernel.invokeFunction('convertToInteractive',\n",
               "                                                     [key], {});\n",
@@ -1185,40 +1166,48 @@
               "  "
             ],
             "text/plain": [
-              "              Season         Daynum  ...         Lscore          Numot\n",
-              "count  145289.000000  145289.000000  ...  145289.000000  145289.000000\n",
-              "mean     2001.574834      75.223816  ...      64.497009       0.044387\n",
-              "std         9.233342      33.287418  ...      11.380625       0.247819\n",
-              "min      1985.000000       0.000000  ...      20.000000       0.000000\n",
-              "25%      1994.000000      47.000000  ...      57.000000       0.000000\n",
-              "50%      2002.000000      78.000000  ...      64.000000       0.000000\n",
-              "75%      2010.000000     103.000000  ...      72.000000       0.000000\n",
-              "max      2016.000000     132.000000  ...     150.000000       6.000000\n",
+              "              Season         Daynum          Wteam         Wscore  \\\n",
+              "count  145289.000000  145289.000000  145289.000000  145289.000000   \n",
+              "mean     2001.574834      75.223816    1286.720646      76.600321   \n",
+              "std         9.233342      33.287418     104.570275      12.173033   \n",
+              "min      1985.000000       0.000000    1101.000000      34.000000   \n",
+              "25%      1994.000000      47.000000    1198.000000      68.000000   \n",
+              "50%      2002.000000      78.000000    1284.000000      76.000000   \n",
+              "75%      2010.000000     103.000000    1379.000000      84.000000   \n",
+              "max      2016.000000     132.000000    1464.000000     186.000000   \n",
               "\n",
-              "[8 rows x 7 columns]"
+              "               Lteam         Lscore          Numot  \n",
+              "count  145289.000000  145289.000000  145289.000000  \n",
+              "mean     1282.864064      64.497009       0.044387  \n",
+              "std       104.829234      11.380625       0.247819  \n",
+              "min      1101.000000      20.000000       0.000000  \n",
+              "25%      1191.000000      57.000000       0.000000  \n",
+              "50%      1280.000000      64.000000       0.000000  \n",
+              "75%      1375.000000      72.000000       0.000000  \n",
+              "max      1464.000000     150.000000       6.000000  "
             ]
           },
+          "execution_count": 14,
           "metadata": {},
-          "execution_count": 360
+          "output_type": "execute_result"
         }
+      ],
+      "source": [
+        "df.describe()"
       ]
     },
     {
       "cell_type": "code",
+      "execution_count": 15,
       "metadata": {
-        "id": "s7JGcSQAcMrq",
         "colab": {
           "base_uri": "https://localhost:8080/"
         },
-        "outputId": "91ce6583-f102-4217-f9e7-ca703a2a98bd"
+        "id": "s7JGcSQAcMrq",
+        "outputId": "5659a2b6-c36a-4e7e-8b4e-21fe5a8cced1"
       },
-      "source": [
-        "df.max()"
-      ],
-      "execution_count": 361,
       "outputs": [
         {
-          "output_type": "execute_result",
           "data": {
             "text/plain": [
               "Season    2016\n",
@@ -1232,9 +1221,13 @@
               "dtype: object"
             ]
           },
+          "execution_count": 15,
           "metadata": {},
-          "execution_count": 361
+          "output_type": "execute_result"
         }
+      ],
+      "source": [
+        "df.max()"
       ]
     },
     {
@@ -1294,20 +1287,16 @@
     },
     {
       "cell_type": "code",
+      "execution_count": 16,
       "metadata": {
-        "id": "sKEOLZnvcMuC",
         "colab": {
           "base_uri": "https://localhost:8080/"
         },
-        "outputId": "95c2a165-aac8-409e-9a98-ed6409ff85aa"
+        "id": "sKEOLZnvcMuC",
+        "outputId": "72300d03-ade9-4ce6-9128-f5aca1163436"
       },
-      "source": [
-        "df['Wteam']"
-      ],
-      "execution_count": 362,
       "outputs": [
         {
-          "output_type": "execute_result",
           "data": {
             "text/plain": [
               "0         1228\n",
@@ -1324,58 +1313,58 @@
               "Name: Wteam, Length: 145289, dtype: int64"
             ]
           },
+          "execution_count": 16,
           "metadata": {},
-          "execution_count": 362
+          "output_type": "execute_result"
         }
+      ],
+      "source": [
+        "df['Wteam']"
       ]
     },
     {
       "cell_type": "code",
+      "execution_count": 17,
       "metadata": {
-        "id": "Fm18-8CWcMyu",
         "colab": {
           "base_uri": "https://localhost:8080/"
         },
-        "outputId": "d0dd31c9-0884-46ba-8699-adc286669b08"
+        "id": "Fm18-8CWcMyu",
+        "outputId": "78371868-93d8-4721-b0a0-953a9a52ac82"
       },
-      "source": [
-        "df['Wteam'].max()"
-      ],
-      "execution_count": 363,
       "outputs": [
         {
-          "output_type": "execute_result",
           "data": {
             "text/plain": [
               "1464"
             ]
           },
+          "execution_count": 17,
           "metadata": {},
-          "execution_count": 363
+          "output_type": "execute_result"
         }
+      ],
+      "source": [
+        "df['Wteam'].max()"
       ]
     },
     {
       "cell_type": "code",
+      "execution_count": 18,
       "metadata": {
         "colab": {
           "base_uri": "https://localhost:8080/",
-          "height": 142
+          "height": 143
         },
         "id": "ldR59h3lBrBZ",
-        "outputId": "dacf7fb8-2c06-4780-e612-af71e07989b5"
+        "outputId": "bbe525cd-72da-490b-e63f-58e94a262d76"
       },
-      "source": [
-        "df[82:85]"
-      ],
-      "execution_count": 364,
       "outputs": [
         {
-          "output_type": "execute_result",
           "data": {
             "text/html": [
               "\n",
-              "  <div id=\"df-a9c282af-3875-4da3-b7ee-464742ab966a\">\n",
+              "  <div id=\"df-c53bf558-323a-4819-9961-0cf6b8335e44\">\n",
               "    <div class=\"colab-df-container\">\n",
               "      <div>\n",
               "<style scoped>\n",
@@ -1442,7 +1431,7 @@
               "  </tbody>\n",
               "</table>\n",
               "</div>\n",
-              "      <button class=\"colab-df-convert\" onclick=\"convertToInteractive('df-a9c282af-3875-4da3-b7ee-464742ab966a')\"\n",
+              "      <button class=\"colab-df-convert\" onclick=\"convertToInteractive('df-c53bf558-323a-4819-9961-0cf6b8335e44')\"\n",
               "              title=\"Convert this dataframe to an interactive table.\"\n",
               "              style=\"display:none;\">\n",
               "        \n",
@@ -1493,12 +1482,12 @@
               "\n",
               "      <script>\n",
               "        const buttonEl =\n",
-              "          document.querySelector('#df-a9c282af-3875-4da3-b7ee-464742ab966a button.colab-df-convert');\n",
+              "          document.querySelector('#df-c53bf558-323a-4819-9961-0cf6b8335e44 button.colab-df-convert');\n",
               "        buttonEl.style.display =\n",
               "          google.colab.kernel.accessAllowed ? 'block' : 'none';\n",
               "\n",
               "        async function convertToInteractive(key) {\n",
-              "          const element = document.querySelector('#df-a9c282af-3875-4da3-b7ee-464742ab966a');\n",
+              "          const element = document.querySelector('#df-c53bf558-323a-4819-9961-0cf6b8335e44');\n",
               "          const dataTable =\n",
               "            await google.colab.kernel.invokeFunction('convertToInteractive',\n",
               "                                                     [key], {});\n",
@@ -1526,54 +1515,53 @@
               "84    1985      29   1124      99   1341      77    H      0"
             ]
           },
+          "execution_count": 18,
           "metadata": {},
-          "execution_count": 364
+          "output_type": "execute_result"
         }
+      ],
+      "source": [
+        "df[82:85]"
       ]
     },
     {
       "cell_type": "code",
+      "execution_count": 19,
       "metadata": {
-        "id": "XyssEc6ZcM1I",
         "colab": {
           "base_uri": "https://localhost:8080/"
         },
-        "outputId": "2ea6e3d4-8503-44d7-9461-ad42b78a7e1d"
+        "id": "XyssEc6ZcM1I",
+        "outputId": "3fb7ee4c-9969-48ba-db7c-ec62d5ba490c"
       },
-      "source": [
-        "df['Wteam'].mean()"
-      ],
-      "execution_count": 365,
       "outputs": [
         {
-          "output_type": "execute_result",
           "data": {
             "text/plain": [
               "1286.7206464357246"
             ]
           },
+          "execution_count": 19,
           "metadata": {},
-          "execution_count": 365
+          "output_type": "execute_result"
         }
+      ],
+      "source": [
+        "df['Wteam'].mean()"
       ]
     },
     {
       "cell_type": "code",
+      "execution_count": 20,
       "metadata": {
-        "id": "uEJNux1HeRnd",
         "colab": {
           "base_uri": "https://localhost:8080/"
         },
-        "outputId": "98dbc59c-5a79-445a-e316-f44f8315de8b"
+        "id": "uEJNux1HeRnd",
+        "outputId": "50f825b0-83ed-4ab5-87bf-3007fc02acc5"
       },
-      "source": [
-        "# df[82] # NOT SUPPORT\n",
-        "df.iloc[82]"
-      ],
-      "execution_count": 366,
       "outputs": [
         {
-          "output_type": "execute_result",
           "data": {
             "text/plain": [
               "Season    1985\n",
@@ -1587,27 +1575,28 @@
               "Name: 82, dtype: object"
             ]
           },
+          "execution_count": 20,
           "metadata": {},
-          "execution_count": 366
+          "output_type": "execute_result"
         }
+      ],
+      "source": [
+        "# df[82] # NOT SUPPORT\n",
+        "df.iloc[82]"
       ]
     },
     {
       "cell_type": "code",
+      "execution_count": 21,
       "metadata": {
         "colab": {
           "base_uri": "https://localhost:8080/"
         },
         "id": "qp3sGHZU9u5g",
-        "outputId": "7513c4bb-57da-43e6-d2dc-dec7b8833a83"
+        "outputId": "621cc261-9f3f-4454-a35b-68a676ec409e"
       },
-      "source": [
-        "df.loc[82]"
-      ],
-      "execution_count": 367,
       "outputs": [
         {
-          "output_type": "execute_result",
           "data": {
             "text/plain": [
               "Season    1985\n",
@@ -1621,158 +1610,158 @@
               "Name: 82, dtype: object"
             ]
           },
+          "execution_count": 21,
           "metadata": {},
-          "execution_count": 367
+          "output_type": "execute_result"
         }
+      ],
+      "source": [
+        "df.loc[82]"
       ]
     },
     {
       "cell_type": "code",
+      "execution_count": 22,
       "metadata": {
         "colab": {
           "base_uri": "https://localhost:8080/"
         },
         "id": "DPQvTrWX-acf",
-        "outputId": "015ec6e4-7531-4869-d114-615937db7401"
+        "outputId": "b2a7e020-ad31-4db0-d75e-23fa7eb35ae9"
       },
-      "source": [
-        "df.loc[82]['Wteam']"
-      ],
-      "execution_count": 368,
       "outputs": [
         {
-          "output_type": "execute_result",
           "data": {
             "text/plain": [
               "1464"
             ]
           },
+          "execution_count": 22,
           "metadata": {},
-          "execution_count": 368
+          "output_type": "execute_result"
         }
+      ],
+      "source": [
+        "df.loc[82]['Wteam']"
       ]
     },
     {
       "cell_type": "code",
+      "execution_count": 23,
       "metadata": {
-        "id": "buPHbtTieRsd",
         "colab": {
           "base_uri": "https://localhost:8080/"
         },
-        "outputId": "5aef9118-fc9d-4357-f563-590221c22a16"
+        "id": "buPHbtTieRsd",
+        "outputId": "707e5225-6d4d-4489-e71c-b6c18b617e1f"
       },
-      "source": [
-        "df.iloc[82]['Wteam']"
-      ],
-      "execution_count": 369,
       "outputs": [
         {
-          "output_type": "execute_result",
           "data": {
             "text/plain": [
               "1464"
             ]
           },
+          "execution_count": 23,
           "metadata": {},
-          "execution_count": 369
+          "output_type": "execute_result"
         }
+      ],
+      "source": [
+        "df.iloc[82]['Wteam']"
       ]
     },
     {
       "cell_type": "code",
+      "execution_count": 24,
       "metadata": {
         "colab": {
           "base_uri": "https://localhost:8080/"
         },
         "id": "a6fbeWyb-nhd",
-        "outputId": "f3950420-d5ac-4186-da26-5005d73415c2"
+        "outputId": "6248a809-f64b-4acf-e923-11256a3fb252"
       },
-      "source": [
-        "df.loc[82, 'Wteam']"
-      ],
-      "execution_count": 370,
       "outputs": [
         {
-          "output_type": "execute_result",
           "data": {
             "text/plain": [
               "1464"
             ]
           },
+          "execution_count": 24,
           "metadata": {},
-          "execution_count": 370
+          "output_type": "execute_result"
         }
+      ],
+      "source": [
+        "df.loc[82, 'Wteam']"
       ]
     },
     {
       "cell_type": "code",
+      "execution_count": 25,
       "metadata": {
         "colab": {
           "base_uri": "https://localhost:8080/"
         },
         "id": "UfXIowMv-pnN",
-        "outputId": "198f0605-4353-4a93-d137-a95da346534b"
+        "outputId": "9001bdf6-84a7-47ee-bdca-fd7ed69f09c4"
       },
+      "outputs": [
+        {
+          "data": {
+            "text/plain": [
+              "1464"
+            ]
+          },
+          "execution_count": 25,
+          "metadata": {},
+          "output_type": "execute_result"
+        }
+      ],
       "source": [
         "# df.iloc[82, 'Wteam'] # Not Support\n",
         "df.iloc[82, 2]"
-      ],
-      "execution_count": 371,
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 26,
+      "metadata": {
+        "colab": {
+          "base_uri": "https://localhost:8080/"
+        },
+        "id": "3phnrVbFhJNX",
+        "outputId": "3d888af0-4c60-426b-a754-5ad38bd9a06d"
+      },
       "outputs": [
         {
-          "output_type": "execute_result",
           "data": {
             "text/plain": [
               "1464"
             ]
           },
+          "execution_count": 26,
           "metadata": {},
-          "execution_count": 371
+          "output_type": "execute_result"
         }
-      ]
-    },
-    {
-      "cell_type": "code",
-      "metadata": {
-        "id": "3phnrVbFhJNX",
-        "colab": {
-          "base_uri": "https://localhost:8080/"
-        },
-        "outputId": "52083ffc-1886-4e69-9922-aa0f4399c3ea"
-      },
+      ],
       "source": [
         "df['Wteam'][82]"
-      ],
-      "execution_count": 372,
-      "outputs": [
-        {
-          "output_type": "execute_result",
-          "data": {
-            "text/plain": [
-              "1464"
-            ]
-          },
-          "metadata": {},
-          "execution_count": 372
-        }
       ]
     },
     {
       "cell_type": "code",
+      "execution_count": 27,
       "metadata": {
-        "id": "Rpl6VHNoc9Xf",
         "colab": {
           "base_uri": "https://localhost:8080/"
         },
-        "outputId": "835abcd9-1f4e-4c6e-a9dd-ffa82452993d"
+        "id": "Rpl6VHNoc9Xf",
+        "outputId": "a863486b-c1c7-4878-c598-ee0c69c1d87b"
       },
-      "source": [
-        "df['Wteam'].value_counts()"
-      ],
-      "execution_count": 373,
       "outputs": [
         {
-          "output_type": "execute_result",
           "data": {
             "text/plain": [
               "1181    819\n",
@@ -1789,9 +1778,13 @@
               "Name: Wteam, Length: 364, dtype: int64"
             ]
           },
+          "execution_count": 27,
           "metadata": {},
-          "execution_count": 373
+          "output_type": "execute_result"
         }
+      ],
+      "source": [
+        "df['Wteam'].value_counts()"
       ]
     },
     {
@@ -1814,40 +1807,18 @@
     },
     {
       "cell_type": "code",
+      "execution_count": 28,
       "metadata": {
         "colab": {
           "base_uri": "https://localhost:8080/"
         },
         "id": "NHfamfU-IZVH",
-        "outputId": "5089daf8-c461-45a8-ac80-a07f85dd2322"
+        "outputId": "92f83eca-ec3f-43c9-bb22-326fb7a77cc1"
       },
-      "source": [
-        "df = pd.DataFrame(\n",
-        "        {\"AAA\": [4, 5, 6, 7], \"BBB\": [10, 20, 30, 40], \"CCC\": [100, 50, -30, -50]}\n",
-        ")\n",
-        "\n",
-        "print(df)\n",
-        "print()\n",
-        "\n",
-        "# 필터 선언\n",
-        "filtered_mask = pd.Series([True, False, True, False])\n",
-        "print(\"filtered_mask legnth =\",len(filtered_mask))\n",
-        "print(filtered_mask)\n",
-        "print()\n",
-        "\n",
-        "# 필터링된 DF\n",
-        "print(df[filtered_mask])\n",
-        "print()\n",
-        "\n",
-        "# 대상 항목만 값 설정\n",
-        "df.loc[filtered_mask, 'BBB'] = -1\n",
-        "print(df)\n"
-      ],
-      "execution_count": 374,
       "outputs": [
         {
-          "output_type": "stream",
           "name": "stdout",
+          "output_type": "stream",
           "text": [
             "   AAA  BBB  CCC\n",
             "0    4   10  100\n",
@@ -1873,6 +1844,28 @@
             "3    7   40  -50\n"
           ]
         }
+      ],
+      "source": [
+        "df = pd.DataFrame(\n",
+        "        {\"AAA\": [4, 5, 6, 7], \"BBB\": [10, 20, 30, 40], \"CCC\": [100, 50, -30, -50]}\n",
+        ")\n",
+        "\n",
+        "print(df)\n",
+        "print()\n",
+        "\n",
+        "# 필터 선언\n",
+        "filtered_mask = pd.Series([True, False, True, False])\n",
+        "print(\"filtered_mask length =\",len(filtered_mask))\n",
+        "print(filtered_mask)\n",
+        "print()\n",
+        "\n",
+        "# 필터링된 DF\n",
+        "print(df[filtered_mask])\n",
+        "print()\n",
+        "\n",
+        "# 대상 항목만 값 설정\n",
+        "df.loc[filtered_mask, 'BBB'] = -1\n",
+        "print(df)\n"
       ]
     },
     {
@@ -1886,40 +1879,18 @@
     },
     {
       "cell_type": "code",
+      "execution_count": 29,
       "metadata": {
         "colab": {
           "base_uri": "https://localhost:8080/"
         },
         "id": "uAM3g7YaNdp4",
-        "outputId": "d93f4d0c-6538-4656-98e9-b5902c746e85"
+        "outputId": "ab0fcce2-9387-4689-8e97-6384b63da609"
       },
-      "source": [
-        "df = pd.DataFrame(\n",
-        "        {\"AAA\": [4, 5, 6, 7], \"BBB\": [10, 20, 30, 40], \"CCC\": [100, 50, -30, -50]}\n",
-        ")\n",
-        "\n",
-        "print(df)\n",
-        "print()\n",
-        "\n",
-        "# 필터 선언\n",
-        "filtered_index = np.array([0, 2])\n",
-        "print(\"filtered_index legnth =\",len(filtered_index))\n",
-        "print(filtered_index)\n",
-        "print()\n",
-        "\n",
-        "# 필터링된 DF\n",
-        "print(df.loc[filtered_index])\n",
-        "print()\n",
-        "\n",
-        "# 대상 항목만 값 설정\n",
-        "df.loc[filtered_index, 'BBB'] = -1\n",
-        "print(df)\n"
-      ],
-      "execution_count": 375,
       "outputs": [
         {
-          "output_type": "stream",
           "name": "stdout",
+          "output_type": "stream",
           "text": [
             "   AAA  BBB  CCC\n",
             "0    4   10  100\n",
@@ -1941,6 +1912,28 @@
             "3    7   40  -50\n"
           ]
         }
+      ],
+      "source": [
+        "df = pd.DataFrame(\n",
+        "        {\"AAA\": [4, 5, 6, 7], \"BBB\": [10, 20, 30, 40], \"CCC\": [100, 50, -30, -50]}\n",
+        ")\n",
+        "\n",
+        "print(df)\n",
+        "print()\n",
+        "\n",
+        "# 필터 선언\n",
+        "filtered_index = np.array([0, 2])\n",
+        "print(\"filtered_index length =\",len(filtered_index))\n",
+        "print(filtered_index)\n",
+        "print()\n",
+        "\n",
+        "# 필터링된 DF\n",
+        "print(df.loc[filtered_index])\n",
+        "print()\n",
+        "\n",
+        "# 대상 항목만 값 설정\n",
+        "df.loc[filtered_index, 'BBB'] = -1\n",
+        "print(df)\n"
       ]
     },
     {
@@ -1954,40 +1947,18 @@
     },
     {
       "cell_type": "code",
+      "execution_count": 30,
       "metadata": {
         "colab": {
           "base_uri": "https://localhost:8080/"
         },
         "id": "dJBot4eFG_3x",
-        "outputId": "f9c5df7f-0c51-4efd-b76a-9aa915e3a3c7"
+        "outputId": "bc8111c9-071f-4d3d-a4b5-1e76bdf70ce1"
       },
-      "source": [
-        "df = pd.DataFrame(\n",
-        "        {\"AAA\": [4, 5, 6, 7], \"BBB\": [10, 20, 30, 40], \"CCC\": [100, 50, -30, -50]}\n",
-        ")\n",
-        "\n",
-        "print(df)\n",
-        "print()\n",
-        "\n",
-        "# 조건으로 필터\n",
-        "filtered_mask = df.AAA>=5\n",
-        "print(\"filtered_mask legnth =\",len(filtered_mask))\n",
-        "print(filtered_mask)\n",
-        "print()\n",
-        "\n",
-        "# 필터링된 DF\n",
-        "print(df[filtered_mask])\n",
-        "print()\n",
-        "\n",
-        "# 대상 항목만 값 설정\n",
-        "df.loc[filtered_mask, 'BBB'] = -1\n",
-        "print(df)"
-      ],
-      "execution_count": 376,
       "outputs": [
         {
-          "output_type": "stream",
           "name": "stdout",
+          "output_type": "stream",
           "text": [
             "   AAA  BBB  CCC\n",
             "0    4   10  100\n",
@@ -2014,6 +1985,28 @@
             "3    7   -1  -50\n"
           ]
         }
+      ],
+      "source": [
+        "df = pd.DataFrame(\n",
+        "        {\"AAA\": [4, 5, 6, 7], \"BBB\": [10, 20, 30, 40], \"CCC\": [100, 50, -30, -50]}\n",
+        ")\n",
+        "\n",
+        "print(df)\n",
+        "print()\n",
+        "\n",
+        "# 조건으로 필터\n",
+        "filtered_mask = df.AAA>=5\n",
+        "print(\"filtered_mask length =\",len(filtered_mask))\n",
+        "print(filtered_mask)\n",
+        "print()\n",
+        "\n",
+        "# 필터링된 DF\n",
+        "print(df[filtered_mask])\n",
+        "print()\n",
+        "\n",
+        "# 대상 항목만 값 설정\n",
+        "df.loc[filtered_mask, 'BBB'] = -1\n",
+        "print(df)"
       ]
     },
     {
@@ -2027,39 +2020,18 @@
     },
     {
       "cell_type": "code",
+      "execution_count": 31,
       "metadata": {
         "colab": {
           "base_uri": "https://localhost:8080/"
         },
         "id": "f5CVtOqHVasc",
-        "outputId": "612b9128-2ecb-4322-e9dc-b1c381ffeafe"
+        "outputId": "8cb9d856-ae30-473a-d891-050bda9d9c3b"
       },
-      "source": [
-        "df = pd.DataFrame(\n",
-        "        {\"AAA\": [4, 5, 6, 7], \"BBB\": [10, 20, 30, 40], \"CCC\": [100, 50, -30, -50]}\n",
-        ")\n",
-        "\n",
-        "print(df)\n",
-        "print()\n",
-        "\n",
-        "import numpy as np\n",
-        "\n",
-        "# 복수 조건으로 필터링된 DF\n",
-        "filtered_mask = (df.AAA>=5) & (df.BBB<40)\n",
-        "\n",
-        "print(\"filtered_mask legnth =\",len(filtered_mask))\n",
-        "print(filtered_mask)\n",
-        "print()\n",
-        "\n",
-        "# 대상 항목만 값 설정\n",
-        "df.loc[filtered_mask, 'BBB'] = -1\n",
-        "print(df)"
-      ],
-      "execution_count": 377,
       "outputs": [
         {
-          "output_type": "stream",
           "name": "stdout",
+          "output_type": "stream",
           "text": [
             "   AAA  BBB  CCC\n",
             "0    4   10  100\n",
@@ -2081,6 +2053,27 @@
             "3    7   40  -50\n"
           ]
         }
+      ],
+      "source": [
+        "df = pd.DataFrame(\n",
+        "        {\"AAA\": [4, 5, 6, 7], \"BBB\": [10, 20, 30, 40], \"CCC\": [100, 50, -30, -50]}\n",
+        ")\n",
+        "\n",
+        "print(df)\n",
+        "print()\n",
+        "\n",
+        "import numpy as np\n",
+        "\n",
+        "# 복수 조건으로 필터링된 DF\n",
+        "filtered_mask = (df.AAA>=5) & (df.BBB<40)\n",
+        "\n",
+        "print(\"filtered_mask length =\",len(filtered_mask))\n",
+        "print(filtered_mask)\n",
+        "print()\n",
+        "\n",
+        "# 대상 항목만 값 설정\n",
+        "df.loc[filtered_mask, 'BBB'] = -1\n",
+        "print(df)"
       ]
     },
     {
@@ -2094,42 +2087,18 @@
     },
     {
       "cell_type": "code",
+      "execution_count": 32,
       "metadata": {
         "colab": {
           "base_uri": "https://localhost:8080/"
         },
         "id": "A57oUcphJ5A8",
-        "outputId": "fa0b4e42-703e-46cc-ab46-dc5fb732e625"
+        "outputId": "fe6d0ef9-8037-4ae4-bc8f-2a753ca99c78"
       },
-      "source": [
-        "df = pd.DataFrame(\n",
-        "        {\"AAA\": [4, 5, 6, 7], \"BBB\": [10, 20, 30, 40], \"CCC\": [100, 50, -30, -50]}\n",
-        ")\n",
-        "\n",
-        "print(df)\n",
-        "print()\n",
-        "\n",
-        "import numpy as np\n",
-        "\n",
-        "# 복수 조건\n",
-        "filtered_index = np.where( (df.AAA>=5) & (df.BBB<40) )[0]\n",
-        "print(\"filtered_index legnth =\",len(filtered_index))\n",
-        "print(filtered_index)\n",
-        "print()\n",
-        "\n",
-        "# 필터링된 DF\n",
-        "print(df.loc[filtered_index])\n",
-        "print()\n",
-        "\n",
-        "# 대상 항목만 값 설정\n",
-        "df.loc[filtered_index, 'BBB'] = -1\n",
-        "print(df)"
-      ],
-      "execution_count": 378,
       "outputs": [
         {
-          "output_type": "stream",
           "name": "stdout",
+          "output_type": "stream",
           "text": [
             "   AAA  BBB  CCC\n",
             "0    4   10  100\n",
@@ -2151,6 +2120,30 @@
             "3    7   40  -50\n"
           ]
         }
+      ],
+      "source": [
+        "df = pd.DataFrame(\n",
+        "        {\"AAA\": [4, 5, 6, 7], \"BBB\": [10, 20, 30, 40], \"CCC\": [100, 50, -30, -50]}\n",
+        ")\n",
+        "\n",
+        "print(df)\n",
+        "print()\n",
+        "\n",
+        "import numpy as np\n",
+        "\n",
+        "# 복수 조건\n",
+        "filtered_index = np.where( (df.AAA>=5) & (df.BBB<40) )[0]\n",
+        "print(\"filtered_index length =\",len(filtered_index))\n",
+        "print(filtered_index)\n",
+        "print()\n",
+        "\n",
+        "# 필터링된 DF\n",
+        "print(df.loc[filtered_index])\n",
+        "print()\n",
+        "\n",
+        "# 대상 항목만 값 설정\n",
+        "df.loc[filtered_index, 'BBB'] = -1\n",
+        "print(df)"
       ]
     },
     {
@@ -2184,31 +2177,18 @@
     },
     {
       "cell_type": "code",
+      "execution_count": 33,
       "metadata": {
         "colab": {
           "base_uri": "https://localhost:8080/"
         },
         "id": "PtatCyRE7Q6-",
-        "outputId": "7626595c-5670-45f8-c492-bbd4a43c6df9"
+        "outputId": "36acccae-c5c2-4709-ba1a-0a6df3a2687b"
       },
-      "source": [
-        "df = pd.DataFrame(\n",
-        "        {\"AAA\": [4, 5, 6, 7], \"BBB\": [10, 20, 30, 40], \"CCC\": [100, 50, -30, -50]}\n",
-        ")\n",
-        "\n",
-        "print(df)\n",
-        "print()\n",
-        "\n",
-        "print(df.loc[df.AAA>=5])\n",
-        "print()\n",
-        "\n",
-        "print(df.loc[df.AAA>=5].loc[df.BBB<=30])"
-      ],
-      "execution_count": 379,
       "outputs": [
         {
-          "output_type": "stream",
           "name": "stdout",
+          "output_type": "stream",
           "text": [
             "   AAA  BBB  CCC\n",
             "0    4   10  100\n",
@@ -2226,6 +2206,19 @@
             "2    6   30  -30\n"
           ]
         }
+      ],
+      "source": [
+        "df = pd.DataFrame(\n",
+        "        {\"AAA\": [4, 5, 6, 7], \"BBB\": [10, 20, 30, 40], \"CCC\": [100, 50, -30, -50]}\n",
+        ")\n",
+        "\n",
+        "print(df)\n",
+        "print()\n",
+        "\n",
+        "print(df.loc[df.AAA>=5])\n",
+        "print()\n",
+        "\n",
+        "print(df.loc[df.AAA>=5].loc[df.BBB<=30])"
       ]
     },
     {
@@ -2239,36 +2232,18 @@
     },
     {
       "cell_type": "code",
+      "execution_count": 34,
       "metadata": {
         "colab": {
           "base_uri": "https://localhost:8080/"
         },
         "id": "Fuzuqp-7dJLx",
-        "outputId": "130c4d18-59f4-42ad-f3c6-ce5fa49aede2"
+        "outputId": "198d95f9-8a83-459b-9352-e0a76b131046"
       },
-      "source": [
-        "df = pd.DataFrame(\n",
-        "        {\"AAA\": [4, 5, 6, 7], \"BBB\": [10, 20, 30, 40], \"CCC\": [100, 50, -30, -50]}\n",
-        ")\n",
-        "\n",
-        "print(df)\n",
-        "print()\n",
-        "\n",
-        "print(df[\"AAA\"])\n",
-        "print(\"type =\", type(df[\"AAA\"])) # Series이다.\n",
-        "print()\n",
-        "\n",
-        "print(df[[\"AAA\"]]) # 컬럼명의 리스트를 주면 DataFrame이다.\n",
-        "print(\"type =\", type(df[[\"AAA\"]]))\n",
-        "print()\n",
-        "\n",
-        "print(df[[\"AAA\", \"CCC\"]])"
-      ],
-      "execution_count": 380,
       "outputs": [
         {
-          "output_type": "stream",
           "name": "stdout",
+          "output_type": "stream",
           "text": [
             "   AAA  BBB  CCC\n",
             "0    4   10  100\n",
@@ -2297,6 +2272,24 @@
             "3    7  -50\n"
           ]
         }
+      ],
+      "source": [
+        "df = pd.DataFrame(\n",
+        "        {\"AAA\": [4, 5, 6, 7], \"BBB\": [10, 20, 30, 40], \"CCC\": [100, 50, -30, -50]}\n",
+        ")\n",
+        "\n",
+        "print(df)\n",
+        "print()\n",
+        "\n",
+        "print(df[\"AAA\"])\n",
+        "print(\"type =\", type(df[\"AAA\"])) # Series이다.\n",
+        "print()\n",
+        "\n",
+        "print(df[[\"AAA\"]]) # 컬럼명의 리스트를 주면 DataFrame이다.\n",
+        "print(\"type =\", type(df[[\"AAA\"]]))\n",
+        "print()\n",
+        "\n",
+        "print(df[[\"AAA\", \"CCC\"]])"
       ]
     },
     {
@@ -2319,29 +2312,18 @@
     },
     {
       "cell_type": "code",
+      "execution_count": 35,
       "metadata": {
         "colab": {
           "base_uri": "https://localhost:8080/"
         },
         "id": "QxRROe5N9Lj1",
-        "outputId": "9c0c9ab8-1382-4adc-bcff-ce8db7170eb2"
+        "outputId": "38933e04-4ace-47e1-e7fa-81621df363ee"
       },
-      "source": [
-        "df = pd.DataFrame(\n",
-        "        {\"AAA\": [4, 5, 6, 7], \"BBB\": [10, 20, 30, 40], \"CCC\": [100, 50, -30, -50]}\n",
-        ")\n",
-        "\n",
-        "print(df)\n",
-        "print()\n",
-        "\n",
-        "df.loc[df.AAA>=5, \"BBB\"] = -1\n",
-        "print(df)\n"
-      ],
-      "execution_count": 381,
       "outputs": [
         {
-          "output_type": "stream",
           "name": "stdout",
+          "output_type": "stream",
           "text": [
             "   AAA  BBB  CCC\n",
             "0    4   10  100\n",
@@ -2356,6 +2338,17 @@
             "3    7   -1  -50\n"
           ]
         }
+      ],
+      "source": [
+        "df = pd.DataFrame(\n",
+        "        {\"AAA\": [4, 5, 6, 7], \"BBB\": [10, 20, 30, 40], \"CCC\": [100, 50, -30, -50]}\n",
+        ")\n",
+        "\n",
+        "print(df)\n",
+        "print()\n",
+        "\n",
+        "df.loc[df.AAA>=5, \"BBB\"] = -1\n",
+        "print(df)\n"
       ]
     },
     {
@@ -2369,33 +2362,18 @@
     },
     {
       "cell_type": "code",
+      "execution_count": 36,
       "metadata": {
         "colab": {
           "base_uri": "https://localhost:8080/"
         },
         "id": "qYxQKNgwQZiw",
-        "outputId": "84f2a08a-e78e-46b4-bb8b-b163ce74b380"
+        "outputId": "f2505c4e-36dd-494a-d5d8-972169eccc3e"
       },
-      "source": [
-        "df = pd.DataFrame(\n",
-        "        {\"AAA\": [4, 5, 6, 7], \"BBB\": [10, 20, 30, 40], \"CCC\": [100, 50, -30, -50]}\n",
-        ")\n",
-        "\n",
-        "print(df)\n",
-        "print()\n",
-        "\n",
-        "filtered_index = df.loc[df.AAA>=5].loc[df.BBB<=30].index\n",
-        "print(\"filtered_index =\", filtered_index)\n",
-        "print()\n",
-        "\n",
-        "df.loc[filtered_index, 'BBB'] = -1\n",
-        "print(df)"
-      ],
-      "execution_count": 382,
       "outputs": [
         {
-          "output_type": "stream",
           "name": "stdout",
+          "output_type": "stream",
           "text": [
             "   AAA  BBB  CCC\n",
             "0    4   10  100\n",
@@ -2412,6 +2390,21 @@
             "3    7   40  -50\n"
           ]
         }
+      ],
+      "source": [
+        "df = pd.DataFrame(\n",
+        "        {\"AAA\": [4, 5, 6, 7], \"BBB\": [10, 20, 30, 40], \"CCC\": [100, 50, -30, -50]}\n",
+        ")\n",
+        "\n",
+        "print(df)\n",
+        "print()\n",
+        "\n",
+        "filtered_index = df.loc[df.AAA>=5].loc[df.BBB<=30].index\n",
+        "print(\"filtered_index =\", filtered_index)\n",
+        "print()\n",
+        "\n",
+        "df.loc[filtered_index, 'BBB'] = -1\n",
+        "print(df)"
       ]
     },
     {
@@ -2425,29 +2418,18 @@
     },
     {
       "cell_type": "code",
+      "execution_count": 37,
       "metadata": {
         "colab": {
           "base_uri": "https://localhost:8080/"
         },
         "id": "_zFS70S1S5om",
-        "outputId": "de02ac96-f0a0-4459-c80d-68cf066d69ad"
+        "outputId": "6578574e-f7a1-4582-cf23-791cf41f2af3"
       },
-      "source": [
-        "df = pd.DataFrame(\n",
-        "        {\"AAA\": [4, 5, 6, 7], \"BBB\": [10, 20, 30, 40], \"CCC\": [100, 50, -30, -50]}\n",
-        ")\n",
-        "\n",
-        "print(df)\n",
-        "print()\n",
-        "\n",
-        "df.loc[df.AAA>=5, [\"BBB\",\"CCC\"]] = -1\n",
-        "print(df)\n"
-      ],
-      "execution_count": 383,
       "outputs": [
         {
-          "output_type": "stream",
           "name": "stdout",
+          "output_type": "stream",
           "text": [
             "   AAA  BBB  CCC\n",
             "0    4   10  100\n",
@@ -2462,6 +2444,17 @@
             "3    7   -1   -1\n"
           ]
         }
+      ],
+      "source": [
+        "df = pd.DataFrame(\n",
+        "        {\"AAA\": [4, 5, 6, 7], \"BBB\": [10, 20, 30, 40], \"CCC\": [100, 50, -30, -50]}\n",
+        ")\n",
+        "\n",
+        "print(df)\n",
+        "print()\n",
+        "\n",
+        "df.loc[df.AAA>=5, [\"BBB\",\"CCC\"]] = -1\n",
+        "print(df)\n"
       ]
     },
     {
@@ -2475,34 +2468,18 @@
     },
     {
       "cell_type": "code",
+      "execution_count": 38,
       "metadata": {
         "colab": {
           "base_uri": "https://localhost:8080/"
         },
         "id": "vbMXo9fOT4p1",
-        "outputId": "49c4db72-a426-415d-cba3-791177d91526"
+        "outputId": "3b287868-ccd5-4f0e-e0f7-1a5cbcd6a19b"
       },
-      "source": [
-        "df = pd.DataFrame(\n",
-        "        {\"AAA\": [4, 5, 6, 7], \"BBB\": [10, 20, 30, 40], \"CCC\": [100, 50, -30, -50]}\n",
-        ")\n",
-        "\n",
-        "print(df)\n",
-        "print()\n",
-        "\n",
-        "\n",
-        "df.loc[df.AAA>=5, df.BBB] = 999\n",
-        "print(df)\n",
-        "\n",
-        "df.loc[df.AAA<5, df.BBB] = -999\n",
-        "print(df)\n",
-        "\n"
-      ],
-      "execution_count": 384,
       "outputs": [
         {
-          "output_type": "stream",
           "name": "stdout",
+          "output_type": "stream",
           "text": [
             "   AAA  BBB  CCC\n",
             "0    4   10  100\n",
@@ -2522,6 +2499,22 @@
             "3    7   40  -50  999.0  999.0  999.0  999.0\n"
           ]
         }
+      ],
+      "source": [
+        "df = pd.DataFrame(\n",
+        "        {\"AAA\": [4, 5, 6, 7], \"BBB\": [10, 20, 30, 40], \"CCC\": [100, 50, -30, -50]}\n",
+        ")\n",
+        "\n",
+        "print(df)\n",
+        "print()\n",
+        "\n",
+        "\n",
+        "df.loc[df.AAA>=5, df.BBB] = 999\n",
+        "print(df)\n",
+        "\n",
+        "df.loc[df.AAA<5, df.BBB] = -999\n",
+        "print(df)\n",
+        "\n"
       ]
     },
     {
@@ -2535,30 +2528,18 @@
     },
     {
       "cell_type": "code",
+      "execution_count": 39,
       "metadata": {
         "colab": {
           "base_uri": "https://localhost:8080/"
         },
         "id": "6NDrhafwUD1a",
-        "outputId": "5b8a42f0-ef6e-465d-e1e8-e3b2f86f74c7"
+        "outputId": "9c69a4d7-948b-4942-f614-d9ef06da6190"
       },
-      "source": [
-        "df = pd.DataFrame(\n",
-        "        {\"AAA\": [4, 5, 6, 7], \"BBB\": [10, 20, 30, 40], \"CCC\": [100, 50, -30, -50]}\n",
-        ")\n",
-        "\n",
-        "print(df)\n",
-        "print()\n",
-        "\n",
-        "df.BBB = np.where(df.AAA>=5, 999, -999)\n",
-        "print(df)\n",
-        "\n"
-      ],
-      "execution_count": 385,
       "outputs": [
         {
-          "output_type": "stream",
           "name": "stdout",
+          "output_type": "stream",
           "text": [
             "   AAA  BBB  CCC\n",
             "0    4   10  100\n",
@@ -2573,6 +2554,18 @@
             "3    7  999  -50\n"
           ]
         }
+      ],
+      "source": [
+        "df = pd.DataFrame(\n",
+        "        {\"AAA\": [4, 5, 6, 7], \"BBB\": [10, 20, 30, 40], \"CCC\": [100, 50, -30, -50]}\n",
+        ")\n",
+        "\n",
+        "print(df)\n",
+        "print()\n",
+        "\n",
+        "df.BBB = np.where(df.AAA>=5, 999, -999)\n",
+        "print(df)\n",
+        "\n"
       ]
     },
     {
@@ -2595,28 +2588,18 @@
     },
     {
       "cell_type": "code",
+      "execution_count": 40,
       "metadata": {
         "colab": {
           "base_uri": "https://localhost:8080/"
         },
         "id": "SueBbTrbap3Y",
-        "outputId": "5224049d-102c-469f-b273-1074e4896e5c"
+        "outputId": "3d1a8e74-544a-4b3a-b7b0-cb080a2e70d4"
       },
-      "source": [
-        "df = pd.DataFrame(\n",
-        "        {\"AAA\": [4, 5, 6, 7], \"BBB\": [10, 20, 30, 40], \"CCC\": [100, 50, -30, -50]}\n",
-        ")\n",
-        "\n",
-        "print(df)\n",
-        "print()\n",
-        "\n",
-        "print(df[df.AAA.isin([4, 5, 7])])\n"
-      ],
-      "execution_count": 386,
       "outputs": [
         {
-          "output_type": "stream",
           "name": "stdout",
+          "output_type": "stream",
           "text": [
             "   AAA  BBB  CCC\n",
             "0    4   10  100\n",
@@ -2630,6 +2613,16 @@
             "3    7   40  -50\n"
           ]
         }
+      ],
+      "source": [
+        "df = pd.DataFrame(\n",
+        "        {\"AAA\": [4, 5, 6, 7], \"BBB\": [10, 20, 30, 40], \"CCC\": [100, 50, -30, -50]}\n",
+        ")\n",
+        "\n",
+        "print(df)\n",
+        "print()\n",
+        "\n",
+        "print(df[df.AAA.isin([4, 5, 7])])\n"
       ]
     },
     {
@@ -2643,28 +2636,18 @@
     },
     {
       "cell_type": "code",
+      "execution_count": 41,
       "metadata": {
         "colab": {
           "base_uri": "https://localhost:8080/"
         },
         "id": "CuP77zjvZeMo",
-        "outputId": "e9d33861-76a9-4e82-be04-73cba89469b0"
+        "outputId": "871dfb4e-1314-4dd0-ff80-8143e99ad3f4"
       },
-      "source": [
-        "df = pd.DataFrame(\n",
-        "        {\"AAA\": [4, 5, 6, 7], \"BBB\": [10, 20, 30, 40], \"CCC\": [100, 50, -30, -50]}\n",
-        ")\n",
-        "\n",
-        "print(df)\n",
-        "print()\n",
-        "\n",
-        "print(df[df.index.isin([0, 1, 3])])\n"
-      ],
-      "execution_count": 387,
       "outputs": [
         {
-          "output_type": "stream",
           "name": "stdout",
+          "output_type": "stream",
           "text": [
             "   AAA  BBB  CCC\n",
             "0    4   10  100\n",
@@ -2678,6 +2661,16 @@
             "3    7   40  -50\n"
           ]
         }
+      ],
+      "source": [
+        "df = pd.DataFrame(\n",
+        "        {\"AAA\": [4, 5, 6, 7], \"BBB\": [10, 20, 30, 40], \"CCC\": [100, 50, -30, -50]}\n",
+        ")\n",
+        "\n",
+        "print(df)\n",
+        "print()\n",
+        "\n",
+        "print(df[df.index.isin([0, 1, 3])])\n"
       ]
     },
     {
@@ -2691,28 +2684,18 @@
     },
     {
       "cell_type": "code",
+      "execution_count": 42,
       "metadata": {
         "colab": {
           "base_uri": "https://localhost:8080/"
         },
         "id": "Tqd0LQQ9Z0l8",
-        "outputId": "69359b48-8185-4251-fd21-3fd5ae91a1ac"
+        "outputId": "f8ecf244-59da-4ecc-c650-10b8451d0bf3"
       },
-      "source": [
-        "df = pd.DataFrame(\n",
-        "        {\"AAA\": [4, 5, 6, 7], \"BBB\": [10, 20, 30, 40], \"CCC\": [100, 50, -30, -50]}\n",
-        ")\n",
-        "\n",
-        "print(df)\n",
-        "print()\n",
-        "\n",
-        "print(df[df.index%2!=0])\n"
-      ],
-      "execution_count": 388,
       "outputs": [
         {
-          "output_type": "stream",
           "name": "stdout",
+          "output_type": "stream",
           "text": [
             "   AAA  BBB  CCC\n",
             "0    4   10  100\n",
@@ -2725,6 +2708,16 @@
             "3    7   40  -50\n"
           ]
         }
+      ],
+      "source": [
+        "df = pd.DataFrame(\n",
+        "        {\"AAA\": [4, 5, 6, 7], \"BBB\": [10, 20, 30, 40], \"CCC\": [100, 50, -30, -50]}\n",
+        ")\n",
+        "\n",
+        "print(df)\n",
+        "print()\n",
+        "\n",
+        "print(df[df.index%2!=0])\n"
       ]
     },
     {
@@ -2747,30 +2740,18 @@
     },
     {
       "cell_type": "code",
+      "execution_count": 43,
       "metadata": {
         "colab": {
           "base_uri": "https://localhost:8080/"
         },
         "id": "-MIWNDy8bwLe",
-        "outputId": "efcf20a6-3aac-4bf8-f658-76bba82fdadc"
+        "outputId": "9e560f8b-1523-49d2-ba5a-54b3da19d9e4"
       },
-      "source": [
-        "df = pd.DataFrame(\n",
-        "        {\"AAA\": [4, 5, 6, 7], \"BBB\": [10, 20, 30, 40], \"CCC\": [100, 50, -30, -50]}\n",
-        ")\n",
-        "\n",
-        "print(df)\n",
-        "print()\n",
-        "\n",
-        "df[\"AAA_copied\"] = df[\"AAA\"]\n",
-        "\n",
-        "print(df)"
-      ],
-      "execution_count": 389,
       "outputs": [
         {
-          "output_type": "stream",
           "name": "stdout",
+          "output_type": "stream",
           "text": [
             "   AAA  BBB  CCC\n",
             "0    4   10  100\n",
@@ -2785,6 +2766,18 @@
             "3    7   40  -50           7\n"
           ]
         }
+      ],
+      "source": [
+        "df = pd.DataFrame(\n",
+        "        {\"AAA\": [4, 5, 6, 7], \"BBB\": [10, 20, 30, 40], \"CCC\": [100, 50, -30, -50]}\n",
+        ")\n",
+        "\n",
+        "print(df)\n",
+        "print()\n",
+        "\n",
+        "df[\"AAA_copied\"] = df[\"AAA\"]\n",
+        "\n",
+        "print(df)"
       ]
     },
     {
@@ -2798,32 +2791,18 @@
     },
     {
       "cell_type": "code",
+      "execution_count": 44,
       "metadata": {
         "colab": {
           "base_uri": "https://localhost:8080/"
         },
         "id": "cvvtLKuhZuCI",
-        "outputId": "55ce5431-f5de-4736-f0d1-e3bcd142d356"
+        "outputId": "ee32d36c-ddd1-4567-f6b9-83d63bb30cdc"
       },
-      "source": [
-        "df = pd.DataFrame(\n",
-        "        {\"AAA\": [4, 5, 6, 7], \"BBB\": [10, 20, 30, 40], \"CCC\": [100, 50, -30, -50]}\n",
-        ")\n",
-        "\n",
-        "print(df)\n",
-        "print()\n",
-        "\n",
-        "source_cols = df.columns\n",
-        "new_cols = [str(x) + \"_copied\" for x in source_cols]\n",
-        "df[new_cols] = df[source_cols]\n",
-        "\n",
-        "print(df)"
-      ],
-      "execution_count": 390,
       "outputs": [
         {
-          "output_type": "stream",
           "name": "stdout",
+          "output_type": "stream",
           "text": [
             "   AAA  BBB  CCC\n",
             "0    4   10  100\n",
@@ -2838,6 +2817,20 @@
             "3    7   40  -50           7          40         -50\n"
           ]
         }
+      ],
+      "source": [
+        "df = pd.DataFrame(\n",
+        "        {\"AAA\": [4, 5, 6, 7], \"BBB\": [10, 20, 30, 40], \"CCC\": [100, 50, -30, -50]}\n",
+        ")\n",
+        "\n",
+        "print(df)\n",
+        "print()\n",
+        "\n",
+        "source_cols = df.columns\n",
+        "new_cols = [str(x) + \"_copied\" for x in source_cols]\n",
+        "df[new_cols] = df[source_cols]\n",
+        "\n",
+        "print(df)"
       ]
     },
     {
@@ -2851,13 +2844,33 @@
     },
     {
       "cell_type": "code",
+      "execution_count": 45,
       "metadata": {
         "colab": {
           "base_uri": "https://localhost:8080/"
         },
         "id": "_fifAcS3ZeKQ",
-        "outputId": "b30ffdcc-7f47-4131-964e-7d801ebfd3a1"
+        "outputId": "81eb75b5-ccab-4b16-8502-318b10a6617a"
       },
+      "outputs": [
+        {
+          "name": "stdout",
+          "output_type": "stream",
+          "text": [
+            "   AAA  BBB  CCC\n",
+            "0    4   10  100\n",
+            "1    5   20   50\n",
+            "2    6   30  -30\n",
+            "3    7   40  -50\n",
+            "\n",
+            "   AAA  BBB  CCC AAA_encoded\n",
+            "0    4   10  100           A\n",
+            "1    5   20   50           C\n",
+            "2    6   30  -30           B\n",
+            "3    7   40  -50           C\n"
+          ]
+        }
+      ],
       "source": [
         "df = pd.DataFrame(\n",
         "        {\"AAA\": [4, 5, 6, 7], \"BBB\": [10, 20, 30, 40], \"CCC\": [100, 50, -30, -50]}\n",
@@ -2874,26 +2887,6 @@
         "df[\"AAA_encoded\"] = df[[\"AAA\"]].applymap(encode)\n",
         "\n",
         "print(df)"
-      ],
-      "execution_count": 391,
-      "outputs": [
-        {
-          "output_type": "stream",
-          "name": "stdout",
-          "text": [
-            "   AAA  BBB  CCC\n",
-            "0    4   10  100\n",
-            "1    5   20   50\n",
-            "2    6   30  -30\n",
-            "3    7   40  -50\n",
-            "\n",
-            "   AAA  BBB  CCC AAA_encoded\n",
-            "0    4   10  100           A\n",
-            "1    5   20   50           C\n",
-            "2    6   30  -30           B\n",
-            "3    7   40  -50           C\n"
-          ]
-        }
       ]
     },
     {
@@ -2907,30 +2900,18 @@
     },
     {
       "cell_type": "code",
+      "execution_count": 46,
       "metadata": {
         "colab": {
           "base_uri": "https://localhost:8080/"
         },
         "id": "a5czufvMkM_X",
-        "outputId": "b3e84454-ad0b-4216-e840-8735a457e798"
+        "outputId": "40e537e5-0237-49d2-adaa-24af2de79b42"
       },
-      "source": [
-        "df = pd.DataFrame(\n",
-        "        {\"AAA\": [4, 5, 6, 7], \"BBB\": [10, 20, 30, 40], \"CCC\": [100, 50, -30, -50]}\n",
-        ")\n",
-        "\n",
-        "print(df)\n",
-        "print()\n",
-        "\n",
-        "df[\"AAA_doubled\"] = df[\"AAA\"]*2.\n",
-        "\n",
-        "print(df)"
-      ],
-      "execution_count": 392,
       "outputs": [
         {
-          "output_type": "stream",
           "name": "stdout",
+          "output_type": "stream",
           "text": [
             "   AAA  BBB  CCC\n",
             "0    4   10  100\n",
@@ -2945,6 +2926,18 @@
             "3    7   40  -50         14.0\n"
           ]
         }
+      ],
+      "source": [
+        "df = pd.DataFrame(\n",
+        "        {\"AAA\": [4, 5, 6, 7], \"BBB\": [10, 20, 30, 40], \"CCC\": [100, 50, -30, -50]}\n",
+        ")\n",
+        "\n",
+        "print(df)\n",
+        "print()\n",
+        "\n",
+        "df[\"AAA_doubled\"] = df[\"AAA\"]*2.\n",
+        "\n",
+        "print(df)"
       ]
     },
     {
@@ -2958,30 +2951,18 @@
     },
     {
       "cell_type": "code",
+      "execution_count": 47,
       "metadata": {
         "colab": {
           "base_uri": "https://localhost:8080/"
         },
         "id": "w_gV0V4skiOp",
-        "outputId": "c7ef3ec6-a888-4099-8dfa-f8019eb29b7d"
+        "outputId": "8ef9c8a8-67f9-46c5-e2e9-7e368df504b5"
       },
-      "source": [
-        "df = pd.DataFrame(\n",
-        "        {\"AAA\": [4, 5, 6, 7], \"BBB\": [10, 20, 30, 40], \"CCC\": [100, 50, -30, -50]}\n",
-        ")\n",
-        "\n",
-        "print(df)\n",
-        "print()\n",
-        "\n",
-        "df.insert(1, 'AAA_doubled', df.AAA*2.)\n",
-        "\n",
-        "print(df)"
-      ],
-      "execution_count": 393,
       "outputs": [
         {
-          "output_type": "stream",
           "name": "stdout",
+          "output_type": "stream",
           "text": [
             "   AAA  BBB  CCC\n",
             "0    4   10  100\n",
@@ -2996,6 +2977,18 @@
             "3    7         14.0   40  -50\n"
           ]
         }
+      ],
+      "source": [
+        "df = pd.DataFrame(\n",
+        "        {\"AAA\": [4, 5, 6, 7], \"BBB\": [10, 20, 30, 40], \"CCC\": [100, 50, -30, -50]}\n",
+        ")\n",
+        "\n",
+        "print(df)\n",
+        "print()\n",
+        "\n",
+        "df.insert(1, 'AAA_doubled', df.AAA*2.)\n",
+        "\n",
+        "print(df)"
       ]
     },
     {
@@ -3018,30 +3011,18 @@
     },
     {
       "cell_type": "code",
+      "execution_count": 48,
       "metadata": {
         "colab": {
           "base_uri": "https://localhost:8080/"
         },
         "id": "yvGjk8pck6MV",
-        "outputId": "f75bfb37-878a-41af-e399-92db71399d6e"
+        "outputId": "f424ca49-2b78-4acd-eb88-709f15e51cab"
       },
-      "source": [
-        "df = pd.DataFrame(\n",
-        "        {\"AAA\": [4, 5, 6, 7], \"BBB\": [10, 20, 30, 40], \"CCC\": [100, 50, -30, -50]}\n",
-        ")\n",
-        "\n",
-        "print(df)\n",
-        "print()\n",
-        "\n",
-        "df.drop(columns=\"BBB\", inplace=True)\n",
-        "\n",
-        "print(df)"
-      ],
-      "execution_count": 394,
       "outputs": [
         {
-          "output_type": "stream",
           "name": "stdout",
+          "output_type": "stream",
           "text": [
             "   AAA  BBB  CCC\n",
             "0    4   10  100\n",
@@ -3056,6 +3037,18 @@
             "3    7  -50\n"
           ]
         }
+      ],
+      "source": [
+        "df = pd.DataFrame(\n",
+        "        {\"AAA\": [4, 5, 6, 7], \"BBB\": [10, 20, 30, 40], \"CCC\": [100, 50, -30, -50]}\n",
+        ")\n",
+        "\n",
+        "print(df)\n",
+        "print()\n",
+        "\n",
+        "df.drop(columns=\"BBB\", inplace=True)\n",
+        "\n",
+        "print(df)"
       ]
     },
     {
@@ -3069,30 +3062,18 @@
     },
     {
       "cell_type": "code",
+      "execution_count": 49,
       "metadata": {
         "colab": {
           "base_uri": "https://localhost:8080/"
         },
         "id": "t0_fCRaplEQI",
-        "outputId": "81afcaef-7d0f-4539-8bfb-1d7608797f2e"
+        "outputId": "5206acb5-fd86-4bd5-c1a0-2b3ddfd8c101"
       },
-      "source": [
-        "df = pd.DataFrame(\n",
-        "        {\"AAA\": [4, 5, 6, 7], \"BBB\": [10, 20, 30, 40], \"CCC\": [100, 50, -30, -50]}\n",
-        ")\n",
-        "\n",
-        "print(df)\n",
-        "print()\n",
-        "\n",
-        "df.drop(columns=[\"BBB\", \"CCC\"], inplace=True)\n",
-        "\n",
-        "print(df)"
-      ],
-      "execution_count": 395,
       "outputs": [
         {
-          "output_type": "stream",
           "name": "stdout",
+          "output_type": "stream",
           "text": [
             "   AAA  BBB  CCC\n",
             "0    4   10  100\n",
@@ -3107,6 +3088,18 @@
             "3    7\n"
           ]
         }
+      ],
+      "source": [
+        "df = pd.DataFrame(\n",
+        "        {\"AAA\": [4, 5, 6, 7], \"BBB\": [10, 20, 30, 40], \"CCC\": [100, 50, -30, -50]}\n",
+        ")\n",
+        "\n",
+        "print(df)\n",
+        "print()\n",
+        "\n",
+        "df.drop(columns=[\"BBB\", \"CCC\"], inplace=True)\n",
+        "\n",
+        "print(df)"
       ]
     },
     {
@@ -3128,7 +3121,7 @@
         "\n",
         "하지 않는다.\n",
         "\n",
-        "만약 필요하다면 list에 추가하고 최종적으로 DataFrmae 생성.\n",
+        "만약 필요하다면 list에 추가하고 최종적으로 DataFrame 생성.\n",
         "\n",
         "```\n",
         "data = []\n",
@@ -3150,38 +3143,18 @@
     },
     {
       "cell_type": "code",
+      "execution_count": 50,
       "metadata": {
         "colab": {
           "base_uri": "https://localhost:8080/"
         },
         "id": "3fvauA9eoJYw",
-        "outputId": "fb4b24e5-cd41-465c-9ad1-1f84925a9bb6"
+        "outputId": "e10e49cb-c625-4f9d-951d-5404c8373318"
       },
-      "source": [
-        "df = pd.DataFrame(\n",
-        "        {\"AAA\": [4, 5, 6, 7], \"BBB\": [10, 20, 30, 40], \"CCC\": [100, 50, -30, -50]}\n",
-        ")\n",
-        "\n",
-        "df2 = pd.DataFrame(\n",
-        "        {\"AAA\": [8, 9], \"BBB\": [80, 90], \"CCC\": [80, 90]}\n",
-        ")\n",
-        "\n",
-        "\n",
-        "print(df)\n",
-        "print()\n",
-        "\n",
-        "print(df2)\n",
-        "print()\n",
-        "\n",
-        "df = df.append(df2) # inplace 못한다.\n",
-        "\n",
-        "print(df)"
-      ],
-      "execution_count": 396,
       "outputs": [
         {
-          "output_type": "stream",
           "name": "stdout",
+          "output_type": "stream",
           "text": [
             "   AAA  BBB  CCC\n",
             "0    4   10  100\n",
@@ -3202,6 +3175,26 @@
             "1    9   90   90\n"
           ]
         }
+      ],
+      "source": [
+        "df = pd.DataFrame(\n",
+        "        {\"AAA\": [4, 5, 6, 7], \"BBB\": [10, 20, 30, 40], \"CCC\": [100, 50, -30, -50]}\n",
+        ")\n",
+        "\n",
+        "df2 = pd.DataFrame(\n",
+        "        {\"AAA\": [8, 9], \"BBB\": [80, 90], \"CCC\": [80, 90]}\n",
+        ")\n",
+        "\n",
+        "\n",
+        "print(df)\n",
+        "print()\n",
+        "\n",
+        "print(df2)\n",
+        "print()\n",
+        "\n",
+        "df = df.append(df2) # inplace 못한다.\n",
+        "\n",
+        "print(df)"
       ]
     },
     {
@@ -3215,13 +3208,41 @@
     },
     {
       "cell_type": "code",
+      "execution_count": 51,
       "metadata": {
         "colab": {
           "base_uri": "https://localhost:8080/"
         },
         "id": "z2VrSJaopBI3",
-        "outputId": "dface6f6-75f4-436d-dac6-b6de481017b9"
+        "outputId": "7254df20-fd4a-4fd2-c405-8cc2df66f09c"
       },
+      "outputs": [
+        {
+          "name": "stdout",
+          "output_type": "stream",
+          "text": [
+            "   AAA  BBB  CCC\n",
+            "0    4   10  100\n",
+            "1    5   20   50\n",
+            "\n",
+            "   AAA  BBB  CCC\n",
+            "0    6   30  -30\n",
+            "1    7   40  -50\n",
+            "\n",
+            "   AAA  BBB  CCC\n",
+            "0    8   80   80\n",
+            "1    9   90   90\n",
+            "\n",
+            "   AAA  BBB  CCC\n",
+            "0    4   10  100\n",
+            "1    5   20   50\n",
+            "2    6   30  -30\n",
+            "3    7   40  -50\n",
+            "4    8   80   80\n",
+            "5    9   90   90\n"
+          ]
+        }
+      ],
       "source": [
         "df1 = pd.DataFrame(\n",
         "        {\"AAA\": [4, 5], \"BBB\": [10, 20], \"CCC\": [100, 50]}\n",
@@ -3250,72 +3271,31 @@
         "#df = df1.append(df2).append(df3)\n",
         "\n",
         "print(df)"
-      ],
-      "execution_count": 397,
-      "outputs": [
-        {
-          "output_type": "stream",
-          "name": "stdout",
-          "text": [
-            "   AAA  BBB  CCC\n",
-            "0    4   10  100\n",
-            "1    5   20   50\n",
-            "\n",
-            "   AAA  BBB  CCC\n",
-            "0    6   30  -30\n",
-            "1    7   40  -50\n",
-            "\n",
-            "   AAA  BBB  CCC\n",
-            "0    8   80   80\n",
-            "1    9   90   90\n",
-            "\n",
-            "   AAA  BBB  CCC\n",
-            "0    4   10  100\n",
-            "1    5   20   50\n",
-            "2    6   30  -30\n",
-            "3    7   40  -50\n",
-            "4    8   80   80\n",
-            "5    9   90   90\n"
-          ]
-        }
       ]
     },
     {
       "cell_type": "markdown",
-      "source": [
-        "### column 수가 다른 dataframe 합치기"
-      ],
       "metadata": {
         "id": "fDaNl2hOwIj2"
-      }
+      },
+      "source": [
+        "### column 수가 다른 dataframe 합치기"
+      ]
     },
     {
       "cell_type": "code",
-      "source": [
-        "df1 = pd.DataFrame(\n",
-        "        {\"AAA\": [4, 5, 6, 7], \"BBB\": [10, 20, 30, 40], \"CCC\": [100, 50, -30, -50]}\n",
-        ")\n",
-        "\n",
-        "df2 = pd.DataFrame(\n",
-        "        {\"AAA\": [4, 5, 6, 7], \"BBB\": [10, 20, 30, 40]}\n",
-        ")\n",
-        "\n",
-        "df = pd.concat([df1, df2])\n",
-        "print(df)\n",
-        "print()\n"
-      ],
+      "execution_count": 52,
       "metadata": {
-        "id": "8wa4eS_xwOat",
-        "outputId": "0d5e7614-67e3-4876-805c-831ccfcff53e",
         "colab": {
           "base_uri": "https://localhost:8080/"
-        }
+        },
+        "id": "8wa4eS_xwOat",
+        "outputId": "98a9cfd6-f678-4dc4-8c92-6e03a8a28d2e"
       },
-      "execution_count": 398,
       "outputs": [
         {
-          "output_type": "stream",
           "name": "stdout",
+          "output_type": "stream",
           "text": [
             "   AAA  BBB    CCC\n",
             "0    4   10  100.0\n",
@@ -3329,6 +3309,19 @@
             "\n"
           ]
         }
+      ],
+      "source": [
+        "df1 = pd.DataFrame(\n",
+        "        {\"AAA\": [4, 5, 6, 7], \"BBB\": [10, 20, 30, 40], \"CCC\": [100, 50, -30, -50]}\n",
+        ")\n",
+        "\n",
+        "df2 = pd.DataFrame(\n",
+        "        {\"AAA\": [4, 5, 6, 7], \"BBB\": [10, 20, 30, 40]}\n",
+        ")\n",
+        "\n",
+        "df = pd.concat([df1, df2])\n",
+        "print(df)\n",
+        "print()\n"
       ]
     },
     {
@@ -3351,30 +3344,18 @@
     },
     {
       "cell_type": "code",
+      "execution_count": 53,
       "metadata": {
         "colab": {
           "base_uri": "https://localhost:8080/"
         },
         "id": "ilSsnCsZk6Jb",
-        "outputId": "c94ff8b7-f036-462f-86b1-fcfe61ecf306"
+        "outputId": "2496d521-da71-4f72-f71e-192770837be1"
       },
-      "source": [
-        "df = pd.DataFrame(\n",
-        "        {\"AAA\": [4, 5, 6, 7], \"BBB\": [10, 20, 30, 40], \"CCC\": [100, 50, -30, -50]}\n",
-        ")\n",
-        "\n",
-        "print(df)\n",
-        "print()\n",
-        "\n",
-        "df.drop(1, inplace=True)\n",
-        "\n",
-        "print(df)"
-      ],
-      "execution_count": 399,
       "outputs": [
         {
-          "output_type": "stream",
           "name": "stdout",
+          "output_type": "stream",
           "text": [
             "   AAA  BBB  CCC\n",
             "0    4   10  100\n",
@@ -3388,6 +3369,18 @@
             "3    7   40  -50\n"
           ]
         }
+      ],
+      "source": [
+        "df = pd.DataFrame(\n",
+        "        {\"AAA\": [4, 5, 6, 7], \"BBB\": [10, 20, 30, 40], \"CCC\": [100, 50, -30, -50]}\n",
+        ")\n",
+        "\n",
+        "print(df)\n",
+        "print()\n",
+        "\n",
+        "df.drop(1, inplace=True)\n",
+        "\n",
+        "print(df)"
       ]
     },
     {
@@ -3401,30 +3394,18 @@
     },
     {
       "cell_type": "code",
+      "execution_count": 54,
       "metadata": {
         "colab": {
           "base_uri": "https://localhost:8080/"
         },
         "id": "ADQkGE2_k6FK",
-        "outputId": "e1491e63-c604-41f8-bbb9-717dad9ef899"
+        "outputId": "6b387a35-2c4b-4cbf-ccb3-67da234715d7"
       },
-      "source": [
-        "df = pd.DataFrame(\n",
-        "        {\"AAA\": [4, 5, 6, 7], \"BBB\": [10, 20, 30, 40], \"CCC\": [100, 50, -30, -50]}\n",
-        ")\n",
-        "\n",
-        "print(df)\n",
-        "print()\n",
-        "\n",
-        "df.drop([1,3], inplace=True)\n",
-        "\n",
-        "print(df)"
-      ],
-      "execution_count": 400,
       "outputs": [
         {
-          "output_type": "stream",
           "name": "stdout",
+          "output_type": "stream",
           "text": [
             "   AAA  BBB  CCC\n",
             "0    4   10  100\n",
@@ -3437,17 +3418,47 @@
             "2    6   30  -30\n"
           ]
         }
+      ],
+      "source": [
+        "df = pd.DataFrame(\n",
+        "        {\"AAA\": [4, 5, 6, 7], \"BBB\": [10, 20, 30, 40], \"CCC\": [100, 50, -30, -50]}\n",
+        ")\n",
+        "\n",
+        "print(df)\n",
+        "print()\n",
+        "\n",
+        "df.drop([1,3], inplace=True)\n",
+        "\n",
+        "print(df)"
       ]
     },
     {
       "cell_type": "code",
+      "execution_count": 55,
       "metadata": {
         "colab": {
           "base_uri": "https://localhost:8080/"
         },
         "id": "TqT2xntWnLB3",
-        "outputId": "1f2e173d-19ec-4091-e83b-bcd17c25e5d7"
+        "outputId": "2a6911fe-549a-4e44-feb1-584c05918e95"
       },
+      "outputs": [
+        {
+          "name": "stdout",
+          "output_type": "stream",
+          "text": [
+            "   AAA  BBB  CCC\n",
+            "0    4   10  100\n",
+            "1    5   20   50\n",
+            "2    6   30  -30\n",
+            "3    7   40  -50\n",
+            "\n",
+            "   AAA  BBB  CCC\n",
+            "0    4   10  100\n",
+            "2    6   30  -30\n"
+          ]
+        }
+      ],
       "source": [
         "df = pd.DataFrame(\n",
         "        {\"AAA\": [4, 5, 6, 7], \"BBB\": [10, 20, 30, 40], \"CCC\": [100, 50, -30, -50]}\n",
@@ -3461,24 +3472,6 @@
         "df.drop(target_indexes, inplace=True)\n",
         "\n",
         "print(df)"
-      ],
-      "execution_count": 401,
-      "outputs": [
-        {
-          "output_type": "stream",
-          "name": "stdout",
-          "text": [
-            "   AAA  BBB  CCC\n",
-            "0    4   10  100\n",
-            "1    5   20   50\n",
-            "2    6   30  -30\n",
-            "3    7   40  -50\n",
-            "\n",
-            "   AAA  BBB  CCC\n",
-            "0    4   10  100\n",
-            "2    6   30  -30\n"
-          ]
-        }
       ]
     },
     {
@@ -3492,13 +3485,33 @@
     },
     {
       "cell_type": "code",
+      "execution_count": 56,
       "metadata": {
         "colab": {
           "base_uri": "https://localhost:8080/"
         },
         "id": "BQkB7uccnJIu",
-        "outputId": "6ee675f8-dab4-4c5a-a98f-a2afd9a037e7"
+        "outputId": "a6d6193a-ae1d-49d4-bfc2-6a5db1b62d11"
       },
+      "outputs": [
+        {
+          "name": "stdout",
+          "output_type": "stream",
+          "text": [
+            "   AAA  BBB  CCC\n",
+            "0    4   10  100\n",
+            "1    5   20   50\n",
+            "2    6   30  -30\n",
+            "3    7   40  -50\n",
+            "\n",
+            "Int64Index([2, 3], dtype='int64')\n",
+            "\n",
+            "   AAA  BBB  CCC\n",
+            "0    4   10  100\n",
+            "1    5   20   50\n"
+          ]
+        }
+      ],
       "source": [
         "df = pd.DataFrame(\n",
         "        {\"AAA\": [4, 5, 6, 7], \"BBB\": [10, 20, 30, 40], \"CCC\": [100, 50, -30, -50]}\n",
@@ -3514,12 +3527,22 @@
         "df.drop(target_indexes, inplace=True)\n",
         "\n",
         "print(df)"
-      ],
-      "execution_count": 402,
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 57,
+      "metadata": {
+        "colab": {
+          "base_uri": "https://localhost:8080/"
+        },
+        "id": "4NfOe1uJmlvn",
+        "outputId": "af3b8fe1-802b-4dc1-cb25-606e79aab9d8"
+      },
       "outputs": [
         {
-          "output_type": "stream",
           "name": "stdout",
+          "output_type": "stream",
           "text": [
             "   AAA  BBB  CCC\n",
             "0    4   10  100\n",
@@ -3527,24 +3550,12 @@
             "2    6   30  -30\n",
             "3    7   40  -50\n",
             "\n",
-            "Int64Index([2, 3], dtype='int64')\n",
-            "\n",
             "   AAA  BBB  CCC\n",
             "0    4   10  100\n",
             "1    5   20   50\n"
           ]
         }
-      ]
-    },
-    {
-      "cell_type": "code",
-      "metadata": {
-        "colab": {
-          "base_uri": "https://localhost:8080/"
-        },
-        "id": "4NfOe1uJmlvn",
-        "outputId": "28c394ef-3fdb-46d5-94d2-3a90f972f283"
-      },
+      ],
       "source": [
         "df = pd.DataFrame(\n",
         "        {\"AAA\": [4, 5, 6, 7], \"BBB\": [10, 20, 30, 40], \"CCC\": [100, 50, -30, -50]}\n",
@@ -3556,24 +3567,6 @@
         "df.drop(df.loc[df.AAA>5].index, inplace=True)\n",
         "\n",
         "print(df)"
-      ],
-      "execution_count": 403,
-      "outputs": [
-        {
-          "output_type": "stream",
-          "name": "stdout",
-          "text": [
-            "   AAA  BBB  CCC\n",
-            "0    4   10  100\n",
-            "1    5   20   50\n",
-            "2    6   30  -30\n",
-            "3    7   40  -50\n",
-            "\n",
-            "   AAA  BBB  CCC\n",
-            "0    4   10  100\n",
-            "1    5   20   50\n"
-          ]
-        }
       ]
     },
     {
@@ -3596,34 +3589,18 @@
     },
     {
       "cell_type": "code",
+      "execution_count": 58,
       "metadata": {
         "colab": {
           "base_uri": "https://localhost:8080/"
         },
         "id": "JkfC2s3Ge0CG",
-        "outputId": "85302530-0296-4fa5-d663-5abf4eded405"
+        "outputId": "8be82630-4f86-4be2-e862-5e50fb97b5b2"
       },
-      "source": [
-        "df = pd.DataFrame(\n",
-        "        {\"AAA\": [4, 5, 6, 7], \"BBB\": [10, 20, 35, 10], \"CCC\": [100, 50, -30, -50]}\n",
-        ")\n",
-        "\n",
-        "print(df)\n",
-        "print()\n",
-        "\n",
-        "print(\"sort by BBB\")\n",
-        "print(df.sort_values(by=\"BBB\"))\n",
-        "print()\n",
-        "\n",
-        "print(\"sort by BBB, CCC\")\n",
-        "print(df.sort_values(by=[\"BBB\", \"CCC\"]))\n",
-        "print()\n"
-      ],
-      "execution_count": 404,
       "outputs": [
         {
-          "output_type": "stream",
           "name": "stdout",
+          "output_type": "stream",
           "text": [
             "   AAA  BBB  CCC\n",
             "0    4   10  100\n",
@@ -3647,6 +3624,22 @@
             "\n"
           ]
         }
+      ],
+      "source": [
+        "df = pd.DataFrame(\n",
+        "        {\"AAA\": [4, 5, 6, 7], \"BBB\": [10, 20, 35, 10], \"CCC\": [100, 50, -30, -50]}\n",
+        ")\n",
+        "\n",
+        "print(df)\n",
+        "print()\n",
+        "\n",
+        "print(\"sort by BBB\")\n",
+        "print(df.sort_values(by=\"BBB\"))\n",
+        "print()\n",
+        "\n",
+        "print(\"sort by BBB, CCC\")\n",
+        "print(df.sort_values(by=[\"BBB\", \"CCC\"]))\n",
+        "print()\n"
       ]
     },
     {
@@ -3660,39 +3653,18 @@
     },
     {
       "cell_type": "code",
+      "execution_count": 59,
       "metadata": {
         "colab": {
           "base_uri": "https://localhost:8080/"
         },
         "id": "uNeH3HicXTRu",
-        "outputId": "a657066f-ebb0-4f48-d6a1-9657db2fb2d2"
+        "outputId": "7c1a370c-3252-4f7b-ae29-ca9de6639078"
       },
-      "source": [
-        "df = pd.DataFrame(\n",
-        "        {\"AAA\": [4, 5, 6, 7], \"BBB\": [10, 20, 30, 40], \"CCC\": [100, 50, -30, -50]}\n",
-        ")\n",
-        "\n",
-        "print(df)\n",
-        "print()\n",
-        "\n",
-        "target_value = 43.0\n",
-        "\n",
-        "abs_value = (df.CCC - target_value).abs()\n",
-        "print(\"abs_value\")\n",
-        "print(abs_value)\n",
-        "print()\n",
-        "\n",
-        "print(\"abs_value.argsort()\")\n",
-        "print(abs_value.argsort())\n",
-        "print()\n",
-        "\n",
-        "print(df.loc[(df.CCC - target_value).abs().argsort()])"
-      ],
-      "execution_count": 405,
       "outputs": [
         {
-          "output_type": "stream",
           "name": "stdout",
+          "output_type": "stream",
           "text": [
             "   AAA  BBB  CCC\n",
             "0    4   10  100\n",
@@ -3721,6 +3693,27 @@
             "3    7   40  -50\n"
           ]
         }
+      ],
+      "source": [
+        "df = pd.DataFrame(\n",
+        "        {\"AAA\": [4, 5, 6, 7], \"BBB\": [10, 20, 30, 40], \"CCC\": [100, 50, -30, -50]}\n",
+        ")\n",
+        "\n",
+        "print(df)\n",
+        "print()\n",
+        "\n",
+        "target_value = 43.0\n",
+        "\n",
+        "abs_value = (df.CCC - target_value).abs()\n",
+        "print(\"abs_value\")\n",
+        "print(abs_value)\n",
+        "print()\n",
+        "\n",
+        "print(\"abs_value.argsort()\")\n",
+        "print(abs_value.argsort())\n",
+        "print()\n",
+        "\n",
+        "print(df.loc[(df.CCC - target_value).abs().argsort()])"
       ]
     },
     {
@@ -3734,28 +3727,18 @@
     },
     {
       "cell_type": "code",
+      "execution_count": 60,
       "metadata": {
         "colab": {
           "base_uri": "https://localhost:8080/"
         },
         "id": "zaVOOS6bZeGQ",
-        "outputId": "e3e9229c-faa8-4501-8133-5d3f31cb9c85"
+        "outputId": "4ab6439f-e57f-4714-bb3f-72a4c51709ef"
       },
-      "source": [
-        "df = pd.DataFrame(\n",
-        "   {\"AAA\": [1, 1, 1, 2, 2, 2, 3, 3], \"BBB\": [2, 1, 3, 4, 5, 1, 2, 3]}\n",
-        ")\n",
-        "\n",
-        "print(df)\n",
-        "print()\n",
-        "\n",
-        "print(df.loc[df.groupby(\"AAA\")[\"BBB\"].idxmin()])"
-      ],
-      "execution_count": 406,
       "outputs": [
         {
-          "output_type": "stream",
           "name": "stdout",
+          "output_type": "stream",
           "text": [
             "   AAA  BBB\n",
             "0    1    2\n",
@@ -3773,18 +3756,26 @@
             "6    3    2\n"
           ]
         }
+      ],
+      "source": [
+        "df = pd.DataFrame(\n",
+        "   {\"AAA\": [1, 1, 1, 2, 2, 2, 3, 3], \"BBB\": [2, 1, 3, 4, 5, 1, 2, 3]}\n",
+        ")\n",
+        "\n",
+        "print(df)\n",
+        "print()\n",
+        "\n",
+        "print(df.loc[df.groupby(\"AAA\")[\"BBB\"].idxmin()])"
       ]
     },
     {
       "cell_type": "code",
+      "execution_count": 60,
       "metadata": {
         "id": "xUniVvQZsuun"
       },
-      "source": [
-        ""
-      ],
-      "execution_count": 406,
-      "outputs": []
+      "outputs": [],
+      "source": []
     },
     {
       "cell_type": "markdown",
@@ -3807,34 +3798,31 @@
     },
     {
       "cell_type": "code",
+      "execution_count": 61,
       "metadata": {
         "id": "DbQbR2vdBDfT"
       },
+      "outputs": [],
       "source": [
         "df = pd.DataFrame(\n",
         "   {\"AAA\": [1, 1, 1, 2, 2, 2, 3, 3], \"BBB\": [\"A\", \"B\", \"C\", \"A\", \"A\", \"C\", \"B\", \"A\"]}\n",
         ")"
-      ],
-      "execution_count": 407,
-      "outputs": []
+      ]
     },
     {
       "cell_type": "code",
+      "execution_count": 62,
       "metadata": {
         "colab": {
           "base_uri": "https://localhost:8080/"
         },
         "id": "Y2kIePNwBk9Z",
-        "outputId": "89693b82-3ed7-4341-b752-cbf697c291e9"
+        "outputId": "195b11fa-f897-4552-ca5a-4d1594ce3f88"
       },
-      "source": [
-        "df.info()"
-      ],
-      "execution_count": 408,
       "outputs": [
         {
-          "output_type": "stream",
           "name": "stdout",
+          "output_type": "stream",
           "text": [
             "<class 'pandas.core.frame.DataFrame'>\n",
             "RangeIndex: 8 entries, 0 to 7\n",
@@ -3847,36 +3835,36 @@
             "memory usage: 256.0+ bytes\n"
           ]
         }
+      ],
+      "source": [
+        "df.info()"
       ]
     },
     {
       "cell_type": "code",
+      "execution_count": 63,
       "metadata": {
         "id": "XvpI4eewBbtK"
       },
+      "outputs": [],
       "source": [
         "df.BBB = df.BBB.astype('category')"
-      ],
-      "execution_count": 409,
-      "outputs": []
+      ]
     },
     {
       "cell_type": "code",
+      "execution_count": 64,
       "metadata": {
         "colab": {
           "base_uri": "https://localhost:8080/"
         },
         "id": "DPadMZMRBjCT",
-        "outputId": "404ae2c6-4082-4734-8637-6fd456da1197"
+        "outputId": "53dd0e79-6f85-4256-ca3f-1311006e8654"
       },
-      "source": [
-        "df.info()"
-      ],
-      "execution_count": 410,
       "outputs": [
         {
-          "output_type": "stream",
           "name": "stdout",
+          "output_type": "stream",
           "text": [
             "<class 'pandas.core.frame.DataFrame'>\n",
             "RangeIndex: 8 entries, 0 to 7\n",
@@ -3886,43 +3874,42 @@
             " 0   AAA     8 non-null      int64   \n",
             " 1   BBB     8 non-null      category\n",
             "dtypes: category(1), int64(1)\n",
-            "memory usage: 304.0 bytes\n"
+            "memory usage: 332.0 bytes\n"
           ]
         }
+      ],
+      "source": [
+        "df.info()"
       ]
     },
     {
       "cell_type": "code",
+      "execution_count": 65,
       "metadata": {
         "id": "TIslm4b0Bq37"
       },
+      "outputs": [],
       "source": [
         "df['BBB_code'] = df.BBB.cat.codes"
-      ],
-      "execution_count": 411,
-      "outputs": []
+      ]
     },
     {
       "cell_type": "code",
+      "execution_count": 66,
       "metadata": {
         "colab": {
           "base_uri": "https://localhost:8080/",
-          "height": 297
+          "height": 300
         },
         "id": "1-EmRWhZBu2j",
-        "outputId": "9185efa4-96f5-4d41-f7ed-f7de3ef6ae74"
+        "outputId": "9ebc47aa-0501-48b8-ea38-174398021dae"
       },
-      "source": [
-        "df"
-      ],
-      "execution_count": 412,
       "outputs": [
         {
-          "output_type": "execute_result",
           "data": {
             "text/html": [
               "\n",
-              "  <div id=\"df-b8791336-f392-493c-858e-981959c2df6c\">\n",
+              "  <div id=\"df-7429e125-a1f3-4710-b900-cfad481b9364\">\n",
               "    <div class=\"colab-df-container\">\n",
               "      <div>\n",
               "<style scoped>\n",
@@ -3999,7 +3986,7 @@
               "  </tbody>\n",
               "</table>\n",
               "</div>\n",
-              "      <button class=\"colab-df-convert\" onclick=\"convertToInteractive('df-b8791336-f392-493c-858e-981959c2df6c')\"\n",
+              "      <button class=\"colab-df-convert\" onclick=\"convertToInteractive('df-7429e125-a1f3-4710-b900-cfad481b9364')\"\n",
               "              title=\"Convert this dataframe to an interactive table.\"\n",
               "              style=\"display:none;\">\n",
               "        \n",
@@ -4050,12 +4037,12 @@
               "\n",
               "      <script>\n",
               "        const buttonEl =\n",
-              "          document.querySelector('#df-b8791336-f392-493c-858e-981959c2df6c button.colab-df-convert');\n",
+              "          document.querySelector('#df-7429e125-a1f3-4710-b900-cfad481b9364 button.colab-df-convert');\n",
               "        buttonEl.style.display =\n",
               "          google.colab.kernel.accessAllowed ? 'block' : 'none';\n",
               "\n",
               "        async function convertToInteractive(key) {\n",
-              "          const element = document.querySelector('#df-b8791336-f392-493c-858e-981959c2df6c');\n",
+              "          const element = document.querySelector('#df-7429e125-a1f3-4710-b900-cfad481b9364');\n",
               "          const dataTable =\n",
               "            await google.colab.kernel.invokeFunction('convertToInteractive',\n",
               "                                                     [key], {});\n",
@@ -4088,9 +4075,13 @@
               "7    3   A         0"
             ]
           },
+          "execution_count": 66,
           "metadata": {},
-          "execution_count": 412
+          "output_type": "execute_result"
         }
+      ],
+      "source": [
+        "df"
       ]
     },
     {
@@ -4104,34 +4095,31 @@
     },
     {
       "cell_type": "code",
+      "execution_count": 67,
       "metadata": {
         "id": "zYri1TmJB9n8"
       },
+      "outputs": [],
       "source": [
         "df = pd.DataFrame(\n",
         "   {\"AAA\": [1, 1, 1, 2, 2, 2, 3, 3], \"BBB\": [\"A\", \"B\", \"C\", \"A\", \"A\", \"C\", \"B\", \"A\"]}\n",
         ")"
-      ],
-      "execution_count": 413,
-      "outputs": []
+      ]
     },
     {
       "cell_type": "code",
+      "execution_count": 68,
       "metadata": {
         "colab": {
           "base_uri": "https://localhost:8080/"
         },
         "id": "fNtWbYH7B9n-",
-        "outputId": "f370df39-946a-4d5a-a37b-f31e4a33d294"
+        "outputId": "9d15fd82-8033-42a9-de29-2f7621aa9e22"
       },
-      "source": [
-        "df.info()"
-      ],
-      "execution_count": 414,
       "outputs": [
         {
-          "output_type": "stream",
           "name": "stdout",
+          "output_type": "stream",
           "text": [
             "<class 'pandas.core.frame.DataFrame'>\n",
             "RangeIndex: 8 entries, 0 to 7\n",
@@ -4144,52 +4132,51 @@
             "memory usage: 256.0+ bytes\n"
           ]
         }
+      ],
+      "source": [
+        "df.info()"
       ]
     },
     {
       "cell_type": "code",
+      "execution_count": 69,
       "metadata": {
         "id": "q9dhMvSWB_lB"
       },
+      "outputs": [],
       "source": [
         "types = [ \"C\", \"B\", \"A\" ]\n",
         "df.BBB = pd.Categorical(df.BBB, categories=types, ordered=True)"
-      ],
-      "execution_count": 415,
-      "outputs": []
+      ]
     },
     {
       "cell_type": "code",
+      "execution_count": 70,
       "metadata": {
         "id": "r-gio5FYFcU3"
       },
+      "outputs": [],
       "source": [
         "df['BBB_code'] = df.BBB.cat.codes"
-      ],
-      "execution_count": 416,
-      "outputs": []
+      ]
     },
     {
       "cell_type": "code",
+      "execution_count": 71,
       "metadata": {
         "colab": {
           "base_uri": "https://localhost:8080/",
-          "height": 297
+          "height": 300
         },
         "id": "6Nl9ol53FdQB",
-        "outputId": "eafb3469-80da-4f34-a73c-a5baa39f5b60"
+        "outputId": "d1b1b32d-f8d8-4275-b52b-3e1c32f9c6c8"
       },
-      "source": [
-        "df"
-      ],
-      "execution_count": 417,
       "outputs": [
         {
-          "output_type": "execute_result",
           "data": {
             "text/html": [
               "\n",
-              "  <div id=\"df-fa844cc7-b1f3-43d9-b2d1-04a064822be8\">\n",
+              "  <div id=\"df-2e4d99d8-3d37-4305-b52e-9949f12e22ed\">\n",
               "    <div class=\"colab-df-container\">\n",
               "      <div>\n",
               "<style scoped>\n",
@@ -4266,7 +4253,7 @@
               "  </tbody>\n",
               "</table>\n",
               "</div>\n",
-              "      <button class=\"colab-df-convert\" onclick=\"convertToInteractive('df-fa844cc7-b1f3-43d9-b2d1-04a064822be8')\"\n",
+              "      <button class=\"colab-df-convert\" onclick=\"convertToInteractive('df-2e4d99d8-3d37-4305-b52e-9949f12e22ed')\"\n",
               "              title=\"Convert this dataframe to an interactive table.\"\n",
               "              style=\"display:none;\">\n",
               "        \n",
@@ -4317,12 +4304,12 @@
               "\n",
               "      <script>\n",
               "        const buttonEl =\n",
-              "          document.querySelector('#df-fa844cc7-b1f3-43d9-b2d1-04a064822be8 button.colab-df-convert');\n",
+              "          document.querySelector('#df-2e4d99d8-3d37-4305-b52e-9949f12e22ed button.colab-df-convert');\n",
               "        buttonEl.style.display =\n",
               "          google.colab.kernel.accessAllowed ? 'block' : 'none';\n",
               "\n",
               "        async function convertToInteractive(key) {\n",
-              "          const element = document.querySelector('#df-fa844cc7-b1f3-43d9-b2d1-04a064822be8');\n",
+              "          const element = document.querySelector('#df-2e4d99d8-3d37-4305-b52e-9949f12e22ed');\n",
               "          const dataTable =\n",
               "            await google.colab.kernel.invokeFunction('convertToInteractive',\n",
               "                                                     [key], {});\n",
@@ -4355,9 +4342,13 @@
               "7    3   A         2"
             ]
           },
+          "execution_count": 71,
           "metadata": {},
-          "execution_count": 417
+          "output_type": "execute_result"
         }
+      ],
+      "source": [
+        "df"
       ]
     },
     {
@@ -4371,30 +4362,18 @@
     },
     {
       "cell_type": "code",
+      "execution_count": 72,
       "metadata": {
-        "id": "8q8yOy0p00xp",
         "colab": {
           "base_uri": "https://localhost:8080/"
         },
-        "outputId": "1eace4e9-d522-4056-c041-64e6917466d0"
+        "id": "8q8yOy0p00xp",
+        "outputId": "17872a50-7014-4da8-8c80-8388a34fffa8"
       },
-      "source": [
-        "df = pd.DataFrame(\n",
-        "   {\"AAA\": [1, 1, 1, 2, 2, 2, 3, 3], \"BBB\": [\"A\", \"B\", \"C\", \"A\", \"A\", \"C\", \"B\", \"A\"]}\n",
-        ")\n",
-        "\n",
-        "print(df)\n",
-        "print()\n",
-        "\n",
-        "df['BBB_coded'] = df['BBB'].map({\"A\":0, \"B\":1, \"C\":2})\n",
-        "\n",
-        "print(df)"
-      ],
-      "execution_count": 418,
       "outputs": [
         {
-          "output_type": "stream",
           "name": "stdout",
+          "output_type": "stream",
           "text": [
             "   AAA BBB\n",
             "0    1   A\n",
@@ -4417,6 +4396,18 @@
             "7    3   A          0\n"
           ]
         }
+      ],
+      "source": [
+        "df = pd.DataFrame(\n",
+        "   {\"AAA\": [1, 1, 1, 2, 2, 2, 3, 3], \"BBB\": [\"A\", \"B\", \"C\", \"A\", \"A\", \"C\", \"B\", \"A\"]}\n",
+        ")\n",
+        "\n",
+        "print(df)\n",
+        "print()\n",
+        "\n",
+        "df['BBB_coded'] = df['BBB'].map({\"A\":0, \"B\":1, \"C\":2})\n",
+        "\n",
+        "print(df)"
       ]
     },
     {
@@ -4439,43 +4430,18 @@
     },
     {
       "cell_type": "code",
+      "execution_count": 73,
       "metadata": {
         "colab": {
           "base_uri": "https://localhost:8080/"
         },
         "id": "qF5Koa0M4q25",
-        "outputId": "b2675f54-b7ba-4214-e514-fe0f6676010a"
+        "outputId": "68b8db32-b02d-4254-990f-f745ca9227d1"
       },
-      "source": [
-        "df = pd.DataFrame([[np.nan, 2, np.nan, 0],\n",
-        "                   [3, 4, np.nan, 1],\n",
-        "                   [np.nan, np.nan, np.nan, 5],\n",
-        "                   [np.nan, 3, np.nan, 4]],\n",
-        "                  columns=list('ABCD'))\n",
-        "\n",
-        "print(df)\n",
-        "print()\n",
-        "\n",
-        "# NaN 인 곳을 True로\n",
-        "print(\"df.isnull()\")\n",
-        "print(df.isnull())\n",
-        "print()\n",
-        "\n",
-        "# 컬럼 별로 True가 한 개라도 있는 지\n",
-        "print(\"df.isnull().any()\")\n",
-        "print(df.isnull().any())\n",
-        "print()\n",
-        "\n",
-        "# 전체에서 True가 한 개라도 있는 지\n",
-        "print(\"df.isnull().any().any()\")\n",
-        "print(df.isnull().any().any())\n",
-        "print()\n"
-      ],
-      "execution_count": 419,
       "outputs": [
         {
-          "output_type": "stream",
           "name": "stdout",
+          "output_type": "stream",
           "text": [
             "     A    B   C  D\n",
             "0  NaN  2.0 NaN  0\n",
@@ -4502,26 +4468,7 @@
             "\n"
           ]
         }
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "ecK0DE5Y6cIA"
-      },
-      "source": [
-        "### 결측치 갯수 확인"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "metadata": {
-        "colab": {
-          "base_uri": "https://localhost:8080/"
-        },
-        "id": "CL_tkafL4qzz",
-        "outputId": "ba1a7f2d-559d-4a30-c6fe-432e0e855cd2"
-      },
+      ],
       "source": [
         "df = pd.DataFrame([[np.nan, 2, np.nan, 0],\n",
         "                   [3, 4, np.nan, 1],\n",
@@ -4537,21 +4484,40 @@
         "print(df.isnull())\n",
         "print()\n",
         "\n",
-        "# 컬럼 별 True 갯수\n",
-        "print(\"df.isnull().sum()\")\n",
-        "print(df.isnull().sum())\n",
+        "# 컬럼 별로 True가 한 개라도 있는 지\n",
+        "print(\"df.isnull().any()\")\n",
+        "print(df.isnull().any())\n",
         "print()\n",
         "\n",
-        "# 전체 True 갯수\n",
-        "print(\"df.isnull().sum().sum()\")\n",
-        "print(df.isnull().sum().sum())\n",
+        "# 전체에서 True가 한 개라도 있는 지\n",
+        "print(\"df.isnull().any().any()\")\n",
+        "print(df.isnull().any().any())\n",
         "print()\n"
-      ],
-      "execution_count": 420,
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "ecK0DE5Y6cIA"
+      },
+      "source": [
+        "### 결측치 갯수 확인"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 74,
+      "metadata": {
+        "colab": {
+          "base_uri": "https://localhost:8080/"
+        },
+        "id": "CL_tkafL4qzz",
+        "outputId": "65b81018-9fd5-4464-9928-ebcb6c64b4ca"
+      },
       "outputs": [
         {
-          "output_type": "stream",
           "name": "stdout",
+          "output_type": "stream",
           "text": [
             "     A    B   C  D\n",
             "0  NaN  2.0 NaN  0\n",
@@ -4578,26 +4544,7 @@
             "\n"
           ]
         }
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "JMuvRq207Xxy"
-      },
-      "source": [
-        "### 각 컬럼별 결측 비율"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "metadata": {
-        "colab": {
-          "base_uri": "https://localhost:8080/"
-        },
-        "id": "5gvYa1j74qvS",
-        "outputId": "12628104-417e-4179-c518-72eea1e749bc"
-      },
+      ],
       "source": [
         "df = pd.DataFrame([[np.nan, 2, np.nan, 0],\n",
         "                   [3, 4, np.nan, 1],\n",
@@ -4618,15 +4565,35 @@
         "print(df.isnull().sum())\n",
         "print()\n",
         "\n",
-        "# 컬럼 별 결측치 비율\n",
-        "print(df.isnull().sum()/(len(df))*100)\n",
+        "# 전체 True 갯수\n",
+        "print(\"df.isnull().sum().sum()\")\n",
+        "print(df.isnull().sum().sum())\n",
         "print()\n"
-      ],
-      "execution_count": 421,
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "JMuvRq207Xxy"
+      },
+      "source": [
+        "### 각 컬럼별 결측 비율"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 75,
+      "metadata": {
+        "colab": {
+          "base_uri": "https://localhost:8080/"
+        },
+        "id": "5gvYa1j74qvS",
+        "outputId": "99e09ad7-d4f7-42c8-8156-2d19aab89d92"
+      },
       "outputs": [
         {
-          "output_type": "stream",
           "name": "stdout",
+          "output_type": "stream",
           "text": [
             "     A    B   C  D\n",
             "0  NaN  2.0 NaN  0\n",
@@ -4656,73 +4623,85 @@
             "\n"
           ]
         }
+      ],
+      "source": [
+        "df = pd.DataFrame([[np.nan, 2, np.nan, 0],\n",
+        "                   [3, 4, np.nan, 1],\n",
+        "                   [np.nan, np.nan, np.nan, 5],\n",
+        "                   [np.nan, 3, np.nan, 4]],\n",
+        "                  columns=list('ABCD'))\n",
+        "\n",
+        "print(df)\n",
+        "print()\n",
+        "\n",
+        "# NaN 인 곳을 True로\n",
+        "print(\"df.isnull()\")\n",
+        "print(df.isnull())\n",
+        "print()\n",
+        "\n",
+        "# 컬럼 별 True 갯수\n",
+        "print(\"df.isnull().sum()\")\n",
+        "print(df.isnull().sum())\n",
+        "print()\n",
+        "\n",
+        "# 컬럼 별 결측치 비율\n",
+        "print(df.isnull().sum()/(len(df))*100)\n",
+        "print()\n"
       ]
     },
     {
       "cell_type": "code",
+      "execution_count": 75,
       "metadata": {
         "id": "v-JBQdBG78rG"
       },
-      "source": [
-        ""
-      ],
-      "execution_count": 421,
-      "outputs": []
+      "outputs": [],
+      "source": []
     },
     {
       "cell_type": "code",
+      "execution_count": 75,
       "metadata": {
         "id": "7g4h0ioE78oS"
       },
-      "source": [
-        ""
-      ],
-      "execution_count": 421,
-      "outputs": []
+      "outputs": [],
+      "source": []
     },
     {
       "cell_type": "code",
+      "execution_count": 75,
       "metadata": {
         "id": "QZuCcOiS78iT"
       },
-      "source": [
-        ""
-      ],
-      "execution_count": 421,
-      "outputs": []
+      "outputs": [],
+      "source": []
     },
     {
       "cell_type": "code",
+      "execution_count": 75,
       "metadata": {
         "id": "BAST44ri78fk"
       },
-      "source": [
-        ""
-      ],
-      "execution_count": 421,
-      "outputs": []
+      "outputs": [],
+      "source": []
     },
     {
       "cell_type": "code",
+      "execution_count": 75,
       "metadata": {
         "id": "7xa2Z-HD78aK"
       },
-      "source": [
-        ""
-      ],
-      "execution_count": 421,
-      "outputs": []
+      "outputs": [],
+      "source": []
     },
     {
       "cell_type": "code",
+      "execution_count": 75,
       "metadata": {
         "id": "-D_o465F4qpy"
       },
-      "source": [
-        ""
-      ],
-      "execution_count": 421,
-      "outputs": []
+      "outputs": [],
+      "source": []
     },
     {
       "cell_type": "markdown",
@@ -4744,30 +4723,18 @@
     },
     {
       "cell_type": "code",
+      "execution_count": 76,
       "metadata": {
         "colab": {
           "base_uri": "https://localhost:8080/"
         },
         "id": "ln_2FwVM78tq",
-        "outputId": "752ba90b-d7e7-4975-fc38-3355214af307"
+        "outputId": "760401a2-97a7-4a23-b3fe-ed99b7339593"
       },
-      "source": [
-        "df = pd.DataFrame([[1, 2, 3, 0],\n",
-        "                   [3, 4, 5, 1],\n",
-        "                   [np.nan, np.nan, np.nan, 5],\n",
-        "                   [2, 3, 1, 4]],\n",
-        "                  columns=list('ABCD'))\n",
-        "\n",
-        "print(df)\n",
-        "print()\n",
-        "\n",
-        "print(df.dropna())\n"
-      ],
-      "execution_count": 422,
       "outputs": [
         {
-          "output_type": "stream",
           "name": "stdout",
+          "output_type": "stream",
           "text": [
             "     A    B    C  D\n",
             "0  1.0  2.0  3.0  0\n",
@@ -4781,6 +4748,18 @@
             "3  2.0  3.0  1.0  4\n"
           ]
         }
+      ],
+      "source": [
+        "df = pd.DataFrame([[1, 2, 3, 0],\n",
+        "                   [3, 4, 5, 1],\n",
+        "                   [np.nan, np.nan, np.nan, 5],\n",
+        "                   [2, 3, 1, 4]],\n",
+        "                  columns=list('ABCD'))\n",
+        "\n",
+        "print(df)\n",
+        "print()\n",
+        "\n",
+        "print(df.dropna())\n"
       ]
     },
     {
@@ -4794,31 +4773,18 @@
     },
     {
       "cell_type": "code",
+      "execution_count": 77,
       "metadata": {
         "colab": {
           "base_uri": "https://localhost:8080/"
         },
         "id": "uJNFhfHa9C0Q",
-        "outputId": "49f44c3d-12d5-4eb2-a231-4f66f504832b"
+        "outputId": "36c0211c-128d-4668-ebb6-e56081be94e6"
       },
-      "source": [
-        "df = pd.DataFrame([[1, 2, np.nan, 0],\n",
-        "                   [3, 4, 5, 1],\n",
-        "                   [3, 4, np.nan, 5],\n",
-        "                   [2, 3, np.nan, 4]],\n",
-        "                  columns=list('ABCD'))\n",
-        "\n",
-        "print(df)\n",
-        "print()\n",
-        "\n",
-        "\n",
-        "print(df.dropna(axis=1))\n"
-      ],
-      "execution_count": 423,
       "outputs": [
         {
-          "output_type": "stream",
           "name": "stdout",
+          "output_type": "stream",
           "text": [
             "   A  B    C  D\n",
             "0  1  2  NaN  0\n",
@@ -4833,6 +4799,19 @@
             "3  2  3  4\n"
           ]
         }
+      ],
+      "source": [
+        "df = pd.DataFrame([[1, 2, np.nan, 0],\n",
+        "                   [3, 4, 5, 1],\n",
+        "                   [3, 4, np.nan, 5],\n",
+        "                   [2, 3, np.nan, 4]],\n",
+        "                  columns=list('ABCD'))\n",
+        "\n",
+        "print(df)\n",
+        "print()\n",
+        "\n",
+        "\n",
+        "print(df.dropna(axis=1))\n"
       ]
     },
     {
@@ -4846,32 +4825,18 @@
     },
     {
       "cell_type": "code",
+      "execution_count": 78,
       "metadata": {
         "colab": {
           "base_uri": "https://localhost:8080/"
         },
         "id": "JfBzGaP6wb9G",
-        "outputId": "3a1f4faa-f12a-4780-925a-211a7ac7c917"
+        "outputId": "b2a6f51b-0a9f-4e54-cf0a-af8964cf3ccb"
       },
-      "source": [
-        "df = pd.DataFrame([[np.nan, 2, np.nan, 0],\n",
-        "                   [3, 4, np.nan, 1],\n",
-        "                   [np.nan, np.nan, np.nan, 5],\n",
-        "                   [np.nan, 3, np.nan, 4]],\n",
-        "                  columns=list('ABCD'))\n",
-        "\n",
-        "print(df)\n",
-        "print()\n",
-        "\n",
-        "filled_df = df.fillna(0)\n",
-        "\n",
-        "print(filled_df)\n"
-      ],
-      "execution_count": 424,
       "outputs": [
         {
-          "output_type": "stream",
           "name": "stdout",
+          "output_type": "stream",
           "text": [
             "     A    B   C  D\n",
             "0  NaN  2.0 NaN  0\n",
@@ -4886,6 +4851,20 @@
             "3  0.0  3.0  0.0  4\n"
           ]
         }
+      ],
+      "source": [
+        "df = pd.DataFrame([[np.nan, 2, np.nan, 0],\n",
+        "                   [3, 4, np.nan, 1],\n",
+        "                   [np.nan, np.nan, np.nan, 5],\n",
+        "                   [np.nan, 3, np.nan, 4]],\n",
+        "                  columns=list('ABCD'))\n",
+        "\n",
+        "print(df)\n",
+        "print()\n",
+        "\n",
+        "filled_df = df.fillna(0)\n",
+        "\n",
+        "print(filled_df)\n"
       ]
     },
     {
@@ -4899,13 +4878,33 @@
     },
     {
       "cell_type": "code",
+      "execution_count": 79,
       "metadata": {
         "colab": {
           "base_uri": "https://localhost:8080/"
         },
         "id": "UG-hyVn90AS9",
-        "outputId": "1bac4c72-52bf-4f1f-ccfc-fd2242bb4c05"
+        "outputId": "e9199ae5-7f16-415c-803f-701fbdf11522"
       },
+      "outputs": [
+        {
+          "name": "stdout",
+          "output_type": "stream",
+          "text": [
+            "     A    B   C  D\n",
+            "0  NaN  2.0 NaN  0\n",
+            "1  3.0  4.0 NaN  1\n",
+            "2  NaN  NaN NaN  5\n",
+            "3  NaN  3.0 NaN  4\n",
+            "\n",
+            "     A    B    C  D\n",
+            "0  0.0  2.0  2.0  0\n",
+            "1  3.0  4.0  2.0  1\n",
+            "2  0.0  1.0  2.0  5\n",
+            "3  0.0  3.0  2.0  4\n"
+          ]
+        }
+      ],
       "source": [
         "df = pd.DataFrame([[np.nan, 2, np.nan, 0],\n",
         "                   [3, 4, np.nan, 1],\n",
@@ -4921,26 +4920,6 @@
         "filled_df = df.fillna(value=values)\n",
         "\n",
         "print(filled_df)"
-      ],
-      "execution_count": 425,
-      "outputs": [
-        {
-          "output_type": "stream",
-          "name": "stdout",
-          "text": [
-            "     A    B   C  D\n",
-            "0  NaN  2.0 NaN  0\n",
-            "1  3.0  4.0 NaN  1\n",
-            "2  NaN  NaN NaN  5\n",
-            "3  NaN  3.0 NaN  4\n",
-            "\n",
-            "     A    B    C  D\n",
-            "0  0.0  2.0  2.0  0\n",
-            "1  3.0  4.0  2.0  1\n",
-            "2  0.0  1.0  2.0  5\n",
-            "3  0.0  3.0  2.0  4\n"
-          ]
-        }
       ]
     },
     {
@@ -4954,32 +4933,18 @@
     },
     {
       "cell_type": "code",
+      "execution_count": 80,
       "metadata": {
         "colab": {
           "base_uri": "https://localhost:8080/"
         },
         "id": "7_3fdE5V0AY8",
-        "outputId": "53cc0cef-f91b-4d2a-92d2-5f7e8562593c"
+        "outputId": "0ab4b7c9-8c78-4996-a633-19b6758487f4"
       },
-      "source": [
-        "df = pd.DataFrame([[np.nan, 2, np.nan, 0],\n",
-        "                   [3, 4, np.nan, 1],\n",
-        "                   [np.nan, np.nan, np.nan, 5],\n",
-        "                   [np.nan, 3, np.nan, 4]],\n",
-        "                  columns=list('ABCD'))\n",
-        "\n",
-        "print(df)\n",
-        "print()\n",
-        "\n",
-        "filled_df = df.fillna(method=\"ffill\")\n",
-        "\n",
-        "print(filled_df)\n"
-      ],
-      "execution_count": 426,
       "outputs": [
         {
-          "output_type": "stream",
           "name": "stdout",
+          "output_type": "stream",
           "text": [
             "     A    B   C  D\n",
             "0  NaN  2.0 NaN  0\n",
@@ -4994,6 +4959,20 @@
             "3  3.0  3.0 NaN  4\n"
           ]
         }
+      ],
+      "source": [
+        "df = pd.DataFrame([[np.nan, 2, np.nan, 0],\n",
+        "                   [3, 4, np.nan, 1],\n",
+        "                   [np.nan, np.nan, np.nan, 5],\n",
+        "                   [np.nan, 3, np.nan, 4]],\n",
+        "                  columns=list('ABCD'))\n",
+        "\n",
+        "print(df)\n",
+        "print()\n",
+        "\n",
+        "filled_df = df.fillna(method=\"ffill\")\n",
+        "\n",
+        "print(filled_df)\n"
       ]
     },
     {
@@ -5007,32 +4986,18 @@
     },
     {
       "cell_type": "code",
+      "execution_count": 81,
       "metadata": {
         "colab": {
           "base_uri": "https://localhost:8080/"
         },
         "id": "Yinoi2As1TlY",
-        "outputId": "0c61e6fd-0aa3-4117-857c-2ca219392278"
+        "outputId": "71a5cb67-5e00-4064-fa73-d989698582b2"
       },
-      "source": [
-        "df = pd.DataFrame([[np.nan, 2, np.nan, 0],\n",
-        "                   [3, 4, np.nan, 1],\n",
-        "                   [np.nan, np.nan, np.nan, 5],\n",
-        "                   [np.nan, 3, np.nan, 4]],\n",
-        "                  columns=list('ABCD'))\n",
-        "\n",
-        "print(df)\n",
-        "print()\n",
-        "\n",
-        "filled_df = df.fillna(method=\"bfill\")\n",
-        "\n",
-        "print(filled_df)\n"
-      ],
-      "execution_count": 427,
       "outputs": [
         {
-          "output_type": "stream",
           "name": "stdout",
+          "output_type": "stream",
           "text": [
             "     A    B   C  D\n",
             "0  NaN  2.0 NaN  0\n",
@@ -5047,6 +5012,20 @@
             "3  NaN  3.0 NaN  4\n"
           ]
         }
+      ],
+      "source": [
+        "df = pd.DataFrame([[np.nan, 2, np.nan, 0],\n",
+        "                   [3, 4, np.nan, 1],\n",
+        "                   [np.nan, np.nan, np.nan, 5],\n",
+        "                   [np.nan, 3, np.nan, 4]],\n",
+        "                  columns=list('ABCD'))\n",
+        "\n",
+        "print(df)\n",
+        "print()\n",
+        "\n",
+        "filled_df = df.fillna(method=\"bfill\")\n",
+        "\n",
+        "print(filled_df)\n"
       ]
     },
     {
@@ -5060,36 +5039,18 @@
     },
     {
       "cell_type": "code",
+      "execution_count": 82,
       "metadata": {
         "colab": {
           "base_uri": "https://localhost:8080/"
         },
         "id": "eF1Tj5tn0AN0",
-        "outputId": "698868a4-2ce0-4b24-8fee-bd3407a74e18"
+        "outputId": "391f4e5d-a07e-46d3-ede8-ee0e28b05e01"
       },
-      "source": [
-        "df = pd.DataFrame([[np.nan, 2, np.nan, 0],\n",
-        "                   [3, 4, np.nan, 1],\n",
-        "                   [np.nan, np.nan, np.nan, 5],\n",
-        "                   [np.nan, 3, np.nan, 4]],\n",
-        "                  columns=list('ABCD'))\n",
-        "\n",
-        "print(df)\n",
-        "print()\n",
-        "\n",
-        "print(\"df.mean()\")\n",
-        "print(df.mean())\n",
-        "print()\n",
-        "\n",
-        "filled_df = df.fillna(df.mean())\n",
-        "\n",
-        "print(filled_df)\n"
-      ],
-      "execution_count": 428,
       "outputs": [
         {
-          "output_type": "stream",
           "name": "stdout",
+          "output_type": "stream",
           "text": [
             "     A    B   C  D\n",
             "0  NaN  2.0 NaN  0\n",
@@ -5111,28 +5072,76 @@
             "3  3.0  3.0 NaN  4\n"
           ]
         }
+      ],
+      "source": [
+        "df = pd.DataFrame([[np.nan, 2, np.nan, 0],\n",
+        "                   [3, 4, np.nan, 1],\n",
+        "                   [np.nan, np.nan, np.nan, 5],\n",
+        "                   [np.nan, 3, np.nan, 4]],\n",
+        "                  columns=list('ABCD'))\n",
+        "\n",
+        "print(df)\n",
+        "print()\n",
+        "\n",
+        "print(\"df.mean()\")\n",
+        "print(df.mean())\n",
+        "print()\n",
+        "\n",
+        "filled_df = df.fillna(df.mean())\n",
+        "\n",
+        "print(filled_df)\n"
       ]
     },
     {
       "cell_type": "code",
+      "execution_count": 82,
       "metadata": {
         "id": "tH1Y11ERz_kC"
       },
-      "source": [
-        ""
-      ],
-      "execution_count": 428,
-      "outputs": []
+      "outputs": [],
+      "source": []
     },
     {
       "cell_type": "code",
+      "execution_count": 83,
       "metadata": {
         "colab": {
           "base_uri": "https://localhost:8080/"
         },
         "id": "Ka26g5JasuVC",
-        "outputId": "2ce7e58e-613e-4fdf-de8d-420f04e19821"
+        "outputId": "a8ad08d7-3162-499c-daa1-58d7bd29cdda"
       },
+      "outputs": [
+        {
+          "name": "stdout",
+          "output_type": "stream",
+          "text": [
+            "                   A\n",
+            "2013-08-01  0.550498\n",
+            "2013-08-02 -0.058729\n",
+            "2013-08-05  0.534708\n",
+            "2013-08-06 -0.774341\n",
+            "2013-08-07  1.167757\n",
+            "2013-08-08  0.899444\n",
+            "\n",
+            "                   A\n",
+            "2013-08-01  0.550498\n",
+            "2013-08-02 -0.058729\n",
+            "2013-08-05  0.534708\n",
+            "2013-08-06       NaN\n",
+            "2013-08-07  1.167757\n",
+            "2013-08-08  0.899444\n",
+            "\n",
+            "                   A\n",
+            "2013-08-01  0.550498\n",
+            "2013-08-02 -0.058729\n",
+            "2013-08-05  0.534708\n",
+            "2013-08-06  0.534708\n",
+            "2013-08-07  1.167757\n",
+            "2013-08-08  0.899444\n"
+          ]
+        }
+      ],
       "source": [
         "import numpy as np\n",
         "\n",
@@ -5152,38 +5161,6 @@
         "\n",
         "df = df.ffill()\n",
         "print(df)"
-      ],
-      "execution_count": 429,
-      "outputs": [
-        {
-          "output_type": "stream",
-          "name": "stdout",
-          "text": [
-            "                   A\n",
-            "2013-08-01  0.802144\n",
-            "2013-08-02  1.828581\n",
-            "2013-08-05 -0.531959\n",
-            "2013-08-06  1.552185\n",
-            "2013-08-07 -0.328952\n",
-            "2013-08-08  0.229079\n",
-            "\n",
-            "                   A\n",
-            "2013-08-01  0.802144\n",
-            "2013-08-02  1.828581\n",
-            "2013-08-05 -0.531959\n",
-            "2013-08-06       NaN\n",
-            "2013-08-07 -0.328952\n",
-            "2013-08-08  0.229079\n",
-            "\n",
-            "                   A\n",
-            "2013-08-01  0.802144\n",
-            "2013-08-02  1.828581\n",
-            "2013-08-05 -0.531959\n",
-            "2013-08-06 -0.531959\n",
-            "2013-08-07 -0.328952\n",
-            "2013-08-08  0.229079\n"
-          ]
-        }
       ]
     },
     {
@@ -5206,29 +5183,18 @@
     },
     {
       "cell_type": "code",
+      "execution_count": 84,
       "metadata": {
         "colab": {
           "base_uri": "https://localhost:8080/"
         },
         "id": "1BxNAmKQdd_M",
-        "outputId": "7659e443-c2b1-44ce-bb73-e0d99e889c15"
+        "outputId": "d750ba0b-90b8-4003-ce31-d9023264e67b"
       },
-      "source": [
-        "df = pd.DataFrame(\n",
-        "        {\"AAA\": [4, 5, 6, 7], \"BBB\": [10, 20, 35, 10], \"CCC\": [100, 50, -30, -50]}\n",
-        ")\n",
-        "\n",
-        "print(df)\n",
-        "print()\n",
-        "\n",
-        "df2 = (df - df.min()) / (df.max() - df.min())\n",
-        "print(df2)"
-      ],
-      "execution_count": 430,
       "outputs": [
         {
-          "output_type": "stream",
           "name": "stdout",
+          "output_type": "stream",
           "text": [
             "   AAA  BBB  CCC\n",
             "0    4   10  100\n",
@@ -5243,6 +5209,17 @@
             "3  1.000000  0.0  0.000000\n"
           ]
         }
+      ],
+      "source": [
+        "df = pd.DataFrame(\n",
+        "        {\"AAA\": [4, 5, 6, 7], \"BBB\": [10, 20, 35, 10], \"CCC\": [100, 50, -30, -50]}\n",
+        ")\n",
+        "\n",
+        "print(df)\n",
+        "print()\n",
+        "\n",
+        "df2 = (df - df.min()) / (df.max() - df.min())\n",
+        "print(df2)"
       ]
     },
     {
@@ -5256,29 +5233,18 @@
     },
     {
       "cell_type": "code",
+      "execution_count": 85,
       "metadata": {
         "colab": {
           "base_uri": "https://localhost:8080/"
         },
         "id": "BZNn6VkVf7YK",
-        "outputId": "5003c2c2-472a-4063-d14a-3385fa360c1a"
+        "outputId": "d510d478-4684-4d79-b6a8-670027514183"
       },
-      "source": [
-        "df = pd.DataFrame(\n",
-        "        {\"AAA\": [4, 5, 6, 7], \"BBB\": [10, 20, 35, 10], \"CCC\": [100, 50, -30, -50]}\n",
-        ")\n",
-        "\n",
-        "print(df)\n",
-        "print()\n",
-        "\n",
-        "df2 = (df - df.mean()) / df.std()\n",
-        "print(df2)"
-      ],
-      "execution_count": 431,
       "outputs": [
         {
-          "output_type": "stream",
           "name": "stdout",
+          "output_type": "stream",
           "text": [
             "   AAA  BBB  CCC\n",
             "0    4   10  100\n",
@@ -5293,6 +5259,17 @@
             "3  1.161895 -0.740613 -0.965107\n"
           ]
         }
+      ],
+      "source": [
+        "df = pd.DataFrame(\n",
+        "        {\"AAA\": [4, 5, 6, 7], \"BBB\": [10, 20, 35, 10], \"CCC\": [100, 50, -30, -50]}\n",
+        ")\n",
+        "\n",
+        "print(df)\n",
+        "print()\n",
+        "\n",
+        "df2 = (df - df.mean()) / df.std()\n",
+        "print(df2)"
       ]
     },
     {
@@ -5306,34 +5283,18 @@
     },
     {
       "cell_type": "code",
+      "execution_count": 86,
       "metadata": {
         "colab": {
           "base_uri": "https://localhost:8080/"
         },
         "id": "SUWLreM-_faa",
-        "outputId": "32e3a2cb-86f4-49f3-a1a2-93496cd0bb5a"
+        "outputId": "36fc2bd7-7b24-47de-825b-85e30c4671a5"
       },
-      "source": [
-        "df = pd.DataFrame(\n",
-        "        {\"AAA\": [4, 5, 6, 7], \"BBB\": [10, 20, 35, 10], \"CCC\": [100, 50, -30, -50]}\n",
-        ")\n",
-        "\n",
-        "print(df)\n",
-        "print()\n",
-        "\n",
-        "df2 = (df - df.min()) / (df.max() - df.min())\n",
-        "print(df2)\n",
-        "\n",
-        "target_columns = [ \"AAA\", \"BBB\" ]\n",
-        "df[target_columns] = df2[target_columns]\n",
-        "\n",
-        "print(df)"
-      ],
-      "execution_count": 432,
       "outputs": [
         {
-          "output_type": "stream",
           "name": "stdout",
+          "output_type": "stream",
           "text": [
             "   AAA  BBB  CCC\n",
             "0    4   10  100\n",
@@ -5353,6 +5314,22 @@
             "3  1.000000  0.0  -50\n"
           ]
         }
+      ],
+      "source": [
+        "df = pd.DataFrame(\n",
+        "        {\"AAA\": [4, 5, 6, 7], \"BBB\": [10, 20, 35, 10], \"CCC\": [100, 50, -30, -50]}\n",
+        ")\n",
+        "\n",
+        "print(df)\n",
+        "print()\n",
+        "\n",
+        "df2 = (df - df.min()) / (df.max() - df.min())\n",
+        "print(df2)\n",
+        "\n",
+        "target_columns = [ \"AAA\", \"BBB\" ]\n",
+        "df[target_columns] = df2[target_columns]\n",
+        "\n",
+        "print(df)"
       ]
     },
     {
@@ -5377,14 +5354,29 @@
     },
     {
       "cell_type": "code",
+      "execution_count": 87,
       "metadata": {
-        "id": "kUI6XHVy3ehs",
         "colab": {
           "base_uri": "https://localhost:8080/",
           "height": 265
         },
-        "outputId": "f5ad5e8c-c29a-4b28-ae70-c0a1ce522c4c"
+        "id": "kUI6XHVy3ehs",
+        "outputId": "3da486f2-3de7-42e3-8267-1a344a9bb9c6"
       },
+      "outputs": [
+        {
+          "data": {
+            "image/png": "iVBORw0KGgoAAAANSUhEUgAAAXwAAAD4CAYAAADvsV2wAAAABHNCSVQICAgIfAhkiAAAAAlwSFlzAAALEgAACxIB0t1+/AAAADh0RVh0U29mdHdhcmUAbWF0cGxvdGxpYiB2ZXJzaW9uMy4yLjIsIGh0dHA6Ly9tYXRwbG90bGliLm9yZy+WH4yJAAARMElEQVR4nO3df4xlZX3H8fenyw8JpWiFDgiEpZGmIIgNU6ipMWNFC2jBnxGaqLQ1Y9qSpv1Hl5Bi6l9L/KNtCiluKCk2jdg0QbbudhFkb6ltVBbLVpYVXckadlERaImDqKx++8dc43SZ2flxztz58bxfyc3ec84z53nufeZ+5uxzzn1OqgpJ0vr3cyvdAEnSaBj4ktQIA1+SGmHgS1IjDHxJasRRK92AIznppJNq48aNK92MZfHcc89x/PHHr3QztET239q2nvvvwQcffKqqTp5t26oO/I0bN7Jr166VbsayGAwGTExMrHQztET239q2nvsvyTfn2uaQjiQ1opfAT3JbkieTPDzH9okkzyZ5aPi4oY96JUkL19eQzt8DNwGfOEKZf6+qt/ZUnyRpkXo5wq+q+4Fn+tiXJGl5jHIM/7VJdif51ySvGmG9kiRGd5XOl4Ezq2oqyeXAp4GzZyuYZBKYBBgbG2MwGIyoiaM1NTW1bl9bC+y/ta3V/ktfs2Um2Qh8pqrOW0DZ/cB4VT11pHLj4+PlZZlajey/tW0991+SB6tqfLZtIxnSSXJKkgyfXzSs9+lR1C1JmtbLkE6STwITwElJDgAfAY4GqKpbgHcBf5jkEPA8cFU5Eb+kZTA8tuxsPUZUL4FfVVfPs/0mpi/blKRltZCg3rhpG/s3v2UErVld/KatJDXCwJekRhj4ktQIA1+SGrGqp0dey7xSQNJq4xH+MqmqIz7O/PBn5i1j2Evqk4EvSY0w8CWpEQa+JDXCwJekRhj4ktQIA1+SGmHgS1IjDHxJaoSBL0mNMPAlqREGviQ1wsnTJK0pF/zFZ3n2+Rc672fjpm1L/tkTjzua3R95c+c2jFpf97S9DXgr8GRVnTfL9gB/DVwOfB+4pqq+3Efd0nLoY7ZTJ79bHs8+/0Ln2xMOBgMmJiaW/PNd/lispL6GdP4euPQI2y8Dzh4+JoG/7aleaVn0MduptNr0EvhVdT/wzBGKXAl8oqZ9AXhpklP7qFuStDCjOml7GvD4jOUDw3WSpBFZdSdtk0wyPezD2NgYg8FgZRu0jNbza2uB/bdyur73U1NTnfexFvt/VIF/EDhjxvLpw3UvUlVbgC0A4+Pj1eXEyqq2Y1unk0ZaYfbfyunhve960nat9v+ohnS2Au/LtN8Anq2qb42obkkS/V2W+UlgAjgpyQHgI8DRAFV1C7Cd6Usy9zF9Webv9VGvJGnhegn8qrp6nu0F/HEfdUmSlsapFSSpEQa+JDXCwJekRqy66/Al6UhOOGcT59++qfuObu/SBoBu8/msBAN/ifqYsa/rBExrdcY+qYvv7d3s5GlLZOAvUdcZ+zp/8YO1+0snaWU4hi9JjTDwJakRBr4kNcIxfDVnNdwiDzzprtEz8NWc1XCLPPCku0bPIR1JaoSBL0mNMPAlqREGviQ1wsCXpEYY+JLUCANfkhrRS+AnuTTJo0n2JXnRvKVJrkny3SQPDR8f6KNeSdLCdf7iVZINwM3Am4ADwANJtlbVI4cV/VRVXdu1PknS0vRxhH8RsK+qHquqHwF3AFf2sF9JUo/6mFrhNODxGcsHgItnKffOJK8Hvgb8WVU9PksZkkwCkwBjY2MMBoMemrg8urRtamqql9e2mt+f1azr+2b/razV0H9rsu+qqtMDeBdw64zl9wI3HVbm5cCxw+cfBO5byL4vvPDCWq3O/PBnOv38zp07V7wNrerjfbP/Vs5q6L/V3HfArpojU/sY0jkInDFj+fThupl/VJ6uqh8OF28FLuyhXknSIvQR+A8AZyc5K8kxwFXA1pkFkpw6Y/EKYG8P9UqSFqHzGH5VHUpyLXA3sAG4rar2JPko0/+12Ar8SZIrgEPAM8A1XeuVJC1OL/PhV9V2YPth626Y8fw64Lo+6pIkLY3ftJWkRhj4ktQIA1+SGmHgS1IjvIm5pDWnlxvA71j6Pk487uju9a8AA1/SmrJ/81s672Pjpm297GetcUhHkhrhEf4SnXDOJs6//UVT/y/O7V3bANDeUYqkpTHwl+h7ezd3+i/hYDBgYmKiUxt6GceU1AyHdCSpEQa+JDXCwJekRhj4ktQIA1+SGmHgS1IjDHxJaoSBL0mNMPAlqRG9BH6SS5M8mmRfkhfNN5Dk2CSfGm7/YpKNfdQrSVq4zoGfZANwM3AZcC5wdZJzDyv2B8D/VNUrgb8EbuxaryRpcfo4wr8I2FdVj1XVj4A7gCsPK3MlP5sq7J+BNyZJD3VLkhaoj8nTTgMen7F8ALh4rjJVdSjJs8DLgacO31mSSWASYGxsjMFg0EMTl0eXtk1NTfXy2lbz+7OadX3f7L+1r8X3ftXNlllVW4AtAOPj49V1Rslls2Nbp9ku+5gts2sbmtXD+2b/rXGNvvd9DOkcBM6YsXz6cN2sZZIcBZwIPN1D3ZKkBeoj8B8Azk5yVpJjgKuArYeV2Qq8f/j8XcB9VVU91C1JWqDOQzrDMflrgbuBDcBtVbUnyUeBXVW1Ffg74B+S7AOeYfqPgiRphHoZw6+q7cD2w9bdMOP5D4B391GXJGlp/KatJDVi1V2ls5Z0vqfsjm4/f+JxR3erX1JTDPwl6nIDc5j+Y9F1H5K0GA7pSFIjDHxJaoSBL0mNMPAlqREGviQ1wsCXpEYY+JLUCANfkhph4EtSIwx8SWqEgS9JjTDwJakRBr4kNcLZMtWcE87ZxPm3b+q+o9u7tgPAGVP7lmRh5W488vb1eBdWA1/N+d7ezZ2nph4MBkxMTHTaR+f7KWhWCwnqPvpvLeo0pJPkF5Pck+Trw39fNke5Hyd5aPg4/AbnkqQR6DqGvwn4XFWdDXxuuDyb56vqNcPHFR3rlCQtQdfAv5KfjWTeDryt4/4kScuk6xj+WFV9a/j828DYHOVekmQXcAjYXFWfnmuHSSaBSYCxsTEGg0HHJq5e6/m1rXZd3/upqale+s/fgZXRV/+tNfMGfpJ7gVNm2XT9zIWqqiRznS05s6oOJvll4L4kX6mqb8xWsKq2AFsAxsfHa92eWNmxrcmTRqtCD+99Lyf9/B1YMa2etJ038Kvqkrm2JflOklOr6ltJTgWenGMfB4f/PpZkAPwaMGvgS5KWR9cx/K3A+4fP3w/cdXiBJC9Lcuzw+UnAbwKPdKxXkrRIXQN/M/CmJF8HLhkuk2Q8ya3DMucAu5LsBnYyPYZv4EvSiHU6aVtVTwNvnGX9LuADw+f/CZzfpR5JUnfOpSNJjTDwJakRBr4kNcLAl6RGGPiS1AgDX5Ia4Xz4y2QhN2GY7wYMsD5vwiBpZXiEv0yq6oiPnTt3zlvGsJfUJwNfkhph4EtSIwx8SWqEgS9JjTDwJakRBr4kNcLAl6RGGPiS1AgDX5IaYeBLUiM6BX6SdyfZk+QnScaPUO7SJI8m2ZdkU5c6JUlL0/UI/2HgHcD9cxVIsgG4GbgMOBe4Osm5HeuVJC1S15uY74V5Z4a8CNhXVY8Ny94BXAk80qVuSdLijGJ65NOAx2csHwAunqtwkklgEmBsbIzBYLCsjVspU1NT6/a1rQVd3/u++s/fgZXR6udv3sBPci9wyiybrq+qu/puUFVtAbYAjI+P18TERN9VrAqDwYD1+tpWvR3bOr/3vfRfD+3Q0rT6+Zs38Kvqko51HATOmLF8+nCdJGmERjGk8wBwdpKzmA76q4DfHUG90pw2btrWfSc7uu3jxOOO7t4GaRE6BX6StwN/A5wMbEvyUFX9dpJXALdW1eVVdSjJtcDdwAbgtqra07nl0hLt3/yWzvvYuGlbL/uRRqnrVTp3AnfOsv4J4PIZy9uB7V3qkiR14zdtJakRBr4kNcLAl6RGGPiS1AgDX5IaYeBLUiMMfElqhIEvSY0w8CWpEQa+JDXCwJekRhj4ktQIA1+SGmHgS1IjDHxJaoSBL0mNMPAlqREGviQ1olPgJ3l3kj1JfpJk/Ajl9if5SpKHkuzqUqckaWk63dMWeBh4B/DxBZR9Q1U91bE+SdISdb2J+V6AJP20RpK0bLoe4S9UAZ9NUsDHq2rLXAWTTAKTAGNjYwwGg9G0cMSmpqbW7Wtrhf23drX6+Zs38JPcC5wyy6brq+quBdbzuqo6mOSXgHuSfLWq7p+t4PCPwRaA8fHxmpiYWGAVa8tgMGC9vrYm7Nhm/61hrX7+5g38qrqkayVVdXD475NJ7gQuAmYNfEnS8lj2yzKTHJ/khJ8+B97M9MleSdIIdb0s8+1JDgCvBbYluXu4/hVJtg+LjQGfT7Ib+BKwrap2dKlXkrR4Xa/SuRO4c5b1TwCXD58/BlzQpR5JUnd+01aSGmHgS1IjDHxJaoSBL0mNMPAlqREGviQ1wsCXpEYY+JLUCANfkhph4EtSIwx8SWqEgS9JjTDwJakRBr4kNcLAl6RGGPiS1AgDX5IaYeBLUiO63tP2Y0m+muS/k9yZ5KVzlLs0yaNJ9iXZ1KVOSdLSdD3Cvwc4r6peDXwNuO7wAkk2ADcDlwHnAlcnObdjvZKkReoU+FX12ao6NFz8AnD6LMUuAvZV1WNV9SPgDuDKLvVKkhbvqB739fvAp2ZZfxrw+IzlA8DFc+0kySQwCTA2NsZgMOixiavH1NTUun1trbD/1q5WP3/zBn6Se4FTZtl0fVXdNSxzPXAI+MeuDaqqLcAWgPHx8ZqYmOi6y1VpMBiwXl9bE3Zss//WsFY/f/MGflVdcqTtSa4B3gq8sapqliIHgTNmLJ8+XCdJGqGuV+lcCnwIuKKqvj9HsQeAs5OcleQY4Cpga5d6JUmL1/UqnZuAE4B7kjyU5BaAJK9Ish1geFL3WuBuYC/wT1W1p2O9kqRF6nTStqpeOcf6J4DLZyxvB7Z3qUuS1I3ftJWkRhj4ktQIA1+SGmHgS1IjDHxJaoSBL0mNMPAlqRF9Tp4mrRtJ5i9z45G3zz7TiLRyPMKXZlFVR3zs3Llz3jLSamPgS1IjDHxJaoSBL0mNMPAlqREGviQ1wsCXpEYY+JLUCANfkhqR1fwFkSTfBb650u1YJicBT610I7Rk9t/atp7778yqOnm2Das68NezJLuqanyl26Glsf/Wtlb7zyEdSWqEgS9JjTDwV86WlW6AOrH/1rYm+88xfElqhEf4ktQIA1+SGmHgL4MkpyS5I8k3kjyYZHuSX5mj7MYkDw+fvzzJziRTSW4abasFnfruTcPyXxn++1ujbbmgU/9dlOSh4WN3krePtuWj4S0Oe5bpe+PdCdxeVVcN110AjAFfm+fHfwD8OXDe8KER6th3TwG/U1VPJDkPuBs4bTnbq/+vY/89DIxX1aEkpwK7k/xLVR1a1kaPmEf4/XsD8EJV3fLTFVW1G/h8ko8leXh4FPiew3+wqp6rqs8zHfwavS59919V9cRwcQ9wXJJjR9NsDXXpv+/PCPeXAOvyahaP8Pt3HvDgLOvfAbwGuIDpr3U/kOT+UTZM8+qr794JfLmqfth/E3UEnfovycXAbcCZwHvX29E9eIQ/Sq8DPllVP66q7wD/Bvz6CrdJC7PgvkvyKuBG4IMjbJ+ObEH9V1VfrKpXDbddl+QlI27nsjPw+7cHuHClG6El6dR3SU5negz5fVX1jd5apYXq5bNXVXuBKdbheTQDv3/3AccmmfzpiiSvBv4XeE+SDUlOBl4PfGmF2qjZLbnvkrwU2AZsqqr/GGGb9TNd+u+sJEcNn58J/Cqwf1QNHxXH8HtWVTW8pOuvknyY6ROw+4E/BX4e2M30CaEPVdW3k2yc+fNJ9gO/AByT5G3Am6vqkZG9gIZ17LtrgVcCNyS5YbjuzVX15Iia37yO/fc6YFOSF4CfAH9UVetu+mSnVpCkRjikI0mNMPAlqREGviQ1wsCXpEYY+JLUCANfkhph4EtSI/4PWXeu1Roc890AAAAASUVORK5CYII=",
+            "text/plain": [
+              "<Figure size 432x288 with 1 Axes>"
+            ]
+          },
+          "metadata": {
+            "needs_background": "light"
+          },
+          "output_type": "display_data"
+        }
+      ],
       "source": [
         "import numpy as np\n",
         "import matplotlib.pyplot as plt\n",
@@ -5396,33 +5388,33 @@
         "\n",
         "df.boxplot(column=['Col1', 'Col2', 'Col3'])\n",
         "plt.show()"
-      ],
-      "execution_count": 433,
-      "outputs": [
-        {
-          "output_type": "display_data",
-          "data": {
-            "image/png": "iVBORw0KGgoAAAANSUhEUgAAAXwAAAD4CAYAAADvsV2wAAAABHNCSVQICAgIfAhkiAAAAAlwSFlzAAALEgAACxIB0t1+/AAAADh0RVh0U29mdHdhcmUAbWF0cGxvdGxpYiB2ZXJzaW9uMy4yLjIsIGh0dHA6Ly9tYXRwbG90bGliLm9yZy+WH4yJAAARMElEQVR4nO3df4xlZX3H8fenyw8JpWiFDgiEpZGmIIgNU6ipMWNFC2jBnxGaqLQ1Y9qSpv1Hl5Bi6l9L/KNtCiluKCk2jdg0QbbudhFkb6ltVBbLVpYVXckadlERaImDqKx++8dc43SZ2flxztz58bxfyc3ec84z53nufeZ+5uxzzn1OqgpJ0vr3cyvdAEnSaBj4ktQIA1+SGmHgS1IjDHxJasRRK92AIznppJNq48aNK92MZfHcc89x/PHHr3QztET239q2nvvvwQcffKqqTp5t26oO/I0bN7Jr166VbsayGAwGTExMrHQztET239q2nvsvyTfn2uaQjiQ1opfAT3JbkieTPDzH9okkzyZ5aPi4oY96JUkL19eQzt8DNwGfOEKZf6+qt/ZUnyRpkXo5wq+q+4Fn+tiXJGl5jHIM/7VJdif51ySvGmG9kiRGd5XOl4Ezq2oqyeXAp4GzZyuYZBKYBBgbG2MwGIyoiaM1NTW1bl9bC+y/ta3V/ktfs2Um2Qh8pqrOW0DZ/cB4VT11pHLj4+PlZZlajey/tW0991+SB6tqfLZtIxnSSXJKkgyfXzSs9+lR1C1JmtbLkE6STwITwElJDgAfAY4GqKpbgHcBf5jkEPA8cFU5Eb+kZTA8tuxsPUZUL4FfVVfPs/0mpi/blKRltZCg3rhpG/s3v2UErVld/KatJDXCwJekRhj4ktQIA1+SGrGqp0dey7xSQNJq4xH+MqmqIz7O/PBn5i1j2Evqk4EvSY0w8CWpEQa+JDXCwJekRhj4ktQIA1+SGmHgS1IjDHxJaoSBL0mNMPAlqREGviQ1wsnTJK0pF/zFZ3n2+Rc672fjpm1L/tkTjzua3R95c+c2jFpf97S9DXgr8GRVnTfL9gB/DVwOfB+4pqq+3Efd0nLoY7ZTJ79bHs8+/0Ln2xMOBgMmJiaW/PNd/lispL6GdP4euPQI2y8Dzh4+JoG/7aleaVn0MduptNr0EvhVdT/wzBGKXAl8oqZ9AXhpklP7qFuStDCjOml7GvD4jOUDw3WSpBFZdSdtk0wyPezD2NgYg8FgZRu0jNbza2uB/bdyur73U1NTnfexFvt/VIF/EDhjxvLpw3UvUlVbgC0A4+Pj1eXEyqq2Y1unk0ZaYfbfyunhve960nat9v+ohnS2Au/LtN8Anq2qb42obkkS/V2W+UlgAjgpyQHgI8DRAFV1C7Cd6Usy9zF9Webv9VGvJGnhegn8qrp6nu0F/HEfdUmSlsapFSSpEQa+JDXCwJekRqy66/Al6UhOOGcT59++qfuObu/SBoBu8/msBAN/ifqYsa/rBExrdcY+qYvv7d3s5GlLZOAvUdcZ+zp/8YO1+0snaWU4hi9JjTDwJakRBr4kNcIxfDVnNdwiDzzprtEz8NWc1XCLPPCku0bPIR1JaoSBL0mNMPAlqREGviQ1wsCXpEYY+JLUCANfkhrRS+AnuTTJo0n2JXnRvKVJrkny3SQPDR8f6KNeSdLCdf7iVZINwM3Am4ADwANJtlbVI4cV/VRVXdu1PknS0vRxhH8RsK+qHquqHwF3AFf2sF9JUo/6mFrhNODxGcsHgItnKffOJK8Hvgb8WVU9PksZkkwCkwBjY2MMBoMemrg8urRtamqql9e2mt+f1azr+2b/razV0H9rsu+qqtMDeBdw64zl9wI3HVbm5cCxw+cfBO5byL4vvPDCWq3O/PBnOv38zp07V7wNrerjfbP/Vs5q6L/V3HfArpojU/sY0jkInDFj+fThupl/VJ6uqh8OF28FLuyhXknSIvQR+A8AZyc5K8kxwFXA1pkFkpw6Y/EKYG8P9UqSFqHzGH5VHUpyLXA3sAG4rar2JPko0/+12Ar8SZIrgEPAM8A1XeuVJC1OL/PhV9V2YPth626Y8fw64Lo+6pIkLY3ftJWkRhj4ktQIA1+SGmHgS1IjvIm5pDWnlxvA71j6Pk487uju9a8AA1/SmrJ/81s672Pjpm297GetcUhHkhrhEf4SnXDOJs6//UVT/y/O7V3bANDeUYqkpTHwl+h7ezd3+i/hYDBgYmKiUxt6GceU1AyHdCSpEQa+JDXCwJekRhj4ktQIA1+SGmHgS1IjDHxJaoSBL0mNMPAlqRG9BH6SS5M8mmRfkhfNN5Dk2CSfGm7/YpKNfdQrSVq4zoGfZANwM3AZcC5wdZJzDyv2B8D/VNUrgb8EbuxaryRpcfo4wr8I2FdVj1XVj4A7gCsPK3MlP5sq7J+BNyZJD3VLkhaoj8nTTgMen7F8ALh4rjJVdSjJs8DLgacO31mSSWASYGxsjMFg0EMTl0eXtk1NTfXy2lbz+7OadX3f7L+1r8X3ftXNlllVW4AtAOPj49V1Rslls2Nbp9ku+5gts2sbmtXD+2b/rXGNvvd9DOkcBM6YsXz6cN2sZZIcBZwIPN1D3ZKkBeoj8B8Azk5yVpJjgKuArYeV2Qq8f/j8XcB9VVU91C1JWqDOQzrDMflrgbuBDcBtVbUnyUeBXVW1Ffg74B+S7AOeYfqPgiRphHoZw6+q7cD2w9bdMOP5D4B391GXJGlp/KatJDVi1V2ls5Z0vqfsjm4/f+JxR3erX1JTDPwl6nIDc5j+Y9F1H5K0GA7pSFIjDHxJaoSBL0mNMPAlqREGviQ1wsCXpEYY+JLUCANfkhph4EtSIwx8SWqEgS9JjTDwJakRBr4kNcLZMtWcE87ZxPm3b+q+o9u7tgPAGVP7lmRh5W488vb1eBdWA1/N+d7ezZ2nph4MBkxMTHTaR+f7KWhWCwnqPvpvLeo0pJPkF5Pck+Trw39fNke5Hyd5aPg4/AbnkqQR6DqGvwn4XFWdDXxuuDyb56vqNcPHFR3rlCQtQdfAv5KfjWTeDryt4/4kScuk6xj+WFV9a/j828DYHOVekmQXcAjYXFWfnmuHSSaBSYCxsTEGg0HHJq5e6/m1rXZd3/upqale+s/fgZXRV/+tNfMGfpJ7gVNm2XT9zIWqqiRznS05s6oOJvll4L4kX6mqb8xWsKq2AFsAxsfHa92eWNmxrcmTRqtCD+99Lyf9/B1YMa2etJ038Kvqkrm2JflOklOr6ltJTgWenGMfB4f/PpZkAPwaMGvgS5KWR9cx/K3A+4fP3w/cdXiBJC9Lcuzw+UnAbwKPdKxXkrRIXQN/M/CmJF8HLhkuk2Q8ya3DMucAu5LsBnYyPYZv4EvSiHU6aVtVTwNvnGX9LuADw+f/CZzfpR5JUnfOpSNJjTDwJakRBr4kNcLAl6RGGPiS1AgDX5Ia4Xz4y2QhN2GY7wYMsD5vwiBpZXiEv0yq6oiPnTt3zlvGsJfUJwNfkhph4EtSIwx8SWqEgS9JjTDwJakRBr4kNcLAl6RGGPiS1AgDX5IaYeBLUiM6BX6SdyfZk+QnScaPUO7SJI8m2ZdkU5c6JUlL0/UI/2HgHcD9cxVIsgG4GbgMOBe4Osm5HeuVJC1S15uY74V5Z4a8CNhXVY8Ny94BXAk80qVuSdLijGJ65NOAx2csHwAunqtwkklgEmBsbIzBYLCsjVspU1NT6/a1rQVd3/u++s/fgZXR6udv3sBPci9wyiybrq+qu/puUFVtAbYAjI+P18TERN9VrAqDwYD1+tpWvR3bOr/3vfRfD+3Q0rT6+Zs38Kvqko51HATOmLF8+nCdJGmERjGk8wBwdpKzmA76q4DfHUG90pw2btrWfSc7uu3jxOOO7t4GaRE6BX6StwN/A5wMbEvyUFX9dpJXALdW1eVVdSjJtcDdwAbgtqra07nl0hLt3/yWzvvYuGlbL/uRRqnrVTp3AnfOsv4J4PIZy9uB7V3qkiR14zdtJakRBr4kNcLAl6RGGPiS1AgDX5IaYeBLUiMMfElqhIEvSY0w8CWpEQa+JDXCwJekRhj4ktQIA1+SGmHgS1IjDHxJaoSBL0mNMPAlqREGviQ1olPgJ3l3kj1JfpJk/Ajl9if5SpKHkuzqUqckaWk63dMWeBh4B/DxBZR9Q1U91bE+SdISdb2J+V6AJP20RpK0bLoe4S9UAZ9NUsDHq2rLXAWTTAKTAGNjYwwGg9G0cMSmpqbW7Wtrhf23drX6+Zs38JPcC5wyy6brq+quBdbzuqo6mOSXgHuSfLWq7p+t4PCPwRaA8fHxmpiYWGAVa8tgMGC9vrYm7Nhm/61hrX7+5g38qrqkayVVdXD475NJ7gQuAmYNfEnS8lj2yzKTHJ/khJ8+B97M9MleSdIIdb0s8+1JDgCvBbYluXu4/hVJtg+LjQGfT7Ib+BKwrap2dKlXkrR4Xa/SuRO4c5b1TwCXD58/BlzQpR5JUnd+01aSGmHgS1IjDHxJaoSBL0mNMPAlqREGviQ1wsCXpEYY+JLUCANfkhph4EtSIwx8SWqEgS9JjTDwJakRBr4kNcLAl6RGGPiS1AgDX5IaYeBLUiO63tP2Y0m+muS/k9yZ5KVzlLs0yaNJ9iXZ1KVOSdLSdD3Cvwc4r6peDXwNuO7wAkk2ADcDlwHnAlcnObdjvZKkReoU+FX12ao6NFz8AnD6LMUuAvZV1WNV9SPgDuDKLvVKkhbvqB739fvAp2ZZfxrw+IzlA8DFc+0kySQwCTA2NsZgMOixiavH1NTUun1trbD/1q5WP3/zBn6Se4FTZtl0fVXdNSxzPXAI+MeuDaqqLcAWgPHx8ZqYmOi6y1VpMBiwXl9bE3Zss//WsFY/f/MGflVdcqTtSa4B3gq8sapqliIHgTNmLJ8+XCdJGqGuV+lcCnwIuKKqvj9HsQeAs5OcleQY4Cpga5d6JUmL1/UqnZuAE4B7kjyU5BaAJK9Ish1geFL3WuBuYC/wT1W1p2O9kqRF6nTStqpeOcf6J4DLZyxvB7Z3qUuS1I3ftJWkRhj4ktQIA1+SGmHgS1IjDHxJaoSBL0mNMPAlqRF9Tp4mrRtJ5i9z45G3zz7TiLRyPMKXZlFVR3zs3Llz3jLSamPgS1IjDHxJaoSBL0mNMPAlqREGviQ1wsCXpEYY+JLUCANfkhqR1fwFkSTfBb650u1YJicBT610I7Rk9t/atp7778yqOnm2Das68NezJLuqanyl26Glsf/Wtlb7zyEdSWqEgS9JjTDwV86WlW6AOrH/1rYm+88xfElqhEf4ktQIA1+SGmHgL4MkpyS5I8k3kjyYZHuSX5mj7MYkDw+fvzzJziRTSW4abasFnfruTcPyXxn++1ujbbmgU/9dlOSh4WN3krePtuWj4S0Oe5bpe+PdCdxeVVcN110AjAFfm+fHfwD8OXDe8KER6th3TwG/U1VPJDkPuBs4bTnbq/+vY/89DIxX1aEkpwK7k/xLVR1a1kaPmEf4/XsD8EJV3fLTFVW1G/h8ko8leXh4FPiew3+wqp6rqs8zHfwavS59919V9cRwcQ9wXJJjR9NsDXXpv+/PCPeXAOvyahaP8Pt3HvDgLOvfAbwGuIDpr3U/kOT+UTZM8+qr794JfLmqfth/E3UEnfovycXAbcCZwHvX29E9eIQ/Sq8DPllVP66q7wD/Bvz6CrdJC7PgvkvyKuBG4IMjbJ+ObEH9V1VfrKpXDbddl+QlI27nsjPw+7cHuHClG6El6dR3SU5negz5fVX1jd5apYXq5bNXVXuBKdbheTQDv3/3AccmmfzpiiSvBv4XeE+SDUlOBl4PfGmF2qjZLbnvkrwU2AZsqqr/GGGb9TNd+u+sJEcNn58J/Cqwf1QNHxXH8HtWVTW8pOuvknyY6ROw+4E/BX4e2M30CaEPVdW3k2yc+fNJ9gO/AByT5G3Am6vqkZG9gIZ17LtrgVcCNyS5YbjuzVX15Iia37yO/fc6YFOSF4CfAH9UVetu+mSnVpCkRjikI0mNMPAlqREGviQ1wsCXpEYY+JLUCANfkhph4EtSI/4PWXeu1Roc890AAAAASUVORK5CYII=\n",
-            "text/plain": [
-              "<Figure size 432x288 with 1 Axes>"
-            ]
-          },
-          "metadata": {
-            "needs_background": "light"
-          }
-        }
       ]
     },
     {
       "cell_type": "code",
+      "execution_count": 88,
       "metadata": {
-        "id": "hcbhY_Ve36Fi",
         "colab": {
           "base_uri": "https://localhost:8080/",
           "height": 301
         },
-        "outputId": "fcf1b770-b9ea-489f-eb78-3f7178038188"
+        "id": "hcbhY_Ve36Fi",
+        "outputId": "2c617500-e571-4315-99db-c100fbf0b1e4"
       },
+      "outputs": [
+        {
+          "data": {
+            "image/png": "iVBORw0KGgoAAAANSUhEUgAAAYcAAAEcCAYAAAAsv3j+AAAABHNCSVQICAgIfAhkiAAAAAlwSFlzAAALEgAACxIB0t1+/AAAADh0RVh0U29mdHdhcmUAbWF0cGxvdGxpYiB2ZXJzaW9uMy4yLjIsIGh0dHA6Ly9tYXRwbG90bGliLm9yZy+WH4yJAAAcH0lEQVR4nO3df5RcZZ3n8feHBPAHTIswNgkBgsrONDSrx2RQdnvXzvEXYDTi+IMeUJGeiY4TXdwjAtMMok7PhGXneGaEURmbBUZpRGcYkk6GX5oepndlJShqoEUj8iOAIqBZkKik/e4f9zZW91PVP1JVfW9VPq9z7knde5+6z7efelLfuvd5qq4iAjMzs0r7FB2AmZmVj5ODmZklnBzMzCzh5GBmZgknBzMzSzg5mJlZwsnBWp6kkPTSouMokqReSTtm2L/Xt5HNj5ODNYyk+yTtkvSUpJ9J2iTp8KLjmiTpDEljRcfRyiR9UNI2SftVbDtL0rckLS4yNmssJwdrtDdFxAHAEuAnwKcLjqdp9tI3w0uBnwMDAJJeDHwc6I+I3UUGZo3l5GBNERG/BL4CHDO5TVKHpKsk/VTS/ZLOl7SPpBdK2iHpTXm5AyRtl/TufP0KSZ+VdLOkJyX9m6Qjq9U7Qx1dwGeBE/Izm5/XeP5Rkm7N67lF0qWSvpDvW55fnumX9ADwtfzY5+d1PZrX3ZGXTy715GdXr80fXyjpK5K+lNf3TUkvqyi7VNI/5X/LjyR9qGLfc/N2+Zmku4E/mMPLcrKkeyU9JuniPPb9JD0h6biKY79I0tOSfnf6ASLiN0A/8OH8Of8A/H1EfHMO9VsLcXKwppD0POCdwG0Vmz8NdAAvBl4NvBt4b0Q8AZwJ/IOkFwGfAu6MiKsqnnsa8EngEOBO4Is1qq5VxzjwfuDrEXFARLygxvOvBr4BHAxcCLyrSplXA13AG4Az8mVVXucBwCU1jl3NGuDLwAvzuv9F0r6S9gE2At8GDgNeA5wl6Q358z4GvCRf3gC8Zw51nQKsBF6R13tmRPwauAY4vaJcH/DViPhptYNExD3AXwNbgGVkZw7WbiLCi5eGLMB9wFNklx2eAR4Gjsv3LQJ+DRxTUf59wGjF+qeB7wIPAQdXbL8CuKZi/QBgAjg8Xw/gpbPVQfYmPjZD/EcAu4HnVWz7AvCF/PHyvK4XV+z/KvCBivXfy//2xUAvsKNKG702f3whcFvFvn2AR4D/ArwSeGDac88D/lf++F7gxIp9a6fXNe25Ma38B8gSAJN1AcrXtwLvmOW17smPOVh0v/PSnMVnDtZob4nsU/lzgHXAv0k6lOwT/77A/RVl7yf7VDzpMqAbuCIiHp923AcnH0TEU8ATwNJpZeZSx0yWAk9ExNPV6q2xbWmV+hYDnXOss/Lv+g2wIz/mkcBSST+fXIA/rzju0mlxVMYwa115+aV5vf8XeBrolfT7ZIl2Q62D5IPRnyNL5uvycQdrM04ObWy26Y3NFBETEfHPZJ/we4DHyD5RV44VHEF2loCkRWTJ4SrgA1WmXT4760nSAWSXYR6eVmbGOsg+6c7kEeCF+SWxpN7KP6/i8cNV6ttNNhj/C+DZY+V/4/Tr+JV/1z5kl2keJnsj/1FEvKBiOTAiTq6ItTK2I2b526b/LUcwtf2uJLu09C7gK5GNGdXyF8CjwH8jG8f53BzqXhBF9vl24+TQIiT9kaSt+WDqI5L+VVLPPI+xLj/GryRd0aRQJ+uSpDXAQcB4REwA1wKDkg7MB5T/O9llG8g+FQfZ2MPFwFX5m+mkkyX15J9aP0l2OWbKp/o51PETYJkqpmFOe/79ZJdULswHak8A3jTLnzpMNjh7VJ60/gr4UmQzd74PPEfSGyXtC5wP7D/t+SskvVXZzKezgF+RjdN8A3hS0jn54PMiSd2SJgeerwXOk3SQpGXAB2eJE+DsvPzhZG/sX6rY9wWyMYnTyRJ0VfmA+YeAP4mIILs0tlzSe+dQ/7zU2+cl7S9pKJ8s8KSkOyWd1Og421bR17W8zL6QvcE9CrwVeD7ZpZM3ARfP8rxeKq5D589/C/AZsks3jY7zPmAX2bjDk8A24LSK/QeRvQn9lOyT8QVkH1BWAD8DXpqXWwT8b2AgX7+C7BPqzfmxbwWOqjhuVDy3ah35vv2ATWSXpB6r8Te8BPj3PP6vkp3NDOX7lud1La4ov09ex4N5nV8ADqrYfwbZp/xHgY+Qjjl8hexN+kngW8ArKp67lCz5/Dhvn9sqnvs8sjfxnwN3A2cz+5jDh8jGKh4H/gZYNK3MLXl8qnGMRWTJ86NV+tljQGeZ+nz+vAvz120fYHXezsuL/j/dCsvkAJSVVD4t8iGyGTdfrrJ/f+Ai4B35pmuBcyLiV5J6yQZTl017zl8CyyLijGbG3ij5Wc6OiDi/gLq/BHwvIj7WhGNfSJbUTp+t7EKQdDnwcBHtPC2Ohvf5iud+B/h4RPxTU4JvI76sVH4nkA3uXldj/wDwKuDlwMuA48kuX9gekPQHkl6SfwfgRLIpn/9SdFzNJmk52af0oWIjAZrU5yV1Av8BuKsxYbY3J4fyO5jsEkitb5+eBnwiIh6NbF76x6k+N9/m5lBglOzy1d8BfxoR3yo0oiaT9EmyS4AXR8SPio6HJvT5fMzni8CVEfG9hkbbpvbGr/+3mseBQyQtrvGfpdpUyulTPFvaQl7+ioiNZF8+W4i6LlyIemYTEX9BNgOpLBra5/NZYP9I9h2YdY0MtJ35zKH8vk42g+UtNfZXm0o5fYqnWStpWJ+XJLJLZZ3AH0bEMw2Ms635zKHkImKnpAuASyXtBm4im8v/WrKfbBgGzpd0O9mMlAv47dTNKfLpkovJZp0skvQcYPcMp+9mC66RfZ5sZl4X2SyvXU0Pvo04ObSAiPgbST8mG3T7Itl0vDuAQeCbwO8A38mLfxn4yxqHOp/sN3kmnU52vfbCxkdttuca0efz77m8j+ws5MfZSQQA74uIWr/NZTlPZTUzs4THHMzMLOHkYGZmCScHMzNLODmYmVnCycHMzBKlnsp6yCGHxPLly4sOo6qdO3fS0dFRdBgtp+ztdscddzwWEcm9kxeC+3t7KnPbzdTfS50cli9fztatW4sOo6qRkRFWr15ddBgtp+ztJmkud1RrCvf39lTmtpupv/uykpmZJZwczMws4eRgZmYJJwczM0s4OZiZWcLJwcysCYaHh+nu7mbNmjV0d3czPDxcdEjzUuqprGZmrWh4eJiBgQGGhoae/Z5Df38/AH19fQVHNzcNOXOQdLmkRyVtq7G/V9JOSXfmywWNqNfMrIwGBwcZGhpi1apVLF68mFWrVjE0NMTg4GDRoc1Zo84crgAuAa6aocy/R0Q5vwliZtZA4+Pj9PT0TNnW09PD+Ph4QRHNX0POHCLiVuCJRhzLzKzVdXV1MTY2NmXb2NgYXV1dBUU0fws55nCCpG+T3Qj8IxFxV7VCktYCawE6OzsZHR1duAjnYWJiorSxlZnbbSr39/Z0yimncNppp3H22WdzxBFH8KlPfYqLL76Y/v7+1mnHiGjIAiwHttXY9zvAAfnjk4EfzOWYK1asiLLauHFj0SG0pLK3G7A1GvR/Yr6L+3t7ufrqq+PYY4+NffbZJ4499ti4+uqriw4pMVN/X5CprBHx/yLiqfzxZmBfSYcsRN1mZkXo6+tj27ZtXH/99Wzbtq1lZilNWpDkIOlQScofH5/X+/hC1G1mZvPXkDEHScNAL3CIpB3Ax4B9ASLis8DbgD+VtBvYBZyan9KYmVkJNSQ5RMSM50sRcQnZVFczM2sB/vkMMzNLODmYmVnCycHMzBJODmZmlnByMDOzhJODmZklnBzMzCzh5GBmZgknBzMzSzg5mJlZwsnBzMwSTg5mZpZwcjAzs4STg5mZJZwczMws4eRgZmYJJwczM0s4OZiZWaIhyUHS5ZIelbStxn5J+jtJ2yV9R9IrGlGvmZk1R6POHK4ATpxh/0nA0fmyFvhMg+o1M7MmaEhyiIhbgSdmKLIGuCoytwEvkLSkEXWbmVnjLV6geg4DHqxY35Fve2R6QUlryc4u6OzsZHR0dCHim7eJiYnSxlZmbrep3N/bX6u23UIlhzmLiMuAywBWrlwZvb29xQZUw8jICGWNrczcblO5v7e/Vm27hZqt9BBweMX6snybmZmV0EIlhw3Au/NZS68CdkZEcknJzMzKoSGXlSQNA73AIZJ2AB8D9gWIiM8Cm4GTge3A08B7G1GvmZk1R0OSQ0T0zbI/gD9rRF1mZtZ8/oa0mZklnBzMzCzh5GBmZonSfc/B2o+kmvuy4SgzKxufOczT8PAw3d3drFmzhu7uboaHh4sOqfQi4tnlyHNGpqybWTn5zGEehoeHGRgYYGhoiJ07d9LR0UF/fz8AfX0zTtgyM2spPnOYh8HBQYaGhli1ahWLFy9m1apVDA0NMTg4WHRoZmYN5eQwD+Pj4/T09EzZ1tPTw/j4eEERmZk1h5PDPHR1dTE2NjZl29jYGF1dXQVFZGbWHE4O8zAwMEB/fz9btmxh9+7dbNmyhf7+fgYGBooOzcysoTwgPQ+Tg84f/OAHGR8fp6uri8HBQQ9Gm1nbcXKYp76+Pvr6+hgZGWH16tVFh2Nm1hS+rGRmZgknBzMzSzg5mJlZwsnBzMwSTg5mZpZwcjAzs0Sj7iF9IvC3wCLg8xGxftr+M4CLgYfyTZdExOcbUbeV18s+fhM7dz2TbF9+7qZkW8dz9+XbH3v9QoRlZnNQd3KQtAi4FHgdsAO4XdKGiLh7WtEvRcS6euuz1rFz1zPct/6NU7bV+n5ItYRhZsVpxGWl44HtEXFvRPwauAZY04DjmplZQRpxWekw4MGK9R3AK6uU+0NJ/xX4PvDhiHiwShkkrQXWAnR2djI6OtqAEBtvYmKitLGVyfQ2mqnd9sb2dH9vfy3bdpV35dqTBXgb2TjD5Pq7yMYUKsscDOyfP34f8LW5HHvFihVRVhs3biw6hNI78pyRZFutdqtWtgjA1qjz/8SeLu7v7anMbTdTf2/EZaWHgMMr1pfx24HnyQT0eET8Kl/9PLCiAfWamVmTNCI53A4cLekoSfsBpwIbKgtIWlKx+mbAd8cxMyuxusccImK3pHXAjWRTWS+PiLskfYLslGUD8CFJbwZ2A08AZ9Rbr5mZNU9DvucQEZuBzdO2XVDx+DzgvEbUZWZmzedvSJuZWcLJwczMEr4TnDXNgV3nctyV5ybbz7syvcJ4YBfAG5PtZlYMJwdrmifH1/vnM8xalC8rmZlZwsnBzMwSTg5mZpZwcjAzs4QHpGdRecOa+y9KB1InHXnOCOCb1phZe3BymMWUG9asj2e3e9aNmbUzJwczq0pSzX3Zrz1bO/OYg5lVVfnb/keeMzL9Pi7W5pwczMws4eRgZmYJJwczM0s4OZiZWcLJwczMEp7KOotaPzsN/ulpM2tfDUkOkk4E/pbsHtKfj4j10/bvD1wFrAAeB94ZEfc1ou5mq/az0+AvwZlZe6s7OUhaBFwKvA7YAdwuaUNE3F1RrB/4WUS8VNKpwEXAO+ute6FUf8MX68bS7R3P3bf5AZmZNVkjzhyOB7ZHxL0Akq4B1gCVyWENcGH++CvAJZIULfBtmmpnDZAljFr7zFpV5W+JTVftQ5J/S6x9NSI5HAY8WLG+A3hlrTIRsVvSTuBg4LHpB5O0FlgL0NnZyejoaANCbI4yx1YW09toYmKiZrvtje1Ztv6+c9czXHHi89PtO3fS0dGRbD/jhl8UHnPZzdTny6x0A9IRcRlwGcDKlSujt7e32IBquWETpY2tLKq00cjISPV220vbs3T9vcbr4Ndtz9Vsu5JrRHJ4CDi8Yn1Zvq1amR2SFgMdZAPTZmZtod1+3r8RyeF24GhJR5ElgVOBP5pWZgPwHuDrwNuAr7XCeIOZ2Vy128/7150c8jGEdcCNZFNZL4+IuyR9AtgaERuAIeAfJW0HniBLIGZmVlINGXOIiM3A5mnbLqh4/Evg7Y2oy8zMmq90A9JmZq2o3X5NwcnBzKwB2u3XFJwc5mH6bRN10W8fe3zdzCbf8Oc6W6nMnBzmoTIB1Po0YGZ7pylnDXOYrVR2/sluMzNLODmYmVnCycHMzBJODmZmlnByMDOzhJODmZklnBzMzCzh5GBmZgknBzMzSzg5mJlZwsnBzMwSTg5mZpZwcjAzs4STg5mZJepKDpJeKOlmST/I/z2oRrkJSXfmy4Z66jQzs+ar98zhXOCrEXE08NV8vZpdEfHyfHlznXWamVmT1Zsc1gBX5o+vBN5S5/HMzKwE6k0OnRHxSP74x0BnjXLPkbRV0m2SnEDMzEpu1tuESroFOLTKroHKlYgISbVupHxkRDwk6cXA1yR9NyJ+WKO+tcBagM7OTkZHR2cLsRATExOlja1MprfRTO22N7ZnGft7tRj8uu25ln2viIg9XoB7gCX54yXAPXN4zhXA2+Zy/BUrVkRZbdy4segQSu/Ic0aSbbXarVrZIgBbo47/E/UsZejvtV6Hsr9uZVbm94qZ+vusZw6z2AC8B1if/3v99AL5DKanI+JXkg4B/jPwP+qs11rE8nM3Tdsi1o1N3wYdz913YQIyszmpNzmsB66V1A/cD7wDQNJK4P0R8cdAF/A5Sb8hG+NYHxF311mvtYD71r8x2bb83E1Vt1s5HNh1LsddWX3S4XlXnlelPIBfz3ZUV3KIiMeB11TZvhX44/zx/wGOq6ceM1sYT46vr5q8R0ZGWL16dbI9PTO0duFvSJuZWcLJwczMEk4OZmaWcHIwM7OEk4OZmSWcHMzMLOHkYGZmCScHMzNLODmYmVnCycHMzBJODmZmlnByMDOzhJODmZklnBzMzCzh5GBmZgknBzMzS9R7JzgzazPVb+Dj27vubZwczOxZtW7h6tu77n3quqwk6e2S7pL0m/y+0bXKnSjpHknbJVW/Qa2ZmZVGvWMO24C3ArfWKiBpEXApcBJwDNAn6Zg66zUzsyaq67JSRIwDSJqp2PHA9oi4Ny97DbAGuLueus3MrHkWYrbSYcCDFes78m1mZlZSs545SLoFOLTKroGIuL7RAUlaC6wF6OzsZHR0tNFVNMTExERpYys7t9tvtUp/B79ue6pV3ytmTQ4R8do663gIOLxifVm+rVZ9lwGXAaxcuTJ6e3vrrL45RkZGKGtspXbDJrdbhVbp737d9lyrvlcsxGWl24GjJR0laT/gVGDDAtRrZmZ7qN6prKdI2gGcAGySdGO+famkzQARsRtYB9wIjAPXRsRd9YVtZmbNVO9speuA66psfxg4uWJ9M7C5nrrMzGzh+LeVzMws4eRgZmYJJwczM0s4OZiZWcLJwczMEk4OZmaWcHIwM7OEk4OZmSWcHMzMLOHkYGZmCScHMzNLODmYmVnCycHMzBJODmZmlnByMDOzhJODmZklnBys6SQ9u9x/0eop62btanh4mO7ubtasWUN3dzfDw8NFhzQvdd0JzmwuIuLZxyMjI6xevbrAaMyab3h4mIGBAYaGhti5cycdHR309/cD0NfXV3B0c1PvPaTfLukuSb+RtHKGcvdJ+q6kOyVtradOM7OyGxwcZGhoiFWrVrF48WJWrVrF0NAQg4ODRYc2Z/WeOWwD3gp8bg5lV0XEY3XWZ2ZWeuPj4/T09EzZ1tPTw/j4eEERzV9dZw4RMR4R9zQqGDOzdtDV1cXY2NiUbWNjY3R1dRUU0fwt1IB0ADdJukPS2gWq08ysEAMDA/T397NlyxZ2797Nli1b6O/vZ2BgoOjQ5mzWy0qSbgEOrbJrICKun2M9PRHxkKQXATdL+l5E3FqjvrXAWoDOzk5GR0fnWMXCmpiYKG1sZeZ2m6pV+jtQ6tjKZsmSJZx22mmceeaZPPDAAxxxxBGcfvrpLFmypHXaMSLqXoBRYOUcy14IfGQuZVesWBFltXHjxqJDaEllbzdgazTg/8SeLGXu70eeM1J0CC2rzH1+pv7e9MtKkp4v6cDJx8DryQayzcyspOqdynqKpB3ACcAmSTfm25dK2pwX6wTGJH0b+AawKSJuqKdeMzNrrrqmskbEdcB1VbY/DJycP74XeFk99ZiZ2cLyz2eYmVnCycHMzBJODmZmlnByMDOzhJODmZklnBzMzCzh5GBmZgknBzMzSzg5mJlZwsnBzMwSTg5mZpZwcjAzs4STg5mZJZwczMws4eRgZmYJJwczM0s4OZiZWcLJwczMEvXeQ/piSd+T9B1J10l6QY1yJ0q6R9J2SefWU6eZmTVfvWcONwPdEfEfge8D500vIGkRcClwEnAM0CfpmDrrNTOzJqorOUTETRGxO1+9DVhWpdjxwPaIuDcifg1cA6ypp14zM2uuRo45nAn8a5XthwEPVqzvyLeZmVlJLZ6tgKRbgEOr7BqIiOvzMgPAbuCL9QYkaS2wFqCzs5PR0dF6D9kUExMTpY2tzNxuU7VKfwdKHVuZtWqfnzU5RMRrZ9ov6QxgNfCaiIgqRR4CDq9YX5Zvq1XfZcBlACtXroze3t7ZQizEyMgIZY2tzNxuU7VKf+eGTX7d9lCr9vl6ZyudCHwUeHNEPF2j2O3A0ZKOkrQfcCqwoZ56zcysueodc7gEOBC4WdKdkj4LIGmppM0A+YD1OuBGYBy4NiLuqrNeMzNrolkvK80kIl5aY/vDwMkV65uBzfXUZWYLS9LU9Yt++7j6FWRrJ/6GtJlVFRHPLhs3bpyybu3PycHMzBJODmZmlnByMDOzhJODmZklnBzMzCzh5GBmZgknBzMzSzg5mJlZQmX+QouknwL3Fx1HDUcBPyo6iBZU9nY7MiJ+t4iK3d/bVpnbrmZ/L3VyKDNJv4iI5xcdR6txu7Umv257rlXbzpeVzMws4eRgZmYJJ4c9989FB9Ci3G6tya/bnmvJtvOYg5mZJXzmYGZmCSeHeZL015JC0klFx9JK8jbblS9PS1pbdEw2N+7z89cO/d2XleZJ0gNAB/CtiOgtOJyWISkiQvnjPwc+GhEvKDgsmwP3+flrh/7uM4d5kNQJHAa8HfhPBYfTyg4GdhUdhM3Ofb4hWrK/13UP6b3QBcD2iLhJ0i8lnRYRXyw6qFYhaRfZB5L9gNMLDsfmxn1+D7V6f/eZw/y8Dbg8f3wTcFaBsbSciHhuROwPrAWGNP0O9lZG7vN7qNX7u8cc5kjSi4EfAhPTdu0bbsRZVV6DzdcngOMi4u4Cw7IZuM/vuXbo7z5zmLuPA+MRsXhyAZ4C/qzguFpOPutFwA+KjsVm5D7fAK3a350c5m41MP1a6y3A+wuIpSVNTu0j+8boJyLimaJjshm5z9eh1fu7LyuZmVnCZw5mZpZwcjAzs4STg5mZJZwczMws4eRgZmYJJwczM0s4ObQwScvzudR3Sjpc0o8kvTDfd1C+vlzSS/IyTxUds9mecn9fWE4Ore+HEfHyiHgQ+AywPt++HrgsIu6LiB9GxMuLC9GsYdzfF4h/lbW9fAq4Q9JZQA+wruB4zJrJ/b2JnBzaSEQ8I+ls4Abg9a32dX2z+XB/by5fVmo/JwGPAN1FB2K2ANzfm8TJoY1IejnwOuBVwIclLSk4JLOmcX9vLieHNpHfSOQzwFkR8QBwMfA/i43KrDnc35vPyaF9/AnwQETcnK//PdAl6dUFxmTWLO7vTeaf7G5hkpYDIxExp+utkp6KiAOaGpRZk7i/LyyfObS2CaBD0p0zFZr8UhDwk4UJy6wp3N8XkM8czMws4TMHMzNLODmYmVnCycHMzBJODmZmlnByMDOzxP8HNoGtj3+amukAAAAASUVORK5CYII=",
+            "text/plain": [
+              "<Figure size 432x288 with 2 Axes>"
+            ]
+          },
+          "metadata": {
+            "needs_background": "light"
+          },
+          "output_type": "display_data"
+        }
+      ],
       "source": [
         "df = pd.DataFrame(np.random.randn(10, 2),\n",
         "                  columns=['Col1', 'Col2'])\n",
@@ -5431,21 +5423,6 @@
         "\n",
         "df.boxplot(by='X')\n",
         "plt.show()"
-      ],
-      "execution_count": 434,
-      "outputs": [
-        {
-          "output_type": "display_data",
-          "data": {
-            "image/png": "iVBORw0KGgoAAAANSUhEUgAAAYcAAAEcCAYAAAAsv3j+AAAABHNCSVQICAgIfAhkiAAAAAlwSFlzAAALEgAACxIB0t1+/AAAADh0RVh0U29mdHdhcmUAbWF0cGxvdGxpYiB2ZXJzaW9uMy4yLjIsIGh0dHA6Ly9tYXRwbG90bGliLm9yZy+WH4yJAAAcH0lEQVR4nO3df5RcZZ3n8feHBPAHTIswNgkBgsrONDSrx2RQdnvXzvEXYDTi+IMeUJGeiY4TXdwjAtMMok7PhGXneGaEURmbBUZpRGcYkk6GX5oepndlJShqoEUj8iOAIqBZkKik/e4f9zZW91PVP1JVfW9VPq9z7knde5+6z7efelLfuvd5qq4iAjMzs0r7FB2AmZmVj5ODmZklnBzMzCzh5GBmZgknBzMzSzg5mJlZwsnBWp6kkPTSouMokqReSTtm2L/Xt5HNj5ODNYyk+yTtkvSUpJ9J2iTp8KLjmiTpDEljRcfRyiR9UNI2SftVbDtL0rckLS4yNmssJwdrtDdFxAHAEuAnwKcLjqdp9tI3w0uBnwMDAJJeDHwc6I+I3UUGZo3l5GBNERG/BL4CHDO5TVKHpKsk/VTS/ZLOl7SPpBdK2iHpTXm5AyRtl/TufP0KSZ+VdLOkJyX9m6Qjq9U7Qx1dwGeBE/Izm5/XeP5Rkm7N67lF0qWSvpDvW55fnumX9ADwtfzY5+d1PZrX3ZGXTy715GdXr80fXyjpK5K+lNf3TUkvqyi7VNI/5X/LjyR9qGLfc/N2+Zmku4E/mMPLcrKkeyU9JuniPPb9JD0h6biKY79I0tOSfnf6ASLiN0A/8OH8Of8A/H1EfHMO9VsLcXKwppD0POCdwG0Vmz8NdAAvBl4NvBt4b0Q8AZwJ/IOkFwGfAu6MiKsqnnsa8EngEOBO4Is1qq5VxzjwfuDrEXFARLygxvOvBr4BHAxcCLyrSplXA13AG4Az8mVVXucBwCU1jl3NGuDLwAvzuv9F0r6S9gE2At8GDgNeA5wl6Q358z4GvCRf3gC8Zw51nQKsBF6R13tmRPwauAY4vaJcH/DViPhptYNExD3AXwNbgGVkZw7WbiLCi5eGLMB9wFNklx2eAR4Gjsv3LQJ+DRxTUf59wGjF+qeB7wIPAQdXbL8CuKZi/QBgAjg8Xw/gpbPVQfYmPjZD/EcAu4HnVWz7AvCF/PHyvK4XV+z/KvCBivXfy//2xUAvsKNKG702f3whcFvFvn2AR4D/ArwSeGDac88D/lf++F7gxIp9a6fXNe25Ma38B8gSAJN1AcrXtwLvmOW17smPOVh0v/PSnMVnDtZob4nsU/lzgHXAv0k6lOwT/77A/RVl7yf7VDzpMqAbuCIiHp923AcnH0TEU8ATwNJpZeZSx0yWAk9ExNPV6q2xbWmV+hYDnXOss/Lv+g2wIz/mkcBSST+fXIA/rzju0mlxVMYwa115+aV5vf8XeBrolfT7ZIl2Q62D5IPRnyNL5uvycQdrM04ObWy26Y3NFBETEfHPZJ/we4DHyD5RV44VHEF2loCkRWTJ4SrgA1WmXT4760nSAWSXYR6eVmbGOsg+6c7kEeCF+SWxpN7KP6/i8cNV6ttNNhj/C+DZY+V/4/Tr+JV/1z5kl2keJnsj/1FEvKBiOTAiTq6ItTK2I2b526b/LUcwtf2uJLu09C7gK5GNGdXyF8CjwH8jG8f53BzqXhBF9vl24+TQIiT9kaSt+WDqI5L+VVLPPI+xLj/GryRd0aRQJ+uSpDXAQcB4REwA1wKDkg7MB5T/O9llG8g+FQfZ2MPFwFX5m+mkkyX15J9aP0l2OWbKp/o51PETYJkqpmFOe/79ZJdULswHak8A3jTLnzpMNjh7VJ60/gr4UmQzd74PPEfSGyXtC5wP7D/t+SskvVXZzKezgF+RjdN8A3hS0jn54PMiSd2SJgeerwXOk3SQpGXAB2eJE+DsvPzhZG/sX6rY9wWyMYnTyRJ0VfmA+YeAP4mIILs0tlzSe+dQ/7zU2+cl7S9pKJ8s8KSkOyWd1Og421bR17W8zL6QvcE9CrwVeD7ZpZM3ARfP8rxeKq5D589/C/AZsks3jY7zPmAX2bjDk8A24LSK/QeRvQn9lOyT8QVkH1BWAD8DXpqXWwT8b2AgX7+C7BPqzfmxbwWOqjhuVDy3ah35vv2ATWSXpB6r8Te8BPj3PP6vkp3NDOX7lud1La4ov09ex4N5nV8ADqrYfwbZp/xHgY+Qjjl8hexN+kngW8ArKp67lCz5/Dhvn9sqnvs8sjfxnwN3A2cz+5jDh8jGKh4H/gZYNK3MLXl8qnGMRWTJ86NV+tljQGeZ+nz+vAvz120fYHXezsuL/j/dCsvkAJSVVD4t8iGyGTdfrrJ/f+Ai4B35pmuBcyLiV5J6yQZTl017zl8CyyLijGbG3ij5Wc6OiDi/gLq/BHwvIj7WhGNfSJbUTp+t7EKQdDnwcBHtPC2Ohvf5iud+B/h4RPxTU4JvI76sVH4nkA3uXldj/wDwKuDlwMuA48kuX9gekPQHkl6SfwfgRLIpn/9SdFzNJmk52af0oWIjAZrU5yV1Av8BuKsxYbY3J4fyO5jsEkitb5+eBnwiIh6NbF76x6k+N9/m5lBglOzy1d8BfxoR3yo0oiaT9EmyS4AXR8SPio6HJvT5fMzni8CVEfG9hkbbpvbGr/+3mseBQyQtrvGfpdpUyulTPFvaQl7+ioiNZF8+W4i6LlyIemYTEX9BNgOpLBra5/NZYP9I9h2YdY0MtJ35zKH8vk42g+UtNfZXm0o5fYqnWStpWJ+XJLJLZZ3AH0bEMw2Ms635zKHkImKnpAuASyXtBm4im8v/WrKfbBgGzpd0O9mMlAv47dTNKfLpkovJZp0skvQcYPcMp+9mC66RfZ5sZl4X2SyvXU0Pvo04ObSAiPgbST8mG3T7Itl0vDuAQeCbwO8A38mLfxn4yxqHOp/sN3kmnU52vfbCxkdttuca0efz77m8j+ws5MfZSQQA74uIWr/NZTlPZTUzs4THHMzMLOHkYGZmCScHMzNLODmYmVnCycHMzBKlnsp6yCGHxPLly4sOo6qdO3fS0dFRdBgtp+ztdscddzwWEcm9kxeC+3t7KnPbzdTfS50cli9fztatW4sOo6qRkRFWr15ddBgtp+ztJmkud1RrCvf39lTmtpupv/uykpmZJZwczMws4eRgZmYJJwczM0s4OZiZWcLJwcysCYaHh+nu7mbNmjV0d3czPDxcdEjzUuqprGZmrWh4eJiBgQGGhoae/Z5Df38/AH19fQVHNzcNOXOQdLmkRyVtq7G/V9JOSXfmywWNqNfMrIwGBwcZGhpi1apVLF68mFWrVjE0NMTg4GDRoc1Zo84crgAuAa6aocy/R0Q5vwliZtZA4+Pj9PT0TNnW09PD+Ph4QRHNX0POHCLiVuCJRhzLzKzVdXV1MTY2NmXb2NgYXV1dBUU0fws55nCCpG+T3Qj8IxFxV7VCktYCawE6OzsZHR1duAjnYWJiorSxlZnbbSr39/Z0yimncNppp3H22WdzxBFH8KlPfYqLL76Y/v7+1mnHiGjIAiwHttXY9zvAAfnjk4EfzOWYK1asiLLauHFj0SG0pLK3G7A1GvR/Yr6L+3t7ufrqq+PYY4+NffbZJ4499ti4+uqriw4pMVN/X5CprBHx/yLiqfzxZmBfSYcsRN1mZkXo6+tj27ZtXH/99Wzbtq1lZilNWpDkIOlQScofH5/X+/hC1G1mZvPXkDEHScNAL3CIpB3Ax4B9ASLis8DbgD+VtBvYBZyan9KYmVkJNSQ5RMSM50sRcQnZVFczM2sB/vkMMzNLODmYmVnCycHMzBJODmZmlnByMDOzhJODmZklnBzMzCzh5GBmZgknBzMzSzg5mJlZwsnBzMwSTg5mZpZwcjAzs4STg5mZJZwczMws4eRgZmYJJwczM0s4OZiZWaIhyUHS5ZIelbStxn5J+jtJ2yV9R9IrGlGvmZk1R6POHK4ATpxh/0nA0fmyFvhMg+o1M7MmaEhyiIhbgSdmKLIGuCoytwEvkLSkEXWbmVnjLV6geg4DHqxY35Fve2R6QUlryc4u6OzsZHR0dCHim7eJiYnSxlZmbrep3N/bX6u23UIlhzmLiMuAywBWrlwZvb29xQZUw8jICGWNrczcblO5v7e/Vm27hZqt9BBweMX6snybmZmV0EIlhw3Au/NZS68CdkZEcknJzMzKoSGXlSQNA73AIZJ2AB8D9gWIiM8Cm4GTge3A08B7G1GvmZk1R0OSQ0T0zbI/gD9rRF1mZtZ8/oa0mZklnBzMzCzh5GBmZonSfc/B2o+kmvuy4SgzKxufOczT8PAw3d3drFmzhu7uboaHh4sOqfQi4tnlyHNGpqybWTn5zGEehoeHGRgYYGhoiJ07d9LR0UF/fz8AfX0zTtgyM2spPnOYh8HBQYaGhli1ahWLFy9m1apVDA0NMTg4WHRoZmYN5eQwD+Pj4/T09EzZ1tPTw/j4eEERmZk1h5PDPHR1dTE2NjZl29jYGF1dXQVFZGbWHE4O8zAwMEB/fz9btmxh9+7dbNmyhf7+fgYGBooOzcysoTwgPQ+Tg84f/OAHGR8fp6uri8HBQQ9Gm1nbcXKYp76+Pvr6+hgZGWH16tVFh2Nm1hS+rGRmZgknBzMzSzg5mJlZwsnBzMwSTg5mZpZwcjAzs0Sj7iF9IvC3wCLg8xGxftr+M4CLgYfyTZdExOcbUbeV18s+fhM7dz2TbF9+7qZkW8dz9+XbH3v9QoRlZnNQd3KQtAi4FHgdsAO4XdKGiLh7WtEvRcS6euuz1rFz1zPct/6NU7bV+n5ItYRhZsVpxGWl44HtEXFvRPwauAZY04DjmplZQRpxWekw4MGK9R3AK6uU+0NJ/xX4PvDhiHiwShkkrQXWAnR2djI6OtqAEBtvYmKitLGVyfQ2mqnd9sb2dH9vfy3bdpV35dqTBXgb2TjD5Pq7yMYUKsscDOyfP34f8LW5HHvFihVRVhs3biw6hNI78pyRZFutdqtWtgjA1qjz/8SeLu7v7anMbTdTf2/EZaWHgMMr1pfx24HnyQT0eET8Kl/9PLCiAfWamVmTNCI53A4cLekoSfsBpwIbKgtIWlKx+mbAd8cxMyuxusccImK3pHXAjWRTWS+PiLskfYLslGUD8CFJbwZ2A08AZ9Rbr5mZNU9DvucQEZuBzdO2XVDx+DzgvEbUZWZmzedvSJuZWcLJwczMEr4TnDXNgV3nctyV5ybbz7syvcJ4YBfAG5PtZlYMJwdrmifH1/vnM8xalC8rmZlZwsnBzMwSTg5mZpZwcjAzs4QHpGdRecOa+y9KB1InHXnOCOCb1phZe3BymMWUG9asj2e3e9aNmbUzJwczq0pSzX3Zrz1bO/OYg5lVVfnb/keeMzL9Pi7W5pwczMws4eRgZmYJJwczM0s4OZiZWcLJwczMEp7KOotaPzsN/ulpM2tfDUkOkk4E/pbsHtKfj4j10/bvD1wFrAAeB94ZEfc1ou5mq/az0+AvwZlZe6s7OUhaBFwKvA7YAdwuaUNE3F1RrB/4WUS8VNKpwEXAO+ute6FUf8MX68bS7R3P3bf5AZmZNVkjzhyOB7ZHxL0Akq4B1gCVyWENcGH++CvAJZIULfBtmmpnDZAljFr7zFpV5W+JTVftQ5J/S6x9NSI5HAY8WLG+A3hlrTIRsVvSTuBg4LHpB5O0FlgL0NnZyejoaANCbI4yx1YW09toYmKiZrvtje1Ztv6+c9czXHHi89PtO3fS0dGRbD/jhl8UHnPZzdTny6x0A9IRcRlwGcDKlSujt7e32IBquWETpY2tLKq00cjISPV220vbs3T9vcbr4Ndtz9Vsu5JrRHJ4CDi8Yn1Zvq1amR2SFgMdZAPTZmZtod1+3r8RyeF24GhJR5ElgVOBP5pWZgPwHuDrwNuAr7XCeIOZ2Vy128/7150c8jGEdcCNZFNZL4+IuyR9AtgaERuAIeAfJW0HniBLIGZmVlINGXOIiM3A5mnbLqh4/Evg7Y2oy8zMmq90A9JmZq2o3X5NwcnBzKwB2u3XFJwc5mH6bRN10W8fe3zdzCbf8Oc6W6nMnBzmoTIB1Po0YGZ7pylnDXOYrVR2/sluMzNLODmYmVnCycHMzBJODmZmlnByMDOzhJODmZklnBzMzCzh5GBmZgknBzMzSzg5mJlZwsnBzMwSTg5mZpZwcjAzs4STg5mZJepKDpJeKOlmST/I/z2oRrkJSXfmy4Z66jQzs+ar98zhXOCrEXE08NV8vZpdEfHyfHlznXWamVmT1Zsc1gBX5o+vBN5S5/HMzKwE6k0OnRHxSP74x0BnjXLPkbRV0m2SnEDMzEpu1tuESroFOLTKroHKlYgISbVupHxkRDwk6cXA1yR9NyJ+WKO+tcBagM7OTkZHR2cLsRATExOlja1MprfRTO22N7ZnGft7tRj8uu25ln2viIg9XoB7gCX54yXAPXN4zhXA2+Zy/BUrVkRZbdy4segQSu/Ic0aSbbXarVrZIgBbo47/E/UsZejvtV6Hsr9uZVbm94qZ+vusZw6z2AC8B1if/3v99AL5DKanI+JXkg4B/jPwP+qs11rE8nM3Tdsi1o1N3wYdz913YQIyszmpNzmsB66V1A/cD7wDQNJK4P0R8cdAF/A5Sb8hG+NYHxF311mvtYD71r8x2bb83E1Vt1s5HNh1LsddWX3S4XlXnlelPIBfz3ZUV3KIiMeB11TZvhX44/zx/wGOq6ceM1sYT46vr5q8R0ZGWL16dbI9PTO0duFvSJuZWcLJwczMEk4OZmaWcHIwM7OEk4OZmSWcHMzMLOHkYGZmCScHMzNLODmYmVnCycHMzBJODmZmlnByMDOzhJODmZklnBzMzCzh5GBmZgknBzMzS9R7JzgzazPVb+Dj27vubZwczOxZtW7h6tu77n3quqwk6e2S7pL0m/y+0bXKnSjpHknbJVW/Qa2ZmZVGvWMO24C3ArfWKiBpEXApcBJwDNAn6Zg66zUzsyaq67JSRIwDSJqp2PHA9oi4Ny97DbAGuLueus3MrHkWYrbSYcCDFes78m1mZlZSs545SLoFOLTKroGIuL7RAUlaC6wF6OzsZHR0tNFVNMTExERpYys7t9tvtUp/B79ue6pV3ytmTQ4R8do663gIOLxifVm+rVZ9lwGXAaxcuTJ6e3vrrL45RkZGKGtspXbDJrdbhVbp737d9lyrvlcsxGWl24GjJR0laT/gVGDDAtRrZmZ7qN6prKdI2gGcAGySdGO+famkzQARsRtYB9wIjAPXRsRd9YVtZmbNVO9speuA66psfxg4uWJ9M7C5nrrMzGzh+LeVzMws4eRgZmYJJwczM0s4OZiZWcLJwczMEk4OZmaWcHIwM7OEk4OZmSWcHMzMLOHkYGZmCScHMzNLODmYmVnCycHMzBJODmZmlnByMDOzhJODmZklnBys6SQ9u9x/0eop62btanh4mO7ubtasWUN3dzfDw8NFhzQvdd0JzmwuIuLZxyMjI6xevbrAaMyab3h4mIGBAYaGhti5cycdHR309/cD0NfXV3B0c1PvPaTfLukuSb+RtHKGcvdJ+q6kOyVtradOM7OyGxwcZGhoiFWrVrF48WJWrVrF0NAQg4ODRYc2Z/WeOWwD3gp8bg5lV0XEY3XWZ2ZWeuPj4/T09EzZ1tPTw/j4eEERzV9dZw4RMR4R9zQqGDOzdtDV1cXY2NiUbWNjY3R1dRUU0fwt1IB0ADdJukPS2gWq08ysEAMDA/T397NlyxZ2797Nli1b6O/vZ2BgoOjQ5mzWy0qSbgEOrbJrICKun2M9PRHxkKQXATdL+l5E3FqjvrXAWoDOzk5GR0fnWMXCmpiYKG1sZeZ2m6pV+jtQ6tjKZsmSJZx22mmceeaZPPDAAxxxxBGcfvrpLFmypHXaMSLqXoBRYOUcy14IfGQuZVesWBFltXHjxqJDaEllbzdgazTg/8SeLGXu70eeM1J0CC2rzH1+pv7e9MtKkp4v6cDJx8DryQayzcyspOqdynqKpB3ACcAmSTfm25dK2pwX6wTGJH0b+AawKSJuqKdeMzNrrrqmskbEdcB1VbY/DJycP74XeFk99ZiZ2cLyz2eYmVnCycHMzBJODmZmlnByMDOzhJODmZklnBzMzCzh5GBmZgknBzMzSzg5mJlZwsnBzMwSTg5mZpZwcjAzs4STg5mZJZwczMws4eRgZmYJJwczM0s4OZiZWcLJwczMEvXeQ/piSd+T9B1J10l6QY1yJ0q6R9J2SefWU6eZmTVfvWcONwPdEfEfge8D500vIGkRcClwEnAM0CfpmDrrNTOzJqorOUTETRGxO1+9DVhWpdjxwPaIuDcifg1cA6ypp14zM2uuRo45nAn8a5XthwEPVqzvyLeZmVlJLZ6tgKRbgEOr7BqIiOvzMgPAbuCL9QYkaS2wFqCzs5PR0dF6D9kUExMTpY2tzNxuU7VKfwdKHVuZtWqfnzU5RMRrZ9ov6QxgNfCaiIgqRR4CDq9YX5Zvq1XfZcBlACtXroze3t7ZQizEyMgIZY2tzNxuU7VKf+eGTX7d9lCr9vl6ZyudCHwUeHNEPF2j2O3A0ZKOkrQfcCqwoZ56zcysueodc7gEOBC4WdKdkj4LIGmppM0A+YD1OuBGYBy4NiLuqrNeMzNrolkvK80kIl5aY/vDwMkV65uBzfXUZWYLS9LU9Yt++7j6FWRrJ/6GtJlVFRHPLhs3bpyybu3PycHMzBJODmZmlnByMDOzhJODmZklnBzMzCzh5GBmZgknBzMzSzg5mJlZQmX+QouknwL3Fx1HDUcBPyo6iBZU9nY7MiJ+t4iK3d/bVpnbrmZ/L3VyKDNJv4iI5xcdR6txu7Umv257rlXbzpeVzMws4eRgZmYJJ4c9989FB9Ci3G6tya/bnmvJtvOYg5mZJXzmYGZmCSeHeZL015JC0klFx9JK8jbblS9PS1pbdEw2N+7z89cO/d2XleZJ0gNAB/CtiOgtOJyWISkiQvnjPwc+GhEvKDgsmwP3+flrh/7uM4d5kNQJHAa8HfhPBYfTyg4GdhUdhM3Ofb4hWrK/13UP6b3QBcD2iLhJ0i8lnRYRXyw6qFYhaRfZB5L9gNMLDsfmxn1+D7V6f/eZw/y8Dbg8f3wTcFaBsbSciHhuROwPrAWGNP0O9lZG7vN7qNX7u8cc5kjSi4EfAhPTdu0bbsRZVV6DzdcngOMi4u4Cw7IZuM/vuXbo7z5zmLuPA+MRsXhyAZ4C/qzguFpOPutFwA+KjsVm5D7fAK3a350c5m41MP1a6y3A+wuIpSVNTu0j+8boJyLimaJjshm5z9eh1fu7LyuZmVnCZw5mZpZwcjAzs4STg5mZJZwczMws4eRgZmYJJwczM0s4ObQwScvzudR3Sjpc0o8kvTDfd1C+vlzSS/IyTxUds9mecn9fWE4Ore+HEfHyiHgQ+AywPt++HrgsIu6LiB9GxMuLC9GsYdzfF4h/lbW9fAq4Q9JZQA+wruB4zJrJ/b2JnBzaSEQ8I+ls4Abg9a32dX2z+XB/by5fVmo/JwGPAN1FB2K2ANzfm8TJoY1IejnwOuBVwIclLSk4JLOmcX9vLieHNpHfSOQzwFkR8QBwMfA/i43KrDnc35vPyaF9/AnwQETcnK//PdAl6dUFxmTWLO7vTeaf7G5hkpYDIxExp+utkp6KiAOaGpRZk7i/LyyfObS2CaBD0p0zFZr8UhDwk4UJy6wp3N8XkM8czMws4TMHMzNLODmYmVnCycHMzBJODmZmlnByMDOzxP8HNoGtj3+amukAAAAASUVORK5CYII=\n",
-            "text/plain": [
-              "<Figure size 432x288 with 2 Axes>"
-            ]
-          },
-          "metadata": {
-            "needs_background": "light"
-          }
-        }
       ]
     },
     {
@@ -5454,40 +5431,40 @@
         "id": "ZF4AxIdbBZpA"
       },
       "source": [
-        "## seris plot"
+        "## series plot"
       ]
     },
     {
       "cell_type": "code",
+      "execution_count": 89,
       "metadata": {
-        "id": "oYmH1phh46gB",
         "colab": {
           "base_uri": "https://localhost:8080/",
           "height": 267
         },
-        "outputId": "257e826a-48f5-4519-afe7-51260a5dc6ab"
+        "id": "oYmH1phh46gB",
+        "outputId": "0525a417-7c83-43e1-d953-e1b9d525c53c"
       },
-      "source": [
-        "x = np.cumsum(np.random.normal(loc=1, scale=5, size=50))\n",
-        "s = pd.Series(x)\n",
-        "\n",
-        "s.plot()\n",
-        "plt.show()"
-      ],
-      "execution_count": 435,
       "outputs": [
         {
-          "output_type": "display_data",
           "data": {
-            "image/png": "iVBORw0KGgoAAAANSUhEUgAAAXAAAAD6CAYAAAC4RRw1AAAABHNCSVQICAgIfAhkiAAAAAlwSFlzAAALEgAACxIB0t1+/AAAADh0RVh0U29mdHdhcmUAbWF0cGxvdGxpYiB2ZXJzaW9uMy4yLjIsIGh0dHA6Ly9tYXRwbG90bGliLm9yZy+WH4yJAAAgAElEQVR4nO3deXiU5dX48e/JThYSskEgG3tYgxBZFBUEFKlV60LdqWKpS/1pN6v1rbbvq632tda+rUupWnEXV6haFBFQ2YNASICwZiUbCdnXmdy/PzJggIRMkplMMnM+18WVmWeZ5zw4nNye517EGINSSqm+x8vVASillOoaTeBKKdVHaQJXSqk+ShO4Ukr1UZrAlVKqj9IErpRSfVSHCVxERovIzlZ/KkXkfhEJF5HVInLA9nNATwSslFKqhXSmH7iIeAP5wDTgHqDMGPOEiDwIDDDG/Pps50dGRprExMRuhKuUUp5n+/btx4wxUadv9+nk58wBDhljskXkSmCWbfsyYB1w1gSemJhIampqJy+plFKeTUSy29re2Rr49cBbttcDjTEFtteFwMB2LrxERFJFJLWkpKSTl1NKKdUeuxO4iPgBVwDvnr7PtNRh2qzFGGOWGmNSjDEpUVFn/B+AUkqpLupMC/wy4FtjTJHtfZGIxADYfhY7OjillFLt60wCv4HvyicAK4FFtteLgBWOCkoppVTH7ErgIhIEzAM+aLX5CWCeiBwA5treK6WU6iF29UIxxtQAEadtK6WlV4pSSikX0JGYSinVR2kCV0opB8g6VsOq9MIevaYmcKWUcoAn/rOPu97YTm5ZbY9dUxO4Ukp1U12jlXX7izEGXt/c5qBJp9AErpRS3bR+fwn1Tc3Ehffj7W251DVae+S6msCVUqqbVqUXEBboy5NXT6Sirol/7zraI9fVBK6UUt3QaGlmzd5i5o0ZyIzhESQNCuGVjVl0ZqbXrtIErpRS3bDx0DGqGizMHz8IEeHWGYnsKahke/Zxp19bE7hSSnXDZxmFBPl5c/6ISACuOmcwIQE+LNvk/IeZmsCVUh6rttHCbz9K73LXP2uz4fOMImYnRRPg6w1AoJ8PC1Pi+M/uAoor6x0Z7hk0gSulPNbqPUW8tjmbH7+a2qWeI6lZZZTWNDJ//KBTtt8yPQFLs+HNrTmOCrVNmsCVUh7ry33F9PP1JrOoioc+SOv0g8dVGYX4+Xgxa3T0KdsTI4OYNTqKN7bk0GhpdmTIp9AErpTySNZmw/r9JVw2fhA/mzuKj3YeZdnGLLvPN8bwWXohF46MJNj/zHkBF81IpKSqgVUZzhterwlcKeWRduYep7y2idlJ0fx09gjmjonmsU/2si2rzK7zd+dXcLSinkvHDWpz/0WjokiICOTVTvxS6CxN4Eopj/TlvmK8vYQLR0Xh5SX8eeEkYgf04+43vrXr4eOq9EK8vYS5Y9pcDhgvL+GW6QmkZh8nPb/C0eG3XMMpn6qUUr3cl/tKmJIwgNB+vgCE9vPlH7ekUF1v4Z43v6XJ2n7t2hjDqvRCZgyLYECQX7vHXTcljn6+3rzmpC6FmsCVUh6noKKOvQWVzD7t4ePoQSE8ee1EtmUd5/FP9rZ7/oHiag4fq+HS8W2XT04IDfTlqnOG8NHOfMprGx0Se2t2rcijlFLuZF1mCQAXJ0Wfse+K5MHszCnn5Q1HCAv05a5Zw/H38T7lmFXphYjApWPbLp+0duuMBPKO13K8tomwwPZb611h75qYYSLynojsE5G9IjJDRMJFZLWIHLD9HODQyJRSykm+3FfMkLB+jBoY3Ob+hxYkcfnEGJ754gCX/OUr1uwtOqWL4ar0QibHDyC6f0CH1xoT05/XFk9jaGSQw+I/wd4Syl+BVcaYJCAZ2As8CKwxxowE1tjeK6VUr9ZgsbLh4DFmJ0UhIm0e4+vtxd9vnMyrt0/Fx0tYvCyV217ZxuGSanJKa9lTUMn8dnqf9KQOSygiEgpcCPwIwBjTCDSKyJXALNthy4B1wK+dEaRSSjnKlsNl1DZa2yyfnO7CUVGsuv9Clm3M4pkvDnDpM18xfkgoQLvdB3uSPS3woUAJ8C8R2SEiL4pIEDDQGFNgO6YQ6LgYpJRSLvblvmL8fbyYMSzSruN9vb2444JhfPnLi7hq0hB25JQzbnB/4iMCnRxpx+x5iOkDTAbuNcZsEZG/clq5xBhjRKTNMagisgRYAhAfH9/NcJVSqnvWZRYzY3gE/fy8Oz64leiQAP73umTuuGAYgZ0811nsaYHnAXnGmC229+/RktCLRCQGwPazuK2TjTFLjTEpxpiUqKgoR8SslFJdcrikmqzSWrvKJ+0ZPSiEuHDXt77BjgRujCkEckVktG3THGAPsBJYZNu2CFjhlAiVUspBvtzX0s48vf93X2VvP/B7gTdExA84DNxGS/JfLiKLgWxgoXNCVEopx1ibWcyI6OBe04LuLrsSuDFmJ5DSxq45jg1HKaWco7rBwtYjZdx2/lBXh+IwOpReKeURvjlwjCarcZvyCWgCV0p5iLX7ignx9yEl0X0GjWsCV0q5PWMMazOLuWBUJL7e7pP23OdOlFKqHRlHKymuanCr8gloAldKeYDn1h3Ez9uL2d3o/90baQJXSrm1j9OO8unuQu6bO5LIYH9Xh+NQmsCVUm7rWHUDj6zIIDk2lJ9cOMzV4TicJnCllFsyxvDbj9Kprrfw1HXJ+LjRw8sT3O+OlFIK+DitgP+kF3L/vJGMHBji6nCcQhO4UsrtlFQ18MiKdJLjwlhygfuVTk7QBK6UcisnSic1DVaeunaiW5ZOTnDfO1NKeaSP0wpYlVHIz+aNctvSyQmawJVSbqN16eTHF7jPpFXt0QSulHIL9U1W7nt7h0eUTk6wdz5wpZTqtZqszfz0zR1sPFTK0wuT3b50coL7/4pSSrm15mbDr97dxRd7i/ifK8dx9eRYV4fUYzSBK6X6LGMMv12Rzkc7j/KrS0dzy4xEV4fUozSBK6X6rCdXZfLGlhx+ctEw7p413NXh9DhN4EqpPum5dQd5Yf0hbpoWz4PzkxARV4fU4+x6iCkiWUAVYAUsxpgUEQkH3gESgSxgoTHmuHPCVEqp77yxJZs/rcrkykmD+Z8rx3tk8obOtcBnG2MmGWNOLG78ILDGGDMSWGN7r5RSTrW/qIrfrcxg9ugonrouGS8vz0ze0L0SypXAMtvrZcBV3Q9HKaXaZ202PPBeGsH+Pjx1XbJbLY/WFfbevQE+F5HtIrLEtm2gMabA9roQGNjWiSKyRERSRSS1pKSkm+EqpTzZKxuz2Jlbzu+uGEeEmy3O0BX2DuSZaYzJF5FoYLWI7Gu90xhjRMS0daIxZimwFCAlJaXNY5RSqiM5pbU89VkmFydFc0XyYFeH0yvY1QI3xuTbfhYDHwJTgSIRiQGw/Sx2VpBKKc9mjOGhD9Pw9hIeu8pzH1qersMELiJBIhJy4jVwCZAOrAQW2Q5bBKxwVpBKKc+2PDWXDQdLeWhBEoPD+rk6nF7DnhLKQOBD2288H+BNY8wqEdkGLBeRxUA2sNB5YSqlPFVRZT2PfbKXaUPDueHceFeH06t0mMCNMYeB5Da2lwJznBGUUkpBS+nkvz5Kp9HSzBPXTPToLoNt8ew+OEqpXu3T3YWs3lPEz+eNYmhkkKvD6XU0gSuleqWK2iYeXZnOxNhQFs90/8UZukITuFKq06zNhnvf2sGrm7Kcdo2nV2dSVtPIH6+e4BGLM3SF/q0opTrttU1Z/HvXUf7w6V6KK+sd/vkZRyt4bXM2N09PYNzgUId/vrvQBK6U6pSCijqe+nw/yXFhWKyGv6896NDPN8bw6IoMwgL9+MW80Q79bHejCVwp1Sm/W5mBpbmZv11/Dj88N463tuaQW1brsM//cEc+qdnH+fX80YQG+jrsc92RJnClegFjDJ/uLuD+t3ewKr0Aa3PvnHXi84xCPsso4r45o4iPCOT/zRmJlwh/Wb3fIZ9fVd/EHz7dR3JcGNdNiXPIZ7ozXdRYKRfLLq3hkRUZrN9fQoCvFx/tPErsgH786LxEFp4bR/+A3tEKrW6w8OjKDJIGhXDHBS29Qgb2D+BH5yWy9OvD3DlrOKO6uZjwM18coLSmgZcWpWifbztoC1wpF2mwWPnrFweY95ev2J59nEcuH8uuRy/hhZunMDisH499spcZf1jD71ZmcORYjavD5enP91NYWc/jP5hwyjSud140nGA/H576LLNbn7+/qIpXNmZx/blxJMeFdTdcj6AtcKVc4JsDx/jtinSOHKvh8okx/PbysQzsHwDA/PGDmD9+EOn5Fby84QhvbMlm2aYslt6Swryxbc7a7HS78yp4ZeMRbpoWz5SEAafsGxDkx48vHMbTq/ezM7ecSV1IvsYYHlmRTrC/D7+6NMlRYbs9bYEr1cNe25TFzS9twRjDq7dP5e83Tj6ZvFsbPySUpxdOYsODFzMqOoTHPtlDo6XZYXE0WZvZnl3G39Yc4Ialm0l57AvufmM7K3bmU1nfdPI4i7WZhz5MIyLYnwfmt51cb585lIggP/73s31t7u/Ix2kFbD5cxi8vHU14kF+XPsMTaQtcqR72TmouE2NDWf6TGQT4end4fHRIAA8tSOJH/9rG65uzub0boxKr6pt4a2sOGw+VsvVIGbWNVgDGxvTnvOERbDpcyqe7C/H1Fs4bHsml4wZRXFVPen4lz944ud16fLC/D/fMHsF/f7yHDQePcf6IyE7F9Pgnexk3uD83TtXJqjpDE7hSPehEMvzVpaPtSt4nXDQqipkjIvm/Lw9wzZRYQvt17cHmIysy+HBHPsOjgrhmciznDY9g2rCIk63e5mbDjtzjfJZRxGcZhfzmw90AXJwUzYIJg8762TdOi+fFrw/zp88y+Wh4hF1zdtc3WVny6naOVTfw3M2T8dYHl52iCVypHrQ+s2VZwdmjozt1nojw0IIkLv/bNzy39iAPLRjT6WsXVNTx711Hue38RB79/rg2j/HyEqYkhDMlIZyHLktiX2EVGw+VckXy4A4TcoCvN/fPHcUD76exek8Rl4w7e8K3WJu5960dbD5SyjM/nMTk+AFnPV6dSWvgSvWgdZklDOzvz5iYzne3Gzc4lB+cM4R/bcwi73jnB868siGLZmO4/Xz7SjAiwpiY/iyeOZSoEPvWn7x68hCGRQXx8EfpfLW//TVwm5sNv35/N6v3FPH7K8Zx5aQhdn2+OpUmcKV6iMXazNcHSpg1KrrLS4L98pLRCHS6y151g4U3t+Zw2YQY4sIDu3Rte/h4e/HsjZMJ7efLrS9v5b8+2k1Ng+WUY4wx/M8ne3j/2zx+MW8Ut85IdFo87k4TuFI9ZEduOZX1FmaNjuryZwwO68fimUP5aOdRdudV2H3eO9tyqaq38OMLhnX52vYaE9Ofj++dyR0zh/LGlhwW/N/XbMsqO7n/b18e5F8bslg8cyg/vXiE0+NxZ5rAleoha/cV4+MlnD/S/h4abblz1nDCg/x4/NM9GNPxkHuLtZmXvznCuYkDutRHuysCfL35r8vH8vaPp9NsDAv/sYk/frqXF78+zNOr93PtlFgeXjBGFyfuJrsTuIh4i8gOEfnY9n6oiGwRkYMi8o6IaOdNpc5iXWYJUxIGdHtofP8AX+6bM5LNh8v4cl9xh8evyigkv7yOO3qg9X26acMi+M99F3L9ufH846vDPPbJXi4ZO5Anrp6gQ+UdoDMt8PuAva3ePwn8xRgzAjgOLHZkYEq5k6LKevYUVDKrk71P2nPjtHiGRgbxx//sw2Jtf3CPMYZ/fn2ExIhA5o5xzSjOYH8f/nj1BF657Vx+ctEw/u+Gc3SBBgex629RRGKB7wEv2t4LcDHwnu2QZcBVzghQKXdwsvtgUtfr3635envx6/lJHCyu5oX1h9o9LjX7OLtyy1k8c6jL+1jPGh3NQ5eN6VT/d3V29v4afAZ4ADjxqz4CKDfGnHi8nAe02Q9IRJaISKqIpJaUtN+tSCl3tjazmEH9Axjdzdn6Wrt03EAuGz+Ipz7f3zJHdxst8X9+dZiwQF+u1alZ3VKHCVxELgeKjTHbu3IBY8xSY0yKMSYlKsoxrQ+l+pImazPfHDjGrNFRDn1oJyL8/cbJ3DFzKK9szOL2ZamnzGFy5FgNq/cWcfO0BPr5aavXHdnTAj8fuEJEsoC3aSmd/BUIE5ETIzljgXynRKhUH7c9+zhVDRaH1b9b8/YS/uvysfzx6glsPHiMa57beHJ1nJe/OYKvlxe3npfg8Ouq3qHDBG6MecgYE2uMSQSuB740xtwErAWutR22CFjhtCiV6sPWZZa0dB8cEeG0a9wwNZ5Xb59KUWU9Vz67gS/2FPHu9lyunDSY6JAzZzpU7qE7j4J/DfxcRA7SUhN/yTEhKeVe1mUWc25iOCFOXlnnvBGRfHTP+YT28+WOV1Opb2p2SddB1XM6NZmVMWYdsM72+jAw1fEhKeU+Cirq2FdYxUOX9cwiBcOigvnw7vP4xfJdDAjyY/Qgxz00Vb2PzkaolBN9133Q8fXv9oQF+vHSj87tsesp19He9Eo50drMYgaHBjAyOtjVoSg3pAlcKSdptDSz4WApF43u+uyDSp2NJnClnCQ1u4zqBguzuzH7oFJnowlcKSdZn1nSsrZkJ9aHVKozNIEr5QQZRyt4a2sO04dFEOyvfQWUc2gCV8rBMguruOWlrQT7+/CHH0xwdTjKjWkCV8qBDpVUc9OLW/DxEt788XSnLl+mlCZwpRwku7SGG/+5GTC8+ePpJEYGuTok5eY0gSvlAHnHa7nxn1totDTzxh3TGaH9vlUP0ASuVDcVVtRz4z+3UFXfxGuLp+nwddVj9PG4Ut1gsTZzy0tbKKtp5PU7pjF+SKirQ1IeRBO4Ut2wfn8JB4qr+dsN5/TYiu9KnaAlFKW6YXlqLpHBfswfP8jVoSgPpAlcqS4qqWpgzd5irp4ci6+usq5cQL91SnXRhzvysDQbFqbEujoU5aE0gSvVBcYYlqfmMTk+jBHR2utEuYYmcKW64Nuccg4WV/PDc+NcHYryYB0mcBEJEJGtIrJLRDJE5Pe27UNFZIuIHBSRd0TEz/nhKtU7LN+WS6CfN9+bONjVoSgPZk8LvAG42BiTDEwC5ovIdOBJ4C/GmBHAcWCx88JUqveoabDwcdpRLp8YozMNKpfqMIGbFtW2t762Pwa4GHjPtn0ZcJVTIlSql/lkdwE1jVYWpmj5RLmWXTVwEfEWkZ1AMbAaOASUG2MstkPygCHtnLtERFJFJLWkpMQRMSsPYIxxdQjtWr4tl2FRQUxJGODqUJSHsyuBG2OsxphJQCwwFUiy9wLGmKXGmBRjTEpUlC4tpTr2/LpDzHxyLU3WZleHcoaDxdWkZh/nhylxus6lcrlO9UIxxpQDa4EZQJiInCgAxgL5Do5NeaC0vHKe+jyT/PI6jpbXuTqcM7y7PRdvL+EHk9v8H06lepQ9vVCiRCTM9rofMA/YS0siv9Z22CJghbOCVJ6hvsnKz97ZibetZZtdWuviiE7VZG3m/e35XJwUTXRIgKvDUcquFngMsFZE0oBtwGpjzMfAr4Gfi8hBIAJ4yXlhKk/wp1WZHCqp4fEfjAcgu6x3JfC1+4o5Vt3AD/XhpeolOuwDZYxJA85pY/thWurhSnXbxkPHeHnDEW6dkcA1k2N5+KN0cntZAl+emktUiD+zRuuzHNU76EhM5XKV9U386t00hkYG8eBlSXh5CfHhgWSX1rg6tJOKKutZm1nCNZNj8dGJq1QvoaMQlMv997/3UFBRx/t3nUegX8tXMiE8sFfVwF/ecARjDDdM1fKJ6j20KaFc6rOMQt7bnsc9s0dwTvx3/arjIwLJKavtFf3BK+qaeGNzDgsmxJAQoQsVq95DE7hymWPVDfzmg92MG9yfey8eecq+hPBAahutlNY0uii677y2KYvqBgt3zRru6lCUOoWWUFSPM8awLrOEJ/6zj6oGC2/9cBJ+Pqe2JeIjAoGWroSRwf6uCBOAukYrL2/IYtboKMYN1vUuVe+iLXDVKXWNVjYcPNbl0sbWI2Us/McmbntlG3VNVp67cTKjBp45n3Z8eEupIqfMtQ8yl6fmUlbTyN2zRrg0DqXaoi1wZbeKuiYWv7KN1OzjPHfTZBZMiLH73PT8Cv73s0zW7y8hOsSfx64az8KUuDNa3ifEhfdDxLWDeZqszSz96jApCQOYOjTcZXEo1R5N4MouJVUNLHp5KweKq4gM9ufZtQe5bPygDucDMcbw8EfpvLklh7BAX36zIIlbZyQS4Ot91vP8fbyJ6R9Ajgv7gq/ceZT88jr+56pxLotBqbPRBK46lF9ex80vbqGgoo4XF51LUUU9D7yfxrr9JcweHX3Wc9ftL+HNLTncPD2eB+Yn0T/A1+7rxoUHkuOiFnhzs+H59YdIGhTS4T0q5SpaA1dndbC4mmuf38ix6gZeXzyNi0ZFcdU5QxgcGsCzXx48ay3c2mx44tN9JEQE8sjl4zqVvAESIgJdNpx+9d4iDhZXc9es4TrroOq1NIGrdqXnV/DDf2yiydrM20umk5LYUgf28/FiyYXDSM0+zpYjZe2e//72PDKLqnjg0qR2a91nkxARRElVA7WNlo4P7gRjDC9/c4QH30/jcEl1m/ufW3eI+PBAvteJOr9SPU0TuGrT7rwKbli6mQBfb5b/ZMYZXeiunxpPZLAfz6492Ob5dY1W/rw6k0lxYSyYMKhLMcSHt3QlzC1z3LSytY0WfvrWDv774z28uz2PuU+v5+fv7OTIse96u2w6VMqu3HKWXDhMh82rXk2/napNr2zMQgTevXMGw6KCz9gf4OvN4pnD+PrAMXbllp+x/6VvDlNU2cDD3xvT5RLEiQTuqDlRckprufq5jfxndwEPXpbE5ofmsHjmUD5NL2Du0+v5xfJdZJfW8Pz6Q0SF+HPtlFiHXFcpZ9EErtqUllfOlIQBDA7r1+4xN0+Pp3+Azxmt8GPVDbyw/jCXjB3IuYld736XYBvM44ieKOv3l/D9v39DQUU9r9w2lTsvGk5UiD8Pf28sXz0wmx+dl8jHaUe5+M/r+frAMRbPHNphTxmlXE0TuDpDdYOFgyXVTIwNO+txIQG+/Oi8RD7fU8T+oqqT2/9vzQHqmqz8+jK7V95rU1igH/0DfLrVF9wYw/PrDnHbv7YSExrAv386kwtHnTodbHRIAL+9fCxfPzCbW2ckMDUxnJumxXcrdqV6giZwdYaM/AqMgeS4joeO33b+UAL9vHnO1go/XFLNm1tyuGFqHMPbKL10VkJEUJd7olQ3WLjnzW95ctU+FkyI4YO7zzs5RL8t0f0DePT741h+5wxCOtljRilX0ASuzpCWVwHQYQscYECQHzdNi2flrqNkl9bwp1WZ+Pt4cd+cUQ6JJT48sEsLO+wvquKKv3/DZxlF/GZBEn+74ZyTU9Uq5S40gasz7MorZ0hYP7snkbrjgmH4eHnx8+W7WJVRyE9s9WVHiI8IJO94LdZm++deWbEznyv/voHKOgtv3DGNJRdqX27lnuxZ1DhORNaKyB4RyRCR+2zbw0VktYgcsP0c0NFnqb4hLa+CibH2z7w3sH8A16XEsj37ONEh/txxwVCHxZIQHkiT1di1Qn2DxcojK9K57+2dTBgSyqf/bybTh0U4LBaleht7WuAW4BfGmLHAdOAeERkLPAisMcaMBNbY3qs+7nhNIzlltXaVT1q786LhBPv78OBlSQ4tVcTb2RMlv7yOhf/YzKubslly4TDe+PE0ovvryvHKvdmzqHEBUGB7XSUie4EhwJXALNthy4B1tKxUr/qwtPyW+ndyJ1rg0DJvya5HL8Hby7GlihN9wXPKajm/nWNqGy1c9ewG6hqtvHDzZOaP19GTyjN0qgYuIom0rFC/BRhoS+4AhcDAds5ZIiKpIpJaUlLSjVBVT0izDcoZ38kEDjg8eQPEhPbD11vO2pXw6wPHKKlq4O83nqPJW3kUuxO4iAQD7wP3G2MqW+8zLTMatfmUyRiz1BiTYoxJiYqKausQ1YvsyqtgWFRQpyeechZvLyFuQOBZF3ZYs7eIkAAfzh8R2YORKeV6diVwEfGlJXm/YYz5wLa5SERibPtjgGLnhKh6UlpeOcmdrH87W3xE+yvUNzcbvtxXwkWjovDVeUuUh7GnF4oALwF7jTFPt9q1Elhke70IWOH48FRPKqyop7iqoVM9UHpCvG1e8Lamrt2VV86x6gbmjmmzgqeUW7OnyXI+cAtwsYjstP1ZADwBzBORA8Bc23vVh+3Ka6l/d7YHirPFhwdS1WChvLbpjH1r9hbj7SXMGq3lOeV57OmF8g3Q3tOpOY4NR7lSWl45Pl7CuMH9XR3KKRIiWhY4zi6rZUCQ3yn71uwrZkrCAMIC/do6VSm3pkVDdVJaXgWjBob0uln4TsxKePq0svnldewtqGROki55pjyTJnAFtMzal5ZXYdcEVj0tbsCJhR1OfZD55d4iAOZo/Vt5KE3gCoDs0loq6pp6Xf0boJ+fN9Eh/mf0RPlibzGJEYEMjwpyUWRKuZYmcAW0foDZ+1rgcOYCxzUNFjYdKmXOmIE6UZXyWJrAPcTmw6WUVDW0uz8trwJ/Hy9GDQzpwajsFx8eRE6rFvjXB47RaG1mzhitfyvPpQncA2zPPs4N/9zMHa+mtjsta1peOeMG9++1g2ESIgIprKynvskKfDf6sjtLtinV1/XOf63KYRotzfzmg9308/VmV245r2/OPuMYa7MhPb+yV9a/TzgxqVXe8Vqamw1rM4t19KXyePrtd3P//PowmUVV/PX6c7hgZCT/+1kmhRX1pxxzsLiauiZrr+yBckL8ya6EtbbRl406+lJ5PE3gbuzIsRr+uuYACyYMYt7YgTx+1QQszc08ujL9lON66wjM1hLCv0vgOvpSqRaawN2UMYaHP9yNv7cXj35/HNDSir1vzig+yyji84zCk8em5ZUT4u/D0Ije2x0vPMiPYH8fcspq+WJvkY6+VApN4G7r/W/z2XiolF9flsTAVivT3HHBUJIGhfDIigyq6lvmFknLq2D8kFC8nDCft6OICHHhgWw+XMq+wirmau8TpTSBu6PS6gYe+2QPUwneU64AAA7lSURBVBIGcOPU+FP2+Xp78cerJ1BUVc+fP99Pg8XK3oJKJvbi+vcJCeGB7CusAnT0pVJgx2RWqu95/JO91DRY+OPVE9psVZ8TP4BbpiewbFMWw6OCaLKaXjcHeFtOzImSGBHIsMjeW+5RqqdoC9zNfH2ghA925HPnRcPPOijnV5eOJjrEn9/9ew/Qe0dgtnaiJ4qOvlSqhSZwN1LfZOXhD9MZGhnEPbNHnPXYkABffn/FeKzNhoggP4aE9euhKLtubEzLNLcLJgxycSRK9Q5aQnEjb2zJIaesltcXT7NrStj54wexMCWWYH/fPtGiPSd+AFsfnkN0SEDHByvlATSBu4m6RivPrzvEjGERzBxp/+K+f7o22YlROZ4mb6W+oyUUN/H65myOVTfws3mjXB2KUqqH2LOo8csiUiwi6a22hYvIahE5YPs5wLlhqrOpbbTwwvpDzBwRydShOrmTUp7Cnhb4K8D807Y9CKwxxowE1tjeKxd5bVM2pTWN/GzeSFeHopTqQR0mcGPMV0DZaZuvBJbZXi8DrnJwXMpONQ0W/vHVYS4cFcWUBG19K+VJuloDH2iMKbC9LgR0WJyLLNuURVlNIz+bq61vpTxNtx9iGmMM0PYqAYCILBGRVBFJLSkp6e7lVCvVDRaWfnWYWaOjOCdeH0Mo5Wm6msCLRCQGwPazuL0DjTFLjTEpxpiUqCid/tORlm3Mory2iZ/N1Z4nSnmiribwlcAi2+tFwArHhKPsVVnfxNKvDjMnKZrkuN4/j4lSyvHs6Ub4FrAJGC0ieSKyGHgCmCciB4C5tveqB72yIYuKuibu19a3Uh6rw5GYxpgb2tk1x8GxKDtV1DXx4teHmTtmIBP6wCRUSinn0JGYvUBZTSM1DRa7j//z55lU1lu4X3ueKOXRNIG7WKOlmSuf/Ybv/+2bkyvknM1X+0t4dVM2t58/lPFDtPWtlCfTBO5iy1NzyS2r40hpDb98dxctvTLbVlHbxAPvpTEiOpgH5o/uwSiVUr2RJnAXarBYeXbtQSbHh/HwgjF8llHEP7463O7xj6xM51h1A39ZOMmu6WKVUu5Np5N1oeXbcimoqOdP105k5ohIduSW86dV+5g4JJTzRpw6JezHaUdZsfMoP583Sh9cKqUAbYF3WXOzoby2scvn1zdZeXbtIc5NHMDMEZGICE9eM5FhUcHc+9YOCirqTh5bVFnPwx+mkxwXxt2zhjsifKWUG9AEbvPXLw7w6e6Cjg+0eSc1l+l/XENuWW2XrvfOtlwKK+v52dxRJ1fDCfb34YWbp1DfZOWu17+lwWLFGMMD76XRYLHy9MJkfLz1P5lSqoVmA+BoeR3PrNnPvzYcsfuczYdLqW9q5oX1hzp9vZbW90GmDg1nxvCIU/aNiA7mqeuS2ZlbzmMf7+WNLTms31/CQ5eNYXhUcKevpZRyX5rAgQ935GMMpOdXYrE223XO7rwKAN5NzaOwor5T13tzSw7FVQ2ntL5bu2xCDEsuHMZrm7P5/b8zuGBkJLdMT+jUNZRS7s/jE7gxhg++zcPXW6hrsnKwpLrDcyrqmjh8rIbrz43DagxLz9Jz5HT1TVaeX3+I6cPObH239sClo5kxLIIgfx/+dO1EvLx6/6LDSqme5fEJfFdeBYdKarj9/KEApOVWdHhORn7LMQsmxHDVpCG8ubVlPUp7vL45mxJb6/tsfLy9eHXxVNb9chYxof3s+myllGfx+AT+/vY8/H28uHv2CEICfNiVV97hObts5ZOJsaHcPXs4DZZmXvqm4/r5ibUrzx8RwbRh7be+T/D19iIs0K/jm1BKeSSPTuANFisrdx3l0nGDCO3ny8TYULsS+O78cuLDAwkL9GN4VDDfmxDDqxuzOuxW2LJyfKPO362UcgiPTuBr9xVTUdfE1ZOHADAxNox9BVXUN1nPel5aXsUpg2numT2CmkYrr2zMavec/UVVPL/uEBeMjCQlUdeuVEp1n0cn8Pe25xMd4s8FI1tWCkqODcXSbNhbUNnuOaXVDeQdryO5VQIfE9OfeWMH8q8NWW1OSLUtq4xrn9+Ir7cXj35/nONvRCnlkTw2gZdWN7Aus5gfnDMEb1sPj4mxLSvbpOW1/yBzt+0B5oQhp66C89PZI6ioa+L1zTmnbP8so5CbX9xCZLA/7991HiOitS+3UsoxPDaBr9h5FEuz4erJsSe3xYQGEBnsf9Y6eFpeBSIwfkj/U7Ynx4Vx4agoXvz6MHWNLSWYN7fkcNfr20mK6c97d51HXHigc25GKeWRPHYyq/e/zWP8kP6MHhRycpuIkBwbetYWeFpeBcMigwgJ8D1j370Xj+C6Fzbx5tYcquqbeOaLA8waHcVzN00m0M9j/6qVUk7ikVllX2ElGUcrefT7Y8/YlxwXxpeZxVQ3WAj2P/OvJy2vnPNPmynwhHMTw5k2NJwn/rOXJqvhmsmxPHHNBHx1/hKllBN0K7OIyHwRyRSRgyLyoKOCcrYPvs3Hx0u4InnwGfsmxoZizHdD5VsrqqynuKqBiWeZzvX+uaNoNnDnRcN56rqJmryVUk7T5Ra4iHgDzwLzgDxgm4isNMbscVRwzmCxNvPhjnxmJ0UTEex/xv7vHmSWnzHUfVduue2Y9hP4jOERpD16CUFttN6VUsqRutM8nAocNMYcNsY0Am8DVzomLOf5+uAxSqoauMbW9/t04UF+xIX3a7MOvju/Am8vYWzM2RdU0OStlOoJ3ck0Q4DcVu/zgGmnHyQiS4AlAPHx8d24XOdU1jdhsRp8vAUfL8HHywtfb+GDb/MJC/RldlJ0u+dOjA1jZ86ZPVHS8ioYGR1MPz9dzkwp5XpObyoaY5YCSwFSUlLaX7HXgV7fnM0jK9Jpbudqt85IwN+n/SScHBvKJ2kFlFY3nCyzGGNIyytn3tiBzghZKaU6rTsJPB+Ia/U+1rbNpValF/DbFenMHBHJ3DEDabI2Y2k2WGw/jYEbp539/wRaD+g50VLPO17H8dqmk/uUUsrVupPAtwEjRWQoLYn7euBGh0TVRVuPlPH/3t7JpLgwlt6S0uVSx/ghoYjArrzykwk8rdUMhEop1Rt0OYEbYywi8lPgM8AbeNkYk+GwyDops7CKO5ZtI25AP15edG636tTB/j6MjA4+5UFmWn45ft5epwz8UUopV+pWDdwY8ynwqYNi6bL88joWvbyVfn7eLLt9KgOCuj+H9sTYMNZlFmOMQURIy60gKSbkrLVzpZTqSX1+lEl5bSOLXt5KTaOFZbdPJXaAY+YbSY4N5Vh1I0cr6mluNqTnVzBhiJZPlFK9R5/usFzdYGHxslRySmt5dfFUkgb17/gkO518kJlbTv2gEKoaLCTrA0ylVC/SpxK4MYZDJTWsyyxm/f4Sthwpo8nazLM3Tma6HUuUdUZSTAi+3sKuvAoaLC0r1U/QB5hKqV6kTyTw9ftL+DyjkPX7S8g7XgfA8Kggbp6WwPcmDmJKguNXuPH38WZMTH925ZbTaGkmwNeLkTqXt1KqF+kTCfy1TdlsPHSM84ZH8pOLhjNrVFSPzK09MTaUFTuO0mCxMm5wKD46MZVSqhfpEwn8Dz8YT2igb4/3AJkYG8brm3PYkVvOohmJPXptpZTqSJ9I4NH9A1xy3UlxLQ8tjYHkOK1/K6V6F60JnMXwqGACbQOCTl8DUymlXE0T+Fl4ewnjh4QS7O/DsMggV4ejlFKn6BMlFFe69+IR5B+vw8u2cr1SSvUWmsA7cMHIKFeHoJRSbdISilJK9VGawJVSqo/SBK6UUn2UJnCllOqjNIErpVQfpQlcKaX6KE3gSinVR2kCV0qpPkqMMT13MZESILuLp0cCxxwYTl+h9+1ZPPW+wXPv3Z77TjDGnDGqsEcTeHeISKoxJsXVcfQ0vW/P4qn3DZ577925by2hKKVUH6UJXCml+qi+lMCXujoAF9H79iyeet/guffe5fvuMzVwpZRSp+pLLXCllFKtaAJXSqk+qk8kcBGZLyKZInJQRB50dTzOIiIvi0ixiKS32hYuIqtF5IDt5wBXxugMIhInImtFZI+IZIjIfbbtbn3vIhIgIltFZJftvn9v2z5URLbYvu/viIifq2N1BhHxFpEdIvKx7b3b37eIZInIbhHZKSKptm1d/p73+gQuIt7As8BlwFjgBhEZ69qonOYVYP5p2x4E1hhjRgJrbO/djQX4hTFmLDAduMf239jd770BuNgYkwxMAuaLyHTgSeAvxpgRwHFgsQtjdKb7gL2t3nvKfc82xkxq1fe7y9/zXp/AganAQWPMYWNMI/A2cKWLY3IKY8xXQNlpm68EltleLwOu6tGgeoAxpsAY863tdRUt/6iH4Ob3blpU29762v4Y4GLgPdt2t7tvABGJBb4HvGh7L3jAfbejy9/zvpDAhwC5rd7n2bZ5ioHGmALb60JgoCuDcTYRSQTOAbbgAfduKyPsBIqB1cAhoNwYY7Ed4q7f92eAB4Bm2/sIPOO+DfC5iGwXkSW2bV3+nuuixn2IMcaIiNv2+xSRYOB94H5jTGVLo6yFu967McYKTBKRMOBDIMnFITmdiFwOFBtjtovILFfH08NmGmPyRSQaWC0i+1rv7Oz3vC+0wPOBuFbvY23bPEWRiMQA2H4WuzgepxARX1qS9xvGmA9smz3i3gGMMeXAWmAGECYiJxpX7vh9Px+4QkSyaCmJXgz8Ffe/b4wx+bafxbT8wp5KN77nfSGBbwNG2p5Q+wHXAytdHFNPWgkssr1eBKxwYSxOYat/vgTsNcY83WqXW9+7iETZWt6ISD9gHi31/7XAtbbD3O6+jTEPGWNijTGJtPx7/tIYcxNuft8iEiQiISdeA5cA6XTje94nRmKKyAJaambewMvGmMddHJJTiMhbwCxappcsAh4FPgKWA/G0TMW70Bhz+oPOPk1EZgJfA7v5rib6G1rq4G577yIykZaHVt60NKaWG2P+W0SG0dIyDQd2ADcbYxpcF6nz2EoovzTGXO7u9227vw9tb32AN40xj4tIBF38nveJBK6UUupMfaGEopRSqg2awJVSqo/SBK6UUn2UJnCllOqjNIErpVQfpQlcKaX6KE3gSinVR/1/EIPODOJpi9YAAAAASUVORK5CYII=\n",
+            "image/png": "iVBORw0KGgoAAAANSUhEUgAAAXAAAAD6CAYAAAC4RRw1AAAABHNCSVQICAgIfAhkiAAAAAlwSFlzAAALEgAACxIB0t1+/AAAADh0RVh0U29mdHdhcmUAbWF0cGxvdGxpYiB2ZXJzaW9uMy4yLjIsIGh0dHA6Ly9tYXRwbG90bGliLm9yZy+WH4yJAAAgAElEQVR4nO3deXiU5dX48e/JThYSskEgG3tYgxBZFBUEFKlV60LdqWKpS/1pN6v1rbbvq632tda+rUupWnEXV6haFBFQ2YNASICwZiUbCdnXmdy/PzJggIRMkplMMnM+18WVmWeZ5zw4nNye517EGINSSqm+x8vVASillOoaTeBKKdVHaQJXSqk+ShO4Ukr1UZrAlVKqj9IErpRSfVSHCVxERovIzlZ/KkXkfhEJF5HVInLA9nNATwSslFKqhXSmH7iIeAP5wDTgHqDMGPOEiDwIDDDG/Pps50dGRprExMRuhKuUUp5n+/btx4wxUadv9+nk58wBDhljskXkSmCWbfsyYB1w1gSemJhIampqJy+plFKeTUSy29re2Rr49cBbttcDjTEFtteFwMB2LrxERFJFJLWkpKSTl1NKKdUeuxO4iPgBVwDvnr7PtNRh2qzFGGOWGmNSjDEpUVFn/B+AUkqpLupMC/wy4FtjTJHtfZGIxADYfhY7OjillFLt60wCv4HvyicAK4FFtteLgBWOCkoppVTH7ErgIhIEzAM+aLX5CWCeiBwA5treK6WU6iF29UIxxtQAEadtK6WlV4pSSikX0JGYSinVR2kCV0opB8g6VsOq9MIevaYmcKWUcoAn/rOPu97YTm5ZbY9dUxO4Ukp1U12jlXX7izEGXt/c5qBJp9AErpRS3bR+fwn1Tc3Ehffj7W251DVae+S6msCVUqqbVqUXEBboy5NXT6Sirol/7zraI9fVBK6UUt3QaGlmzd5i5o0ZyIzhESQNCuGVjVl0ZqbXrtIErpRS3bDx0DGqGizMHz8IEeHWGYnsKahke/Zxp19bE7hSSnXDZxmFBPl5c/6ISACuOmcwIQE+LNvk/IeZmsCVUh6rttHCbz9K73LXP2uz4fOMImYnRRPg6w1AoJ8PC1Pi+M/uAoor6x0Z7hk0gSulPNbqPUW8tjmbH7+a2qWeI6lZZZTWNDJ//KBTtt8yPQFLs+HNrTmOCrVNmsCVUh7ry33F9PP1JrOoioc+SOv0g8dVGYX4+Xgxa3T0KdsTI4OYNTqKN7bk0GhpdmTIp9AErpTySNZmw/r9JVw2fhA/mzuKj3YeZdnGLLvPN8bwWXohF46MJNj/zHkBF81IpKSqgVUZzhterwlcKeWRduYep7y2idlJ0fx09gjmjonmsU/2si2rzK7zd+dXcLSinkvHDWpz/0WjokiICOTVTvxS6CxN4Eopj/TlvmK8vYQLR0Xh5SX8eeEkYgf04+43vrXr4eOq9EK8vYS5Y9pcDhgvL+GW6QmkZh8nPb/C0eG3XMMpn6qUUr3cl/tKmJIwgNB+vgCE9vPlH7ekUF1v4Z43v6XJ2n7t2hjDqvRCZgyLYECQX7vHXTcljn6+3rzmpC6FmsCVUh6noKKOvQWVzD7t4ePoQSE8ee1EtmUd5/FP9rZ7/oHiag4fq+HS8W2XT04IDfTlqnOG8NHOfMprGx0Se2t2rcijlFLuZF1mCQAXJ0Wfse+K5MHszCnn5Q1HCAv05a5Zw/H38T7lmFXphYjApWPbLp+0duuMBPKO13K8tomwwPZb611h75qYYSLynojsE5G9IjJDRMJFZLWIHLD9HODQyJRSykm+3FfMkLB+jBoY3Ob+hxYkcfnEGJ754gCX/OUr1uwtOqWL4ar0QibHDyC6f0CH1xoT05/XFk9jaGSQw+I/wd4Syl+BVcaYJCAZ2As8CKwxxowE1tjeK6VUr9ZgsbLh4DFmJ0UhIm0e4+vtxd9vnMyrt0/Fx0tYvCyV217ZxuGSanJKa9lTUMn8dnqf9KQOSygiEgpcCPwIwBjTCDSKyJXALNthy4B1wK+dEaRSSjnKlsNl1DZa2yyfnO7CUVGsuv9Clm3M4pkvDnDpM18xfkgoQLvdB3uSPS3woUAJ8C8R2SEiL4pIEDDQGFNgO6YQ6LgYpJRSLvblvmL8fbyYMSzSruN9vb2444JhfPnLi7hq0hB25JQzbnB/4iMCnRxpx+x5iOkDTAbuNcZsEZG/clq5xBhjRKTNMagisgRYAhAfH9/NcJVSqnvWZRYzY3gE/fy8Oz64leiQAP73umTuuGAYgZ0811nsaYHnAXnGmC229+/RktCLRCQGwPazuK2TjTFLjTEpxpiUqKgoR8SslFJdcrikmqzSWrvKJ+0ZPSiEuHDXt77BjgRujCkEckVktG3THGAPsBJYZNu2CFjhlAiVUspBvtzX0s48vf93X2VvP/B7gTdExA84DNxGS/JfLiKLgWxgoXNCVEopx1ibWcyI6OBe04LuLrsSuDFmJ5DSxq45jg1HKaWco7rBwtYjZdx2/lBXh+IwOpReKeURvjlwjCarcZvyCWgCV0p5iLX7ignx9yEl0X0GjWsCV0q5PWMMazOLuWBUJL7e7pP23OdOlFKqHRlHKymuanCr8gloAldKeYDn1h3Ez9uL2d3o/90baQJXSrm1j9OO8unuQu6bO5LIYH9Xh+NQmsCVUm7rWHUDj6zIIDk2lJ9cOMzV4TicJnCllFsyxvDbj9Kprrfw1HXJ+LjRw8sT3O+OlFIK+DitgP+kF3L/vJGMHBji6nCcQhO4UsrtlFQ18MiKdJLjwlhygfuVTk7QBK6UcisnSic1DVaeunaiW5ZOTnDfO1NKeaSP0wpYlVHIz+aNctvSyQmawJVSbqN16eTHF7jPpFXt0QSulHIL9U1W7nt7h0eUTk6wdz5wpZTqtZqszfz0zR1sPFTK0wuT3b50coL7/4pSSrm15mbDr97dxRd7i/ifK8dx9eRYV4fUYzSBK6X6LGMMv12Rzkc7j/KrS0dzy4xEV4fUozSBK6X6rCdXZfLGlhx+ctEw7p413NXh9DhN4EqpPum5dQd5Yf0hbpoWz4PzkxARV4fU4+x6iCkiWUAVYAUsxpgUEQkH3gESgSxgoTHmuHPCVEqp77yxJZs/rcrkykmD+Z8rx3tk8obOtcBnG2MmGWNOLG78ILDGGDMSWGN7r5RSTrW/qIrfrcxg9ugonrouGS8vz0ze0L0SypXAMtvrZcBV3Q9HKaXaZ202PPBeGsH+Pjx1XbJbLY/WFfbevQE+F5HtIrLEtm2gMabA9roQGNjWiSKyRERSRSS1pKSkm+EqpTzZKxuz2Jlbzu+uGEeEmy3O0BX2DuSZaYzJF5FoYLWI7Gu90xhjRMS0daIxZimwFCAlJaXNY5RSqiM5pbU89VkmFydFc0XyYFeH0yvY1QI3xuTbfhYDHwJTgSIRiQGw/Sx2VpBKKc9mjOGhD9Pw9hIeu8pzH1qersMELiJBIhJy4jVwCZAOrAQW2Q5bBKxwVpBKKc+2PDWXDQdLeWhBEoPD+rk6nF7DnhLKQOBD2288H+BNY8wqEdkGLBeRxUA2sNB5YSqlPFVRZT2PfbKXaUPDueHceFeH06t0mMCNMYeB5Da2lwJznBGUUkpBS+nkvz5Kp9HSzBPXTPToLoNt8ew+OEqpXu3T3YWs3lPEz+eNYmhkkKvD6XU0gSuleqWK2iYeXZnOxNhQFs90/8UZukITuFKq06zNhnvf2sGrm7Kcdo2nV2dSVtPIH6+e4BGLM3SF/q0opTrttU1Z/HvXUf7w6V6KK+sd/vkZRyt4bXM2N09PYNzgUId/vrvQBK6U6pSCijqe+nw/yXFhWKyGv6896NDPN8bw6IoMwgL9+MW80Q79bHejCVwp1Sm/W5mBpbmZv11/Dj88N463tuaQW1brsM//cEc+qdnH+fX80YQG+jrsc92RJnClegFjDJ/uLuD+t3ewKr0Aa3PvnHXi84xCPsso4r45o4iPCOT/zRmJlwh/Wb3fIZ9fVd/EHz7dR3JcGNdNiXPIZ7ozXdRYKRfLLq3hkRUZrN9fQoCvFx/tPErsgH786LxEFp4bR/+A3tEKrW6w8OjKDJIGhXDHBS29Qgb2D+BH5yWy9OvD3DlrOKO6uZjwM18coLSmgZcWpWifbztoC1wpF2mwWPnrFweY95ev2J59nEcuH8uuRy/hhZunMDisH499spcZf1jD71ZmcORYjavD5enP91NYWc/jP5hwyjSud140nGA/H576LLNbn7+/qIpXNmZx/blxJMeFdTdcj6AtcKVc4JsDx/jtinSOHKvh8okx/PbysQzsHwDA/PGDmD9+EOn5Fby84QhvbMlm2aYslt6Swryxbc7a7HS78yp4ZeMRbpoWz5SEAafsGxDkx48vHMbTq/ezM7ecSV1IvsYYHlmRTrC/D7+6NMlRYbs9bYEr1cNe25TFzS9twRjDq7dP5e83Tj6ZvFsbPySUpxdOYsODFzMqOoTHPtlDo6XZYXE0WZvZnl3G39Yc4Ialm0l57AvufmM7K3bmU1nfdPI4i7WZhz5MIyLYnwfmt51cb585lIggP/73s31t7u/Ix2kFbD5cxi8vHU14kF+XPsMTaQtcqR72TmouE2NDWf6TGQT4end4fHRIAA8tSOJH/9rG65uzub0boxKr6pt4a2sOGw+VsvVIGbWNVgDGxvTnvOERbDpcyqe7C/H1Fs4bHsml4wZRXFVPen4lz944ud16fLC/D/fMHsF/f7yHDQePcf6IyE7F9Pgnexk3uD83TtXJqjpDE7hSPehEMvzVpaPtSt4nXDQqipkjIvm/Lw9wzZRYQvt17cHmIysy+HBHPsOjgrhmciznDY9g2rCIk63e5mbDjtzjfJZRxGcZhfzmw90AXJwUzYIJg8762TdOi+fFrw/zp88y+Wh4hF1zdtc3WVny6naOVTfw3M2T8dYHl52iCVypHrQ+s2VZwdmjozt1nojw0IIkLv/bNzy39iAPLRjT6WsXVNTx711Hue38RB79/rg2j/HyEqYkhDMlIZyHLktiX2EVGw+VckXy4A4TcoCvN/fPHcUD76exek8Rl4w7e8K3WJu5960dbD5SyjM/nMTk+AFnPV6dSWvgSvWgdZklDOzvz5iYzne3Gzc4lB+cM4R/bcwi73jnB868siGLZmO4/Xz7SjAiwpiY/iyeOZSoEPvWn7x68hCGRQXx8EfpfLW//TVwm5sNv35/N6v3FPH7K8Zx5aQhdn2+OpUmcKV6iMXazNcHSpg1KrrLS4L98pLRCHS6y151g4U3t+Zw2YQY4sIDu3Rte/h4e/HsjZMJ7efLrS9v5b8+2k1Ng+WUY4wx/M8ne3j/2zx+MW8Ut85IdFo87k4TuFI9ZEduOZX1FmaNjuryZwwO68fimUP5aOdRdudV2H3eO9tyqaq38OMLhnX52vYaE9Ofj++dyR0zh/LGlhwW/N/XbMsqO7n/b18e5F8bslg8cyg/vXiE0+NxZ5rAleoha/cV4+MlnD/S/h4abblz1nDCg/x4/NM9GNPxkHuLtZmXvznCuYkDutRHuysCfL35r8vH8vaPp9NsDAv/sYk/frqXF78+zNOr93PtlFgeXjBGFyfuJrsTuIh4i8gOEfnY9n6oiGwRkYMi8o6IaOdNpc5iXWYJUxIGdHtofP8AX+6bM5LNh8v4cl9xh8evyigkv7yOO3qg9X26acMi+M99F3L9ufH846vDPPbJXi4ZO5Anrp6gQ+UdoDMt8PuAva3ePwn8xRgzAjgOLHZkYEq5k6LKevYUVDKrk71P2nPjtHiGRgbxx//sw2Jtf3CPMYZ/fn2ExIhA5o5xzSjOYH8f/nj1BF657Vx+ctEw/u+Gc3SBBgex629RRGKB7wEv2t4LcDHwnu2QZcBVzghQKXdwsvtgUtfr3635envx6/lJHCyu5oX1h9o9LjX7OLtyy1k8c6jL+1jPGh3NQ5eN6VT/d3V29v4afAZ4ADjxqz4CKDfGnHi8nAe02Q9IRJaISKqIpJaUtN+tSCl3tjazmEH9Axjdzdn6Wrt03EAuGz+Ipz7f3zJHdxst8X9+dZiwQF+u1alZ3VKHCVxELgeKjTHbu3IBY8xSY0yKMSYlKsoxrQ+l+pImazPfHDjGrNFRDn1oJyL8/cbJ3DFzKK9szOL2ZamnzGFy5FgNq/cWcfO0BPr5aavXHdnTAj8fuEJEsoC3aSmd/BUIE5ETIzljgXynRKhUH7c9+zhVDRaH1b9b8/YS/uvysfzx6glsPHiMa57beHJ1nJe/OYKvlxe3npfg8Ouq3qHDBG6MecgYE2uMSQSuB740xtwErAWutR22CFjhtCiV6sPWZZa0dB8cEeG0a9wwNZ5Xb59KUWU9Vz67gS/2FPHu9lyunDSY6JAzZzpU7qE7j4J/DfxcRA7SUhN/yTEhKeVe1mUWc25iOCFOXlnnvBGRfHTP+YT28+WOV1Opb2p2SddB1XM6NZmVMWYdsM72+jAw1fEhKeU+Cirq2FdYxUOX9cwiBcOigvnw7vP4xfJdDAjyY/Qgxz00Vb2PzkaolBN9133Q8fXv9oQF+vHSj87tsesp19He9Eo50drMYgaHBjAyOtjVoSg3pAlcKSdptDSz4WApF43u+uyDSp2NJnClnCQ1u4zqBguzuzH7oFJnowlcKSdZn1nSsrZkJ9aHVKozNIEr5QQZRyt4a2sO04dFEOyvfQWUc2gCV8rBMguruOWlrQT7+/CHH0xwdTjKjWkCV8qBDpVUc9OLW/DxEt788XSnLl+mlCZwpRwku7SGG/+5GTC8+ePpJEYGuTok5eY0gSvlAHnHa7nxn1totDTzxh3TGaH9vlUP0ASuVDcVVtRz4z+3UFXfxGuLp+nwddVj9PG4Ut1gsTZzy0tbKKtp5PU7pjF+SKirQ1IeRBO4Ut2wfn8JB4qr+dsN5/TYiu9KnaAlFKW6YXlqLpHBfswfP8jVoSgPpAlcqS4qqWpgzd5irp4ci6+usq5cQL91SnXRhzvysDQbFqbEujoU5aE0gSvVBcYYlqfmMTk+jBHR2utEuYYmcKW64Nuccg4WV/PDc+NcHYryYB0mcBEJEJGtIrJLRDJE5Pe27UNFZIuIHBSRd0TEz/nhKtU7LN+WS6CfN9+bONjVoSgPZk8LvAG42BiTDEwC5ovIdOBJ4C/GmBHAcWCx88JUqveoabDwcdpRLp8YozMNKpfqMIGbFtW2t762Pwa4GHjPtn0ZcJVTIlSql/lkdwE1jVYWpmj5RLmWXTVwEfEWkZ1AMbAaOASUG2MstkPygCHtnLtERFJFJLWkpMQRMSsPYIxxdQjtWr4tl2FRQUxJGODqUJSHsyuBG2OsxphJQCwwFUiy9wLGmKXGmBRjTEpUlC4tpTr2/LpDzHxyLU3WZleHcoaDxdWkZh/nhylxus6lcrlO9UIxxpQDa4EZQJiInCgAxgL5Do5NeaC0vHKe+jyT/PI6jpbXuTqcM7y7PRdvL+EHk9v8H06lepQ9vVCiRCTM9rofMA/YS0siv9Z22CJghbOCVJ6hvsnKz97ZibetZZtdWuviiE7VZG3m/e35XJwUTXRIgKvDUcquFngMsFZE0oBtwGpjzMfAr4Gfi8hBIAJ4yXlhKk/wp1WZHCqp4fEfjAcgu6x3JfC1+4o5Vt3AD/XhpeolOuwDZYxJA85pY/thWurhSnXbxkPHeHnDEW6dkcA1k2N5+KN0cntZAl+emktUiD+zRuuzHNU76EhM5XKV9U386t00hkYG8eBlSXh5CfHhgWSX1rg6tJOKKutZm1nCNZNj8dGJq1QvoaMQlMv997/3UFBRx/t3nUegX8tXMiE8sFfVwF/ecARjDDdM1fKJ6j20KaFc6rOMQt7bnsc9s0dwTvx3/arjIwLJKavtFf3BK+qaeGNzDgsmxJAQoQsVq95DE7hymWPVDfzmg92MG9yfey8eecq+hPBAahutlNY0uii677y2KYvqBgt3zRru6lCUOoWWUFSPM8awLrOEJ/6zj6oGC2/9cBJ+Pqe2JeIjAoGWroSRwf6uCBOAukYrL2/IYtboKMYN1vUuVe+iLXDVKXWNVjYcPNbl0sbWI2Us/McmbntlG3VNVp67cTKjBp45n3Z8eEupIqfMtQ8yl6fmUlbTyN2zRrg0DqXaoi1wZbeKuiYWv7KN1OzjPHfTZBZMiLH73PT8Cv73s0zW7y8hOsSfx64az8KUuDNa3ifEhfdDxLWDeZqszSz96jApCQOYOjTcZXEo1R5N4MouJVUNLHp5KweKq4gM9ufZtQe5bPygDucDMcbw8EfpvLklh7BAX36zIIlbZyQS4Ot91vP8fbyJ6R9Ajgv7gq/ceZT88jr+56pxLotBqbPRBK46lF9ex80vbqGgoo4XF51LUUU9D7yfxrr9JcweHX3Wc9ftL+HNLTncPD2eB+Yn0T/A1+7rxoUHkuOiFnhzs+H59YdIGhTS4T0q5SpaA1dndbC4mmuf38ix6gZeXzyNi0ZFcdU5QxgcGsCzXx48ay3c2mx44tN9JEQE8sjl4zqVvAESIgJdNpx+9d4iDhZXc9es4TrroOq1NIGrdqXnV/DDf2yiydrM20umk5LYUgf28/FiyYXDSM0+zpYjZe2e//72PDKLqnjg0qR2a91nkxARRElVA7WNlo4P7gRjDC9/c4QH30/jcEl1m/ufW3eI+PBAvteJOr9SPU0TuGrT7rwKbli6mQBfb5b/ZMYZXeiunxpPZLAfz6492Ob5dY1W/rw6k0lxYSyYMKhLMcSHt3QlzC1z3LSytY0WfvrWDv774z28uz2PuU+v5+fv7OTIse96u2w6VMqu3HKWXDhMh82rXk2/napNr2zMQgTevXMGw6KCz9gf4OvN4pnD+PrAMXbllp+x/6VvDlNU2cDD3xvT5RLEiQTuqDlRckprufq5jfxndwEPXpbE5ofmsHjmUD5NL2Du0+v5xfJdZJfW8Pz6Q0SF+HPtlFiHXFcpZ9EErtqUllfOlIQBDA7r1+4xN0+Pp3+Azxmt8GPVDbyw/jCXjB3IuYld736XYBvM44ieKOv3l/D9v39DQUU9r9w2lTsvGk5UiD8Pf28sXz0wmx+dl8jHaUe5+M/r+frAMRbPHNphTxmlXE0TuDpDdYOFgyXVTIwNO+txIQG+/Oi8RD7fU8T+oqqT2/9vzQHqmqz8+jK7V95rU1igH/0DfLrVF9wYw/PrDnHbv7YSExrAv386kwtHnTodbHRIAL+9fCxfPzCbW2ckMDUxnJumxXcrdqV6giZwdYaM/AqMgeS4joeO33b+UAL9vHnO1go/XFLNm1tyuGFqHMPbKL10VkJEUJd7olQ3WLjnzW95ctU+FkyI4YO7zzs5RL8t0f0DePT741h+5wxCOtljRilX0ASuzpCWVwHQYQscYECQHzdNi2flrqNkl9bwp1WZ+Pt4cd+cUQ6JJT48sEsLO+wvquKKv3/DZxlF/GZBEn+74ZyTU9Uq5S40gasz7MorZ0hYP7snkbrjgmH4eHnx8+W7WJVRyE9s9WVHiI8IJO94LdZm++deWbEznyv/voHKOgtv3DGNJRdqX27lnuxZ1DhORNaKyB4RyRCR+2zbw0VktYgcsP0c0NFnqb4hLa+CibH2z7w3sH8A16XEsj37ONEh/txxwVCHxZIQHkiT1di1Qn2DxcojK9K57+2dTBgSyqf/bybTh0U4LBaleht7WuAW4BfGmLHAdOAeERkLPAisMcaMBNbY3qs+7nhNIzlltXaVT1q786LhBPv78OBlSQ4tVcTb2RMlv7yOhf/YzKubslly4TDe+PE0ovvryvHKvdmzqHEBUGB7XSUie4EhwJXALNthy4B1tKxUr/qwtPyW+ndyJ1rg0DJvya5HL8Hby7GlihN9wXPKajm/nWNqGy1c9ewG6hqtvHDzZOaP19GTyjN0qgYuIom0rFC/BRhoS+4AhcDAds5ZIiKpIpJaUlLSjVBVT0izDcoZ38kEDjg8eQPEhPbD11vO2pXw6wPHKKlq4O83nqPJW3kUuxO4iAQD7wP3G2MqW+8zLTMatfmUyRiz1BiTYoxJiYqKausQ1YvsyqtgWFRQpyeechZvLyFuQOBZF3ZYs7eIkAAfzh8R2YORKeV6diVwEfGlJXm/YYz5wLa5SERibPtjgGLnhKh6UlpeOcmdrH87W3xE+yvUNzcbvtxXwkWjovDVeUuUh7GnF4oALwF7jTFPt9q1Elhke70IWOH48FRPKqyop7iqoVM9UHpCvG1e8Lamrt2VV86x6gbmjmmzgqeUW7OnyXI+cAtwsYjstP1ZADwBzBORA8Bc23vVh+3Ka6l/d7YHirPFhwdS1WChvLbpjH1r9hbj7SXMGq3lOeV57OmF8g3Q3tOpOY4NR7lSWl45Pl7CuMH9XR3KKRIiWhY4zi6rZUCQ3yn71uwrZkrCAMIC/do6VSm3pkVDdVJaXgWjBob0uln4TsxKePq0svnldewtqGROki55pjyTJnAFtMzal5ZXYdcEVj0tbsCJhR1OfZD55d4iAOZo/Vt5KE3gCoDs0loq6pp6Xf0boJ+fN9Eh/mf0RPlibzGJEYEMjwpyUWRKuZYmcAW0foDZ+1rgcOYCxzUNFjYdKmXOmIE6UZXyWJrAPcTmw6WUVDW0uz8trwJ/Hy9GDQzpwajsFx8eRE6rFvjXB47RaG1mzhitfyvPpQncA2zPPs4N/9zMHa+mtjsta1peOeMG9++1g2ESIgIprKynvskKfDf6sjtLtinV1/XOf63KYRotzfzmg9308/VmV245r2/OPuMYa7MhPb+yV9a/TzgxqVXe8Vqamw1rM4t19KXyePrtd3P//PowmUVV/PX6c7hgZCT/+1kmhRX1pxxzsLiauiZrr+yBckL8ya6EtbbRl406+lJ5PE3gbuzIsRr+uuYACyYMYt7YgTx+1QQszc08ujL9lON66wjM1hLCv0vgOvpSqRaawN2UMYaHP9yNv7cXj35/HNDSir1vzig+yyji84zCk8em5ZUT4u/D0Ije2x0vPMiPYH8fcspq+WJvkY6+VApN4G7r/W/z2XiolF9flsTAVivT3HHBUJIGhfDIigyq6lvmFknLq2D8kFC8nDCft6OICHHhgWw+XMq+wirmau8TpTSBu6PS6gYe+2QPUwneU64AAA7lSURBVBIGcOPU+FP2+Xp78cerJ1BUVc+fP99Pg8XK3oJKJvbi+vcJCeGB7CusAnT0pVJgx2RWqu95/JO91DRY+OPVE9psVZ8TP4BbpiewbFMWw6OCaLKaXjcHeFtOzImSGBHIsMjeW+5RqqdoC9zNfH2ghA925HPnRcPPOijnV5eOJjrEn9/9ew/Qe0dgtnaiJ4qOvlSqhSZwN1LfZOXhD9MZGhnEPbNHnPXYkABffn/FeKzNhoggP4aE9euhKLtubEzLNLcLJgxycSRK9Q5aQnEjb2zJIaesltcXT7NrStj54wexMCWWYH/fPtGiPSd+AFsfnkN0SEDHByvlATSBu4m6RivPrzvEjGERzBxp/+K+f7o22YlROZ4mb6W+oyUUN/H65myOVTfws3mjXB2KUqqH2LOo8csiUiwi6a22hYvIahE5YPs5wLlhqrOpbbTwwvpDzBwRydShOrmTUp7Cnhb4K8D807Y9CKwxxowE1tjeKxd5bVM2pTWN/GzeSFeHopTqQR0mcGPMV0DZaZuvBJbZXi8DrnJwXMpONQ0W/vHVYS4cFcWUBG19K+VJuloDH2iMKbC9LgR0WJyLLNuURVlNIz+bq61vpTxNtx9iGmMM0PYqAYCILBGRVBFJLSkp6e7lVCvVDRaWfnWYWaOjOCdeH0Mo5Wm6msCLRCQGwPazuL0DjTFLjTEpxpiUqCid/tORlm3Mory2iZ/N1Z4nSnmiribwlcAi2+tFwArHhKPsVVnfxNKvDjMnKZrkuN4/j4lSyvHs6Ub4FrAJGC0ieSKyGHgCmCciB4C5tveqB72yIYuKuibu19a3Uh6rw5GYxpgb2tk1x8GxKDtV1DXx4teHmTtmIBP6wCRUSinn0JGYvUBZTSM1DRa7j//z55lU1lu4X3ueKOXRNIG7WKOlmSuf/Ybv/+2bkyvknM1X+0t4dVM2t58/lPFDtPWtlCfTBO5iy1NzyS2r40hpDb98dxctvTLbVlHbxAPvpTEiOpgH5o/uwSiVUr2RJnAXarBYeXbtQSbHh/HwgjF8llHEP7463O7xj6xM51h1A39ZOMmu6WKVUu5Np5N1oeXbcimoqOdP105k5ohIduSW86dV+5g4JJTzRpw6JezHaUdZsfMoP583Sh9cKqUAbYF3WXOzoby2scvn1zdZeXbtIc5NHMDMEZGICE9eM5FhUcHc+9YOCirqTh5bVFnPwx+mkxwXxt2zhjsifKWUG9AEbvPXLw7w6e6Cjg+0eSc1l+l/XENuWW2XrvfOtlwKK+v52dxRJ1fDCfb34YWbp1DfZOWu17+lwWLFGMMD76XRYLHy9MJkfLz1P5lSqoVmA+BoeR3PrNnPvzYcsfuczYdLqW9q5oX1hzp9vZbW90GmDg1nxvCIU/aNiA7mqeuS2ZlbzmMf7+WNLTms31/CQ5eNYXhUcKevpZRyX5rAgQ935GMMpOdXYrE223XO7rwKAN5NzaOwor5T13tzSw7FVQ2ntL5bu2xCDEsuHMZrm7P5/b8zuGBkJLdMT+jUNZRS7s/jE7gxhg++zcPXW6hrsnKwpLrDcyrqmjh8rIbrz43DagxLz9Jz5HT1TVaeX3+I6cPObH239sClo5kxLIIgfx/+dO1EvLx6/6LDSqme5fEJfFdeBYdKarj9/KEApOVWdHhORn7LMQsmxHDVpCG8ubVlPUp7vL45mxJb6/tsfLy9eHXxVNb9chYxof3s+myllGfx+AT+/vY8/H28uHv2CEICfNiVV97hObts5ZOJsaHcPXs4DZZmXvqm4/r5ibUrzx8RwbRh7be+T/D19iIs0K/jm1BKeSSPTuANFisrdx3l0nGDCO3ny8TYULsS+O78cuLDAwkL9GN4VDDfmxDDqxuzOuxW2LJyfKPO362UcgiPTuBr9xVTUdfE1ZOHADAxNox9BVXUN1nPel5aXsUpg2numT2CmkYrr2zMavec/UVVPL/uEBeMjCQlUdeuVEp1n0cn8Pe25xMd4s8FI1tWCkqODcXSbNhbUNnuOaXVDeQdryO5VQIfE9OfeWMH8q8NWW1OSLUtq4xrn9+Ir7cXj35/nONvRCnlkTw2gZdWN7Aus5gfnDMEb1sPj4mxLSvbpOW1/yBzt+0B5oQhp66C89PZI6ioa+L1zTmnbP8so5CbX9xCZLA/7991HiOitS+3UsoxPDaBr9h5FEuz4erJsSe3xYQGEBnsf9Y6eFpeBSIwfkj/U7Ynx4Vx4agoXvz6MHWNLSWYN7fkcNfr20mK6c97d51HXHigc25GKeWRPHYyq/e/zWP8kP6MHhRycpuIkBwbetYWeFpeBcMigwgJ8D1j370Xj+C6Fzbx5tYcquqbeOaLA8waHcVzN00m0M9j/6qVUk7ikVllX2ElGUcrefT7Y8/YlxwXxpeZxVQ3WAj2P/OvJy2vnPNPmynwhHMTw5k2NJwn/rOXJqvhmsmxPHHNBHx1/hKllBN0K7OIyHwRyRSRgyLyoKOCcrYPvs3Hx0u4InnwGfsmxoZizHdD5VsrqqynuKqBiWeZzvX+uaNoNnDnRcN56rqJmryVUk7T5Ra4iHgDzwLzgDxgm4isNMbscVRwzmCxNvPhjnxmJ0UTEex/xv7vHmSWnzHUfVduue2Y9hP4jOERpD16CUFttN6VUsqRutM8nAocNMYcNsY0Am8DVzomLOf5+uAxSqoauMbW9/t04UF+xIX3a7MOvju/Am8vYWzM2RdU0OStlOoJ3ck0Q4DcVu/zgGmnHyQiS4AlAPHx8d24XOdU1jdhsRp8vAUfL8HHywtfb+GDb/MJC/RldlJ0u+dOjA1jZ86ZPVHS8ioYGR1MPz9dzkwp5XpObyoaY5YCSwFSUlLaX7HXgV7fnM0jK9Jpbudqt85IwN+n/SScHBvKJ2kFlFY3nCyzGGNIyytn3tiBzghZKaU6rTsJPB+Ia/U+1rbNpValF/DbFenMHBHJ3DEDabI2Y2k2WGw/jYEbp539/wRaD+g50VLPO17H8dqmk/uUUsrVupPAtwEjRWQoLYn7euBGh0TVRVuPlPH/3t7JpLgwlt6S0uVSx/ghoYjArrzykwk8rdUMhEop1Rt0OYEbYywi8lPgM8AbeNkYk+GwyDops7CKO5ZtI25AP15edG636tTB/j6MjA4+5UFmWn45ft5epwz8UUopV+pWDdwY8ynwqYNi6bL88joWvbyVfn7eLLt9KgOCuj+H9sTYMNZlFmOMQURIy60gKSbkrLVzpZTqSX1+lEl5bSOLXt5KTaOFZbdPJXaAY+YbSY4N5Vh1I0cr6mluNqTnVzBhiJZPlFK9R5/usFzdYGHxslRySmt5dfFUkgb17/gkO518kJlbTv2gEKoaLCTrA0ylVC/SpxK4MYZDJTWsyyxm/f4Sthwpo8nazLM3Tma6HUuUdUZSTAi+3sKuvAoaLC0r1U/QB5hKqV6kTyTw9ftL+DyjkPX7S8g7XgfA8Kggbp6WwPcmDmJKguNXuPH38WZMTH925ZbTaGkmwNeLkTqXt1KqF+kTCfy1TdlsPHSM84ZH8pOLhjNrVFSPzK09MTaUFTuO0mCxMm5wKD46MZVSqhfpEwn8Dz8YT2igb4/3AJkYG8brm3PYkVvOohmJPXptpZTqSJ9I4NH9A1xy3UlxLQ8tjYHkOK1/K6V6F60JnMXwqGACbQOCTl8DUymlXE0T+Fl4ewnjh4QS7O/DsMggV4ejlFKn6BMlFFe69+IR5B+vw8u2cr1SSvUWmsA7cMHIKFeHoJRSbdISilJK9VGawJVSqo/SBK6UUn2UJnCllOqjNIErpVQfpQlcKaX6KE3gSinVR2kCV0qpPkqMMT13MZESILuLp0cCxxwYTl+h9+1ZPPW+wXPv3Z77TjDGnDGqsEcTeHeISKoxJsXVcfQ0vW/P4qn3DZ577925by2hKKVUH6UJXCml+qi+lMCXujoAF9H79iyeet/guffe5fvuMzVwpZRSp+pLLXCllFKtaAJXSqk+qk8kcBGZLyKZInJQRB50dTzOIiIvi0ixiKS32hYuIqtF5IDt5wBXxugMIhInImtFZI+IZIjIfbbtbn3vIhIgIltFZJftvn9v2z5URLbYvu/viIifq2N1BhHxFpEdIvKx7b3b37eIZInIbhHZKSKptm1d/p73+gQuIt7As8BlwFjgBhEZ69qonOYVYP5p2x4E1hhjRgJrbO/djQX4hTFmLDAduMf239jd770BuNgYkwxMAuaLyHTgSeAvxpgRwHFgsQtjdKb7gL2t3nvKfc82xkxq1fe7y9/zXp/AganAQWPMYWNMI/A2cKWLY3IKY8xXQNlpm68EltleLwOu6tGgeoAxpsAY863tdRUt/6iH4Ob3blpU29762v4Y4GLgPdt2t7tvABGJBb4HvGh7L3jAfbejy9/zvpDAhwC5rd7n2bZ5ioHGmALb60JgoCuDcTYRSQTOAbbgAfduKyPsBIqB1cAhoNwYY7Ed4q7f92eAB4Bm2/sIPOO+DfC5iGwXkSW2bV3+nuuixn2IMcaIiNv2+xSRYOB94H5jTGVLo6yFu967McYKTBKRMOBDIMnFITmdiFwOFBtjtovILFfH08NmGmPyRSQaWC0i+1rv7Oz3vC+0wPOBuFbvY23bPEWRiMQA2H4WuzgepxARX1qS9xvGmA9smz3i3gGMMeXAWmAGECYiJxpX7vh9Px+4QkSyaCmJXgz8Ffe/b4wx+bafxbT8wp5KN77nfSGBbwNG2p5Q+wHXAytdHFNPWgkssr1eBKxwYSxOYat/vgTsNcY83WqXW9+7iETZWt6ISD9gHi31/7XAtbbD3O6+jTEPGWNijTGJtPx7/tIYcxNuft8iEiQiISdeA5cA6XTje94nRmKKyAJaambewMvGmMddHJJTiMhbwCxappcsAh4FPgKWA/G0TMW70Bhz+oPOPk1EZgJfA7v5rib6G1rq4G577yIykZaHVt60NKaWG2P+W0SG0dIyDQd2ADcbYxpcF6nz2EoovzTGXO7u9227vw9tb32AN40xj4tIBF38nveJBK6UUupMfaGEopRSqg2awJVSqo/SBK6UUn2UJnCllOqjNIErpVQfpQlcKaX6KE3gSinVR/1/EIPODOJpi9YAAAAASUVORK5CYII=",
             "text/plain": [
               "<Figure size 432x288 with 1 Axes>"
             ]
           },
           "metadata": {
             "needs_background": "light"
-          }
+          },
+          "output_type": "display_data"
         }
+      ],
+      "source": [
+        "x = np.cumsum(np.random.normal(loc=1, scale=5, size=50))\n",
+        "s = pd.Series(x)\n",
+        "\n",
+        "s.plot()\n",
+        "plt.show()"
       ]
     },
     {
@@ -5501,35 +5478,35 @@
     },
     {
       "cell_type": "code",
+      "execution_count": 90,
       "metadata": {
         "colab": {
           "base_uri": "https://localhost:8080/",
           "height": 265
         },
         "id": "TdSdgKhYD1SA",
-        "outputId": "905a4e86-57e7-49e6-d459-9ec8af575048"
+        "outputId": "1088f633-b5ca-4578-d7f1-f0f83d3222a9"
       },
-      "source": [
-        "x = np.random.normal(loc=1, scale=5, size=50)\n",
-        "s = pd.Series(x)\n",
-        "\n",
-        "s.hist()\n",
-        "plt.show()"
-      ],
-      "execution_count": 436,
       "outputs": [
         {
-          "output_type": "display_data",
           "data": {
-            "image/png": "iVBORw0KGgoAAAANSUhEUgAAAXAAAAD4CAYAAAD1jb0+AAAABHNCSVQICAgIfAhkiAAAAAlwSFlzAAALEgAACxIB0t1+/AAAADh0RVh0U29mdHdhcmUAbWF0cGxvdGxpYiB2ZXJzaW9uMy4yLjIsIGh0dHA6Ly9tYXRwbG90bGliLm9yZy+WH4yJAAAOSklEQVR4nO3dfYxc91XG8echpuBkIyeVwxA5Fds/okjFWyI84i0IZppATRORFhVwFKoYgpY/CETICDmqUJCqCgtkUMWrFholUkKG4jZqiFGJCZ1aldrAbrC6dpyQqHWpl9SmCnXZYBEWDn94Fu9Mxzuz987LntnvR1rt3N/elzPHdx7fvTv3jiNCAIB8vmXcBQAAiiHAASApAhwAkiLAASApAhwAkto2yo3t3Lkzpqene873xhtv6Jprrhl+QUnQj3b04zJ60W5S+7GwsPC1iLihc3ykAT49Pa35+fme8zWbTdVqteEXlAT9aEc/LqMX7Sa1H7a/3G2cUygAkBQBDgBJEeAAkBQBDgBJEeAAkBQBDgBJ9Qxw24/YPm/75Jqx37X9ku0v2H7K9nXDLRMA0KmfI/BHJe3tGDsmaXdEvFPSP0t6aMB1AQB66BngEXFc0usdY89GxEpr8vOSbhpCbQCAdbifD3SwPS3pmYjY3eVnfy3pLyPi8SssOytpVpIqlcqeRqPRc3vLy8uamprqOd9WQT/aTVo/FpcuFF62sl06d7HYsjO7dhTe7mY1afvGqnq9vhAR1c7xUpfS2/6gpBVJT1xpnoiYkzQnSdVqNfq5zHVSL4ctin60m7R+7D94tPCyB2ZWdHix2Mv4zL21wtvdrCZt3+ilcIDb3i/pLkm3B5/LBgAjVyjAbe+V9BuSfjQi/nOwJQEA+tHP2wiflPQ5SbfYPmv7fkl/KOlaScdsn7D9p0OuEwDQoecReETc02X4o0OoBQCwAVyJCQBJEeAAkBQBDgBJEeAAkBQBDgBJEeAAkBQBDgBJEeAAkBQBDgBJEeAAkBQBDgBJEeAAkBQBDgBJEeAAkBQBDgBJEeAAkBQBDgBJEeAAkBQBDgBJEeAAkBQBDgBJEeAAkBQBDgBJEeAAkBQBDgBJ9Qxw24/YPm/75Jqxt9o+ZvuV1vfrh1smAKBTP0fgj0ra2zF2UNJzEXGzpOda0wCAEeoZ4BFxXNLrHcN3S3qs9fgxSe8dcF0AgB4cEb1nsqclPRMRu1vTX4+I61qPLenfV6e7LDsraVaSKpXKnkaj0XN7y8vLmpqa6vMpTD760W7S+rG4dKHwspXt0rmLxZad2bWj8HY3q0nbN1bV6/WFiKh2jm8ru+KICNtX/F8gIuYkzUlStVqNWq3Wc53NZlP9zLdV0I92k9aP/QePFl72wMyKDi8WexmfubdWeLub1aTtG70UfRfKOds3SlLr+/nBlQQA6EfRAH9a0n2tx/dJ+uRgygEA9KuftxE+Kelzkm6xfdb2/ZIOSfox269IuqM1DQAYoZ4nzyLiniv86PYB1wIA2ACuxASApAhwAEiKAAeApAhwAEiKAAeApAhwAEiKAAeApAhwAEiKAAeApAhwAEiKAAeApAhwAEiKAAeApAhwAEiKAAeApAhwAEiKAAeApAhwAEiKAAeApAhwAEiKAAeApAhwAEiKAAeApAhwAEiKAAeApAhwAEiqVIDb/jXbp2yftP2k7W8fVGEAgPUVDnDbuyT9qqRqROyWdJWkfYMqDACwvrKnULZJ2m57m6SrJf1r+ZIAAP1wRBRf2H5Q0oclXZT0bETc22WeWUmzklSpVPY0Go2e611eXtbU1FThuibNqPuxuHRhZNvqNLNrR895Jm3/KNPvynbp3MViy/bT62wmbd9YVa/XFyKi2jleOMBtXy/p45J+VtLXJf2VpCMR8fiVlqlWqzE/P99z3c1mU7VarVBdk2jU/Zg+eHRk2+p05tCdPeeZtP2jTL8PzKzo8OK2Qsv20+tsJm3fWGW7a4CXOYVyh6QvRcS/RcR/S/qEpB8qsT4AwAaUCfB/kfQDtq+2bUm3Szo9mLIAAL0UDvCIeF7SEUkvSFpsrWtuQHUBAHoodvKsJSIelvTwgGoBAGwAV2ICQFIEOAAkRYADQFIEOAAkRYADQFIEOAAkRYADQFIEOAAkRYADQFIEOAAkRYADQFKl7oUCDFo/98Y+MLOi/WO8ZzmwWXAEDgBJEeAAkBQBDgBJEeAAkBQBDgBJEeAAkBQBDgBJEeAAkBQBDgBJEeAAkBQBDgBJEeAAkBQBDgBJlQpw29fZPmL7Jdunbf/goAoDAKyv7O1kPyLpUxHxfttvkXT1AGoCAPShcIDb3iHpRyTtl6SIeFPSm4MpCwDQiyOi2IL2rZLmJL0o6XskLUh6MCLe6JhvVtKsJFUqlT2NRqPnupeXlzU1NdU2trh0oVCdgzCza8fYti1178cwjbPX/ahsl85dHHcVm0OZXox7vx6GUb9WRqVery9ERLVzvEyAVyV9XtJtEfG87Y9I+kZE/OaVlqlWqzE/P99z3c1mU7VarW2sn09qGZYzh+4c27al7v0YpnH2uh8HZlZ0eJEPk5LK9WLc+/UwjPq1Miq2uwZ4mT9inpV0NiKeb00fkfS9JdYHANiAwgEeEV+V9BXbt7SGbtel0ykAgBEo+3vor0h6ovUOlC9K+vnyJQEA+lEqwCPihKRvOi8DABg+rsQEgKQIcABIigAHgKQIcABIigAHgKQIcABIigAHgKQIcABIigAHgKQIcABIigAHgKQIcABIigAHgKQIcABIigAHgKQIcABIigAHgKQIcABIigAHgKQIcABIigAHgKQIcABIigAHgKQIcABIigAHgKQIcABIqnSA277K9j/ZfmYQBQEA+jOII/AHJZ0ewHoAABtQKsBt3yTpTkl/PphyAAD9ckQUX9g+Ium3JV0r6dcj4q4u88xKmpWkSqWyp9Fo9Fzv8vKypqam2sYWly4UrrOsmV07xrLd1edc2S6duziWEjYl+nFZmV6Ma78epm7ZMQnq9fpCRFQ7x7cVXaHtuySdj4gF27UrzRcRc5LmJKlarUatdsVZ/1+z2VTnfPsPHi1aamln7q2NZburz/nAzIoOLxb+p5o49OOyMr0Y1349TN2yY5KVOYVym6SftH1GUkPSu2w/PpCqAAA9FQ7wiHgoIm6KiGlJ+yT9fUT83MAqAwCsi/eBA0BSAzmRGBFNSc1BrAsA0B+OwAEgKQIcAJIiwAEgKQIcAJIiwAEgKQIcAJIiwAEgKQIcAJIiwAEgKQIcAJIiwAEgKW6qDGxR0+O8x/6hO8e27UnCETgAJEWAA0BSBDgAJEWAA0BSBDgAJEWAA0BSBDgAJEWAA0BSBDgAJEWAA0BSBDgAJEWAA0BSBDgAJFU4wG2/zfanbb9o+5TtBwdZGABgfWVuJ7si6UBEvGD7WkkLto9FxIsDqg0AsI7CR+AR8VpEvNB6/B+STkvaNajCAADrc0SUX4k9Lem4pN0R8Y2On81KmpWkSqWyp9Fo9Fzf8vKypqam2sYWly6UrrOomV07xrLd1edc2S6duziWEjYl+nFZ1l4M6zXVLTvWypoj9Xp9ISKqneOlA9z2lKTPSPpwRHxivXmr1WrMz8/3XGez2VStVmsb24qfHrL6nA/MrOjwIh+etIp+XJa1F8N6TXXLjrWy5ojtrgFe6l0otr9V0sclPdErvAEAg1XmXSiW9FFJpyPi9wZXEgCgH2WOwG+T9AFJ77J9ovX1ngHVBQDoofDJs4j4rCQPsBYAwAZwJSYAJEWAA0BSBDgAJEWAA0BSBDgAJEWAA0BSBDgAJEWAA0BSBDgAJEWAA0BSBDgAJEWAA0BS+e4EDyC9YX2wwoGZFe0f44c2jBpH4ACQFAEOAEkR4ACQFAEOAEkR4ACQFAEOAEkR4ACQFAEOAEkR4ACQFAEOAEkR4ACQFAEOAEkR4ACQVKkAt73X9su2X7V9cFBFAQB6Kxzgtq+S9EeSfkLSOyTdY/sdgyoMALC+Mkfg3yfp1Yj4YkS8Kakh6e7BlAUA6MURUWxB+/2S9kbEL7amPyDp+yPigY75ZiXNtiZvkfRyH6vfKelrhQqbTPSjHf24jF60m9R+fFdE3NA5OPRP5ImIOUlzG1nG9nxEVIdUUjr0ox39uIxetNtq/ShzCmVJ0tvWTN/UGgMAjECZAP9HSTfbfrvtt0jaJ+npwZQFAOil8CmUiFix/YCkv5V0laRHIuLUgOra0CmXLYB+tKMfl9GLdluqH4X/iAkAGC+uxASApAhwAEhqUwW47Z+2fcr2/9qudvzsodYl+y/bfve4ahwX279le8n2idbXe8Zd06hx64Z2ts/YXmztD/PjrmfUbD9i+7ztk2vG3mr7mO1XWt+vH2eNw7apAlzSSUk/Jen42sHWJfr7JH23pL2S/rh1Kf9W8/sRcWvr62/GXcwoceuGK6q39oct897nNR7VpTxY66Ck5yLiZknPtaYn1qYK8Ig4HRHdrtS8W1IjIv4rIr4k6VVdupQfWwe3bkCbiDgu6fWO4bslPdZ6/Jik9460qBHbVAG+jl2SvrJm+mxrbKt5wPYXWr86TvSvhl2wD3yzkPSs7YXWLSsgVSLitdbjr0qqjLOYYRv6pfSdbP+dpO/s8qMPRsQnR13PZrJebyT9iaQP6dKL9kOSDkv6hdFVh03ohyNiyfZ3SDpm+6XWUSkkRUTYnuj3SY88wCPijgKLbYnL9vvtje0/k/TMkMvZbLbEPrAREbHU+n7e9lO6dJppqwf4Ods3RsRrtm+UdH7cBQ1TllMoT0vaZ/vbbL9d0s2S/mHMNY1Ua2dc9T5d+oPvVsKtG9awfY3ta1cfS/pxbb19opunJd3XenyfpIn+rX7kR+Drsf0+SX8g6QZJR22fiIh3R8Qp2x+T9KKkFUm/HBH/M85ax+B3bN+qS6dQzkj6pfGWM1pDvnVDRhVJT9mWLr2O/yIiPjXekkbL9pOSapJ22j4r6WFJhyR9zPb9kr4s6WfGV+HwcSk9ACSV5RQKAKADAQ4ASRHgAJAUAQ4ASRHgAJAUAQ4ASRHgAJDU/wHvws7rodafBAAAAABJRU5ErkJggg==\n",
+            "image/png": "iVBORw0KGgoAAAANSUhEUgAAAXAAAAD4CAYAAAD1jb0+AAAABHNCSVQICAgIfAhkiAAAAAlwSFlzAAALEgAACxIB0t1+/AAAADh0RVh0U29mdHdhcmUAbWF0cGxvdGxpYiB2ZXJzaW9uMy4yLjIsIGh0dHA6Ly9tYXRwbG90bGliLm9yZy+WH4yJAAAOSklEQVR4nO3dfYxc91XG8echpuBkIyeVwxA5Fds/okjFWyI84i0IZppATRORFhVwFKoYgpY/CETICDmqUJCqCgtkUMWrFholUkKG4jZqiFGJCZ1aldrAbrC6dpyQqHWpl9SmCnXZYBEWDn94Fu9Mxzuz987LntnvR1rt3N/elzPHdx7fvTv3jiNCAIB8vmXcBQAAiiHAASApAhwAkiLAASApAhwAkto2yo3t3Lkzpqene873xhtv6Jprrhl+QUnQj3b04zJ60W5S+7GwsPC1iLihc3ykAT49Pa35+fme8zWbTdVqteEXlAT9aEc/LqMX7Sa1H7a/3G2cUygAkBQBDgBJEeAAkBQBDgBJEeAAkBQBDgBJ9Qxw24/YPm/75Jqx37X9ku0v2H7K9nXDLRMA0KmfI/BHJe3tGDsmaXdEvFPSP0t6aMB1AQB66BngEXFc0usdY89GxEpr8vOSbhpCbQCAdbifD3SwPS3pmYjY3eVnfy3pLyPi8SssOytpVpIqlcqeRqPRc3vLy8uamprqOd9WQT/aTVo/FpcuFF62sl06d7HYsjO7dhTe7mY1afvGqnq9vhAR1c7xUpfS2/6gpBVJT1xpnoiYkzQnSdVqNfq5zHVSL4ctin60m7R+7D94tPCyB2ZWdHix2Mv4zL21wtvdrCZt3+ilcIDb3i/pLkm3B5/LBgAjVyjAbe+V9BuSfjQi/nOwJQEA+tHP2wiflPQ5SbfYPmv7fkl/KOlaScdsn7D9p0OuEwDQoecReETc02X4o0OoBQCwAVyJCQBJEeAAkBQBDgBJEeAAkBQBDgBJEeAAkBQBDgBJEeAAkBQBDgBJEeAAkBQBDgBJEeAAkBQBDgBJEeAAkBQBDgBJEeAAkBQBDgBJEeAAkBQBDgBJEeAAkBQBDgBJEeAAkBQBDgBJEeAAkBQBDgBJ9Qxw24/YPm/75Jqxt9o+ZvuV1vfrh1smAKBTP0fgj0ra2zF2UNJzEXGzpOda0wCAEeoZ4BFxXNLrHcN3S3qs9fgxSe8dcF0AgB4cEb1nsqclPRMRu1vTX4+I61qPLenfV6e7LDsraVaSKpXKnkaj0XN7y8vLmpqa6vMpTD760W7S+rG4dKHwspXt0rmLxZad2bWj8HY3q0nbN1bV6/WFiKh2jm8ru+KICNtX/F8gIuYkzUlStVqNWq3Wc53NZlP9zLdV0I92k9aP/QePFl72wMyKDi8WexmfubdWeLub1aTtG70UfRfKOds3SlLr+/nBlQQA6EfRAH9a0n2tx/dJ+uRgygEA9KuftxE+Kelzkm6xfdb2/ZIOSfox269IuqM1DQAYoZ4nzyLiniv86PYB1wIA2ACuxASApAhwAEiKAAeApAhwAEiKAAeApAhwAEiKAAeApAhwAEiKAAeApAhwAEiKAAeApAhwAEiKAAeApAhwAEiKAAeApAhwAEiKAAeApAhwAEiKAAeApAhwAEiKAAeApAhwAEiKAAeApAhwAEiKAAeApAhwAEiqVIDb/jXbp2yftP2k7W8fVGEAgPUVDnDbuyT9qqRqROyWdJWkfYMqDACwvrKnULZJ2m57m6SrJf1r+ZIAAP1wRBRf2H5Q0oclXZT0bETc22WeWUmzklSpVPY0Go2e611eXtbU1FThuibNqPuxuHRhZNvqNLNrR895Jm3/KNPvynbp3MViy/bT62wmbd9YVa/XFyKi2jleOMBtXy/p45J+VtLXJf2VpCMR8fiVlqlWqzE/P99z3c1mU7VarVBdk2jU/Zg+eHRk2+p05tCdPeeZtP2jTL8PzKzo8OK2Qsv20+tsJm3fWGW7a4CXOYVyh6QvRcS/RcR/S/qEpB8qsT4AwAaUCfB/kfQDtq+2bUm3Szo9mLIAAL0UDvCIeF7SEUkvSFpsrWtuQHUBAHoodvKsJSIelvTwgGoBAGwAV2ICQFIEOAAkRYADQFIEOAAkRYADQFIEOAAkRYADQFIEOAAkRYADQFIEOAAkRYADQFKl7oUCDFo/98Y+MLOi/WO8ZzmwWXAEDgBJEeAAkBQBDgBJEeAAkBQBDgBJEeAAkBQBDgBJEeAAkBQBDgBJEeAAkBQBDgBJEeAAkBQBDgBJlQpw29fZPmL7Jdunbf/goAoDAKyv7O1kPyLpUxHxfttvkXT1AGoCAPShcIDb3iHpRyTtl6SIeFPSm4MpCwDQiyOi2IL2rZLmJL0o6XskLUh6MCLe6JhvVtKsJFUqlT2NRqPnupeXlzU1NdU2trh0oVCdgzCza8fYti1178cwjbPX/ahsl85dHHcVm0OZXox7vx6GUb9WRqVery9ERLVzvEyAVyV9XtJtEfG87Y9I+kZE/OaVlqlWqzE/P99z3c1mU7VarW2sn09qGZYzh+4c27al7v0YpnH2uh8HZlZ0eJEPk5LK9WLc+/UwjPq1Miq2uwZ4mT9inpV0NiKeb00fkfS9JdYHANiAwgEeEV+V9BXbt7SGbtel0ykAgBEo+3vor0h6ovUOlC9K+vnyJQEA+lEqwCPihKRvOi8DABg+rsQEgKQIcABIigAHgKQIcABIigAHgKQIcABIigAHgKQIcABIigAHgKQIcABIigAHgKQIcABIigAHgKQIcABIigAHgKQIcABIigAHgKQIcABIigAHgKQIcABIigAHgKQIcABIigAHgKQIcABIigAHgKQIcABIqnSA277K9j/ZfmYQBQEA+jOII/AHJZ0ewHoAABtQKsBt3yTpTkl/PphyAAD9ckQUX9g+Ium3JV0r6dcj4q4u88xKmpWkSqWyp9Fo9Fzv8vKypqam2sYWly4UrrOsmV07xrLd1edc2S6duziWEjYl+nFZmV6Ma78epm7ZMQnq9fpCRFQ7x7cVXaHtuySdj4gF27UrzRcRc5LmJKlarUatdsVZ/1+z2VTnfPsPHi1aamln7q2NZburz/nAzIoOLxb+p5o49OOyMr0Y1349TN2yY5KVOYVym6SftH1GUkPSu2w/PpCqAAA9FQ7wiHgoIm6KiGlJ+yT9fUT83MAqAwCsi/eBA0BSAzmRGBFNSc1BrAsA0B+OwAEgKQIcAJIiwAEgKQIcAJIiwAEgKQIcAJIiwAEgKQIcAJIiwAEgKQIcAJIiwAEgKW6qDGxR0+O8x/6hO8e27UnCETgAJEWAA0BSBDgAJEWAA0BSBDgAJEWAA0BSBDgAJEWAA0BSBDgAJEWAA0BSBDgAJEWAA0BSBDgAJFU4wG2/zfanbb9o+5TtBwdZGABgfWVuJ7si6UBEvGD7WkkLto9FxIsDqg0AsI7CR+AR8VpEvNB6/B+STkvaNajCAADrc0SUX4k9Lem4pN0R8Y2On81KmpWkSqWyp9Fo9Fzf8vKypqam2sYWly6UrrOomV07xrLd1edc2S6duziWEjYl+nFZ1l4M6zXVLTvWypoj9Xp9ISKqneOlA9z2lKTPSPpwRHxivXmr1WrMz8/3XGez2VStVmsb24qfHrL6nA/MrOjwIh+etIp+XJa1F8N6TXXLjrWy5ojtrgFe6l0otr9V0sclPdErvAEAg1XmXSiW9FFJpyPi9wZXEgCgH2WOwG+T9AFJ77J9ovX1ngHVBQDoofDJs4j4rCQPsBYAwAZwJSYAJEWAA0BSBDgAJEWAA0BSBDgAJEWAA0BSBDgAJEWAA0BSBDgAJEWAA0BSBDgAJEWAA0BS+e4EDyC9YX2wwoGZFe0f44c2jBpH4ACQFAEOAEkR4ACQFAEOAEkR4ACQFAEOAEkR4ACQFAEOAEkR4ACQFAEOAEkR4ACQFAEOAEkR4ACQVKkAt73X9su2X7V9cFBFAQB6Kxzgtq+S9EeSfkLSOyTdY/sdgyoMALC+Mkfg3yfp1Yj4YkS8Kakh6e7BlAUA6MURUWxB+/2S9kbEL7amPyDp+yPigY75ZiXNtiZvkfRyH6vfKelrhQqbTPSjHf24jF60m9R+fFdE3NA5OPRP5ImIOUlzG1nG9nxEVIdUUjr0ox39uIxetNtq/ShzCmVJ0tvWTN/UGgMAjECZAP9HSTfbfrvtt0jaJ+npwZQFAOil8CmUiFix/YCkv5V0laRHIuLUgOra0CmXLYB+tKMfl9GLdluqH4X/iAkAGC+uxASApAhwAEhqUwW47Z+2fcr2/9qudvzsodYl+y/bfve4ahwX279le8n2idbXe8Zd06hx64Z2ts/YXmztD/PjrmfUbD9i+7ztk2vG3mr7mO1XWt+vH2eNw7apAlzSSUk/Jen42sHWJfr7JH23pL2S/rh1Kf9W8/sRcWvr62/GXcwoceuGK6q39oct897nNR7VpTxY66Ck5yLiZknPtaYn1qYK8Ig4HRHdrtS8W1IjIv4rIr4k6VVdupQfWwe3bkCbiDgu6fWO4bslPdZ6/Jik9460qBHbVAG+jl2SvrJm+mxrbKt5wPYXWr86TvSvhl2wD3yzkPSs7YXWLSsgVSLitdbjr0qqjLOYYRv6pfSdbP+dpO/s8qMPRsQnR13PZrJebyT9iaQP6dKL9kOSDkv6hdFVh03ohyNiyfZ3SDpm+6XWUSkkRUTYnuj3SY88wCPijgKLbYnL9vvtje0/k/TMkMvZbLbEPrAREbHU+n7e9lO6dJppqwf4Ods3RsRrtm+UdH7cBQ1TllMoT0vaZ/vbbL9d0s2S/mHMNY1Ua2dc9T5d+oPvVsKtG9awfY3ta1cfS/pxbb19opunJd3XenyfpIn+rX7kR+Drsf0+SX8g6QZJR22fiIh3R8Qp2x+T9KKkFUm/HBH/M85ax+B3bN+qS6dQzkj6pfGWM1pDvnVDRhVJT9mWLr2O/yIiPjXekkbL9pOSapJ22j4r6WFJhyR9zPb9kr4s6WfGV+HwcSk9ACSV5RQKAKADAQ4ASRHgAJAUAQ4ASRHgAJAUAQ4ASRHgAJDU/wHvws7rodafBAAAAABJRU5ErkJggg==",
             "text/plain": [
               "<Figure size 432x288 with 1 Axes>"
             ]
           },
           "metadata": {
             "needs_background": "light"
-          }
+          },
+          "output_type": "display_data"
         }
+      ],
+      "source": [
+        "x = np.random.normal(loc=1, scale=5, size=50)\n",
+        "s = pd.Series(x)\n",
+        "\n",
+        "s.hist()\n",
+        "plt.show()"
       ]
     },
     {
@@ -5543,57 +5520,57 @@
     },
     {
       "cell_type": "code",
+      "execution_count": 91,
       "metadata": {
-        "id": "ddjXc1C55ddQ",
         "colab": {
           "base_uri": "https://localhost:8080/",
           "height": 290
         },
-        "outputId": "7680b56b-c3fa-4d12-958a-2ac36e58e57d"
+        "id": "ddjXc1C55ddQ",
+        "outputId": "72daa412-71b1-43a8-f7bc-da5d710c9563"
       },
-      "source": [
-        "df = pd.DataFrame(np.random.randn(1000, 4), columns=['A','B','C','D'])\n",
-        "\n",
-        "pd.plotting.scatter_matrix(df, alpha=0.2)\n",
-        "plt.show()"
-      ],
-      "execution_count": 437,
       "outputs": [
         {
-          "output_type": "display_data",
           "data": {
-            "image/png": "iVBORw0KGgoAAAANSUhEUgAAAYUAAAERCAYAAACU1LsdAAAABHNCSVQICAgIfAhkiAAAAAlwSFlzAAALEgAACxIB0t1+/AAAADh0RVh0U29mdHdhcmUAbWF0cGxvdGxpYiB2ZXJzaW9uMy4yLjIsIGh0dHA6Ly9tYXRwbG90bGliLm9yZy+WH4yJAAAgAElEQVR4nOy9169leZ7l9fltv/fx5/qIG5Hh0lSW7ersrvYaZlrACKSRQIPo+QN6hBBCmIdBPDASGgnzMAIhQP0w4gE0gARPIJBmoMZ0d9HVlWW70kRmRtww159zj9l+75/h4XfiZkRmpIk0lVXVd73EjWP33Xfvn1nftdZXGGO4wAUucIELXADA+aIP4AIXuMAFLvDzg4tJ4QIXuMAFLnCOi0nhAhe4wAUucI6LSeECF7jABS5wjotJ4QIXuMAFLnCOi0nhAhe4wAUucI4vZFIQQnxLCPGnQog/FkL8/fc893eFED8SQvwTIcS//0Uc3wUucIEL/GWF9wV97z3grxpjKiHE/ySE+Kox5iePPf8fGGP+8cf5oPX1dXPt2rXP5SD/smFvb4+f1bk0BgwGqQyuI3Ad8aGvl9pQ1BKlDXHgEvnuz+Q4Pw1+lufzw2AMiA8/vQAobUCA+9iLa6mRSqMNJKH7xHOfFsoYWqkRQhB6H70+fZbzqbT1X33UdfVeNFKjjcF3nfe91xhDowyuEHjuk+dIa4MQ/EJcl4/w6quvTowxG+99/AuZFIwxR4/9twXUe17ynwshZsB/aIz54Yd91rVr1/je9773WR/iX0q88sorn/u5VNrw53tnKG1Q2jBKAoSAL1/qIz5kwLk3zfnOOxNOlg2XhhG/98IGm/3oEx3DLG84SWsGsc/24JN9xsfBz+J8fhiMMbxzknF3UpCELt+4MqQTPv2WP01rjhYVANfWE3qRD8BrB0tuH6cg4IXNHi9f6n/k91atYlY09CP/A78PYG+Sk1YSgBsbnQ99LXz887koWu6fFQBcHsWMO8H7XvNwVpDXip1hRH/1u5aN4u2TDIBO6HJjo3v+eqU0/8dPDpkXLdfWOrxybXR+vLePU+pWIwS8vNPHecaJ6IuCEOLe0x7/onYKAAghvgZsGGNee+zh/9oY83eFEM8D/wD43ae87w+BPwS4evXqz+RYPy2u/Z3/80Of3/vP/pWf0ZE8G/RqxfUsF3pWSw7mJZHncmUcPzHYP5wVHM4rqlbSCV1GSUDoORgDR8sSgK1e9L7vuzyM2epHVK1mexDxaXz4x2lFKw2nac1GL3zm1eQvCpQ2TIuGrJbUUjHJ6icG3tO0ZpLVDBP/iXOgHzu5SehijGGzFxH5H49tvn9WULeaadbw5Ut9ylYhEMTBk6voURKQ1ZLId4k/wxW2fiylQT8lseFwUfLGYcooCThZ1ueTQug5JKFL2SjKVvHawZLLo5hB7HO4rJjlLcuyZRrW1K3Cdx0Cz2F3FDPNGgaJ/wszIXwYvrBJQQgxBv4b4N94/HFjzNnq37c+aOVojPkj4I8AXnnllYucjs8JeS25O8kRAm5udD/21niS1hS14t60oGgktza7eK4dUELPBQyLUnJpFLM7julHPmdFwyRtAPAch41eCNjV7jRv0NrwjSsjvnJ5gAHWO+ET31m1itvHKa4Q3NrqEnouVWsHwl7kM4j989cOYp9J2tCNvF+6CUFrw6Jszym2K6OERdHSi/zzwe8R9qYZr96bo7TmX//mZbYHEa4jzs9V0UjSUnJ9vUvsO1xb63ysY0gryemypp94vHOSMSsbIs/j+kaHbughlQZgkPgMksFTP2Oa1VRSs9ENCT4GtfQ4Rp0AbQwGWHvPLqGRmpNlTaMUp2nN1iDk7iQn9BwuDWNubnSppeLbr59Stop5WfNbNzdIAo+r44R50XBlHLM/r3Ccihe2eiSBRxVqlmVL5Lm4jkBpQ+A5SKU5yxviwEUqw/68JAlcrq93PnRn/DRobVhWLZH/+dKnX8ikIITwgP8RSw8dvee5vjFmKYRY/6KO7wIWeS0t9284X9F9HPRjnwdnBbVUVFJztqISikax3g24tdlldxwTed75TfT4jf/4z5Os4XBesjct2OiFbPZDrq11eDArkNpweRhxmjbsTXKOlxWe6zCIfXbHCQ9nBWWjmRct3Z3++QSwM4jZ6IbnE9UvE/bnJWd5w0lacXWc8Nxah9++tUbR6CcmRgCpDE2rSQKXw0XNr1wdPfG85zgIYXn5QRLgOIJZ3nBWNKx1AobJ+2kZYwyugG7sMctbpDScFQ3X1zs0UpNjFxoA19efThmVjeJgbqkspQxX15JnPg9r3fCpj7uOwHcddkcJg9hHa8gqSYa9bruhhysEerUXFdhrZtwJ+NVrIxwB06whrSRas6JBFfszu8utGkWjNLOi5blxgjKGZSkRAnzX4TStqKVmlASM3jNhlY1if14Qei67o/h9k8b+vGRetAgBL2738D+n6/eLGnT/JvBrwH+x+sX/I+BvGWP+HeC/FEJ8BauM+jtf0PFdABgmAWktEcDwPQPKh2HcCfj6lSH3pjlCCHxH8PZJRl5LllV7Pih3I/+cUuhHPjc37Uo0Cd69LB/dF9rYQl5WSf7szoSfHqSMk4CTZUTZaJZVQ9Eoxh0XR1i++v60oBv69GKP967JDHYl/Ph3/TJAaUNRK7JKkdeKo2XF4bxkVrTsjmK+tjs8f+03r44oG0WrzFN3AULYBUHVSrqRff67e1P25yWXBzH/0ld2nvIeQTfycR0HYwz9yGdZtSit6YYu87LlEaNTNIpO6PFwVpDVkp1+zGBFZT36bt/7bHdyriO4tdllf17QSn1O97iOYJJW/PhhxagT8PXdActKsjOIeHBWcJY3dEOPy6OYnWGEu6zPd2Ot0jgOaA0aOF5WzAtJ0SiSwOHBWcm4E/DyTp9laRdXs6J536RwmtaUjaZsNKNOQPc9E+YjKsyYp9NinxW+qELzPwT+4Xse/s7qub/9sz+iCzwNgedw87Fi27OgH/u8uG2LkkKA0iXLskWtdh6jTvjEynVRtNRSsdYNMcYghGCSWRpqoxeyvqKTFkXDm7OKe2c5Wd0iHI3juEht+MrlAYPYUkKvPVxQtYokcLm21kEZg7OaGlqluX2cojVs9kO2PmHB+ucRl4YxQoDj2L9fJ/A4TWuUhuNlff46rQ2h7/JXv7R1/lgtFVIaskYyiH3q1tI8ke+xKFuMMdw9yXn9eMnrBylXxwlfuvR++ufaOKGSmsDr8sbREiFsneL+WcFz44SitrqSUeJTS8UsbwE4zSoGiU/gOdza7NIoTe8jis+fBL4ryCp7DJ4reH6ri9Kan+wvOV7UzIuWr18Z8qWdPj89WPD6QUrRSDZ6IdO85vnNHlfGdvfSKo2A851QP/JIq5aq1YwSn2le00jNvGwZdwNe2O4hlaEbvft7HS5KilqRhHaB5HuC6CmU2aVhTODVJL63omE/H/xyLZMu8HOFRzTQaVpTtgqEoawldyaKYeITeg5Fo2haxT96/RgDJIHDpUHC5VXxznedJ5QgniPoRZYrHyUejnBwgUujhBe3e9yd5Eyygqxq8V0Xz3W4M8nQGq6uWcqgVZqyUUhtqNpfjlvAGEPRKELPoRt69EIPg6FdTbRp1XJtRcO8fZzy1knGqBPwzasjAs/heFlxsqx5cFZwaRQzL1pubnQsF67tAIeBcccncG3x+f9545jtQfzEirdVmrdPM5Q2bPRCpIJWGd44Srk0sJTI4wsN1xiS0KWoFf3HFglKG2Z5g1LmfSvqTwshxPl3dkOPyHcxxqEfeRwJ6IYep2nFP7t9wsm8ZtTzuX9WkNUts8Iey8uXBhhjuHOaM81rOoFHL/KJNzt848qIaVYTeA7uRFC2mthzmaQ1V0cxh8sKqQyLoiavJd+7t0Bpw/X1hC9fHuAK8UTBumgkB/OKOHC5PIw/03PxNPxy3BEX+LnCI5qolRrfc8hrSSfwmGQ1ZWtphFlhedm0avnJwzl3pwUCiH2XRSl57WBB4Lns9EM2+hFnWY0jBP3I56XtATc2urgOHC8a3jpOkVozSDyMgXi1O9DAomyZZg2Ba3ceNzY7bHaD1erZcGn4wbuEWioC13nmguAXgf15ySxv8T1BIzX3pwUHC0tbeI4d8B7OChwBB4uKvFYsyoyr45hLw4SsapkXNcuypRd7ZLVkrePjOrDRi/CE4E/vTtHA7ijiaFExyxu+/eYxv/v8BidpTTf0GMQ+Ullq43hZUkvF7ihmktWsdwOKWmGMoVUGz7GDXy/08B3B6LEaxf68pG41y1LSj/3PXBBwY71DozS+46C09cqs90JC32GtE/Lq3ozXDlKWZcOg8FnrhjSt5ixr2Pcrrq93yGrJd/emzPKW3XHMOAnYm2S8uN3jxkYXqfRq8dPl4azk7ZOc+17BIA746cEZp8uabuRRNophEiC1eWqd4HhRsSxbykYxSvzPnfK8mBR+TvBhktWfV7nqe6G1QWrN3UnONGuoWkv99EKXwBNkVUvTak7bilubHVqlqRpFJ/LY6AUobRgnPn+xvyBvFWuJT8cfEQYeP7g/5+1JRuAIrowTfNfhcF7yxvGSWd6wM4zohh63NnsgBJ3A4+2TjDiwcte8sVTS9/fmDBKPolE4QlDW71pkqlZRryiAB2cli7KlG3lcX/94qpsvElVrf4+qUeR1y940wxhopcHzDW+fZjgC9ucVlwYh92c5jVRwG17Y6nH/rOB4UTNOfNKyRRvDf/X/HrLZCelGHi/vDPj+vRmBa1e+xkDRao4WFUfLCoxgWUo2uyH92ONkWZFWkiRw2eqHPL/Z4zSr6Ufe+QQWeA7bg+ic1nKcit2R3c2EnkPdagLP4Vnng7JR7E1zXEdYFZuBYeI/Mblbn57gzeMUpQ3DxOd0WdtdRKCIA8dKVAOPUSfAcwRnRUNaS6TW3NpMeDiv7A4n8lHScHeSUdSaHz6Y8xs311DKkNWKXuiS1S2ny5o3jlKGiRVdKKW5utbhK5f7bPbjD6RqZ2XLvWnBqOPzsvfRPpFPi4tJ4QKfCZZVy/2pNQxVjdXF10py/8wahEZxYIu+EZykJd/fmyGN4coo5uWdPjfWO4w6AVmpOF7WHO4v0BryVrFuYFbWLIoWV8BZUTGMQvbOCg7mJUeLimneMogCnt/qYzCklSQOXBZly5cv9UkClx89WNjdBNCPPY6WFdO84WRZMUwC3j6xA+la1+rnwe56fhFwaRhzmta8fZrxznFKWknWOiE3N2JOs5bDWcmibAh9l0G8DgaOFzV7k4KzrMF1HEszlQ2TrCLwXWZZQ+A4TLKGnWFM7LscLkp6sc9GL0IbjTGC1/aX9BOfG+sdaqXZGcQsy5Z705J52XJjo8sg8elFHm+dZNyd5MS+a01l5t2C9uOqs6vjhLxRxL77zDu1edkglSGrpDUpRpYyfGR2PFlWHC9rWqXxHIEQgmlWc29leFvrBnzzuTHLomVvWrA7jrkzSTnNaopGMStbslpiELjCXsO/fmPEd96Z8fpyQdYofvJwjuc47AxjKmWltX/y1oSjRcXBvGR3GOG5Hkng8a3r63QeqzEUjeRoUZHVklHiYzSsdwMGn8OO6Wm4mBQu8JlguVKVGGNNYRoYxQFx4BF4DvemObXSVI2kagzT2mrFX9zq4wiBVFA2miiwq8f9ecVaJ+C59Q5b3YC3T1KmWcm8UGz3I06WKRhD3SgcAaHr0irFvbN8pYU3TLOaTuTRjzwC3+W3bq2xNyk4XBRUrS1i1lLx6r0Zz40TpNK4joNUhp1BxDSvnyq7BKt3dwQ/M1lrWrUrdVXwPorhkTt8oxvy+kFKWkqyWvKlnT6B61LLmtB3UIUdeCdZTeI7IGyNZla03NzqEvuC793LKOqWRmoGic+irLm50aWoJeOOjzKGtGpZ74ZEnsOylhwvKzZ7EWdZQyPN+cDVSIU2hnB1vI3SNFKvqLyK59YSBolPFHRplaEbelStOqcA36u++bgYxD6zvMVzBZ5rC7JqpdZ55BvYn68czYOIzX6I73rsjgxSG7QxZFVL1ig8V7A3yckrTVZbb8N6L2BRSFwB/ThAanjnpODSICKvW/JaMitaholP4Aq+vNMnrVq2BgFnRUsjJaHvsDOMeHGnRxy45LWkVVY2fDC3irHDRcXNjQ6zsqGRmsh3qaWiqG1N7ixvUMb+3YtGnb//09KdF5PCBZ5AXkvSSjLq+E9VOCzKloezgti3vL3jiPP3FI2Vrx4vbWH5pZ2udX26Dq02LPKWtW7AWjfkYF4hhGGaVxwt7c04agO+cnnAX3lxy/oMpgUPzwp+eH/Ow1nB/bOSqtU4aKQBF1t01hi2hwFH84qHs0OM0fyVFzfxXYdF3vJ//cURNze6DGKPNw5T9heF3XU4gl7s85VLA767d0bgOjy3lqw04OJ9lMPj5+D+tMBxns3U90nRKs29aWEpm0ad01nGGGqpuTfNaaRZFYWtG3cY+/Rjn7yWLAob67Eo7U7reFGz1vUZJz6uK9jsRXQDj2HiobRhWSlOlyVvndgB+nBeM0oCnt/uUra2JpAELoHnUEnFW5MCbTS10qx1QtY6IZu9kHE3YF40/ORgya8+NyIOXAaJx4OZ5so4OZdVhp5L6Nlr786p9TBcHdsJ44NQtYqjRUWwMp09jiTwzuM4ZnlDqzTr3ZCsluxNct46Srl/VrI7jljrhqx3QyZZgyOsnHSW1/iulc/uzyvy2lJdm72Qy8OEq2sxm/2Ig3lO1Ri748wq9uclaMOkaHj7JOfSMObyMOH2qrB/tGgo65aNbohYOSB8YXcGdyfFKgtKkTeKd04yTrOaVmt2BiHGCKZ5zR/fPmVZ2b/vI0Ve3VovDkDd159aTXcxKXxG+KgYi18U3J3k52a1W5vv5zhneWNpndoOPp3Q43BRIpWlbIq6ZX9eILVdlY47Ea3SK37WGtV+59Y686Lh1Xsz3jhK7cp8GDFKfKTWXB3HHC9LDpcVR4uKRmmmWc00rfE8wZ2pZHcYs6wlnisoW7VapWoqpUgCj7dOUtZ7EUZbPv3OJGNetAwiOxBO8prdYXJOLZSNQrqGVtvV7J+8PWVWtPzOrfX3ZSw9opS0toPT5z0pPD4taa1ZVi290LNKq7TmzaOUK+OEKHCYFQ3jbojvCpZFy0lW00rNdj8iqyVpLVHLim7kMU4CBknAWVYzcx2WVctz45j7k5S8bZnnCmms+awX+SzLmqKRrPcjXCHYXetw/6wk8l1eO8rY7oc8nM7ZHcdMi4itTsiylLzdpnRDh6/tjrg8TM6NX+/d8dTSSmCzSnJ3mvGS3//Ac3ua1ue5SY9MZ0/DqBOgtXUSv3GUorRGA9c2EivZDV3eOEoJXIe9qfW23DnN2OxHbA9CPGEH71YZro4Tnt/u0g08Qt/j5nrC7eOM79+bcWeaUdYajWGeNyDs32Je1EwzwQ/uz5gXDZOsYVq0hJ7gjZOM/VlBowxHy5rQE/RjW1urpLbfbeyu1HccosDlYF4Qeh7Luj2fFB53LCj96f0LF5PCBZ6AI4TV9H/ADnTUsXx7sFIVSWWIA4+yaaikHSBPspqNToQQlkJIAo/Nng2+2+xGxIHHjx/M+enhkodnJcuqYe/M56+9tMHd05xZ3vLawZLjRcVpaqkPz7EuU6kdkkAQ+y5FKykqSeg5ZI0krxSNVPRDn7O85bm1Du+cZjyclezPS/qRx8Rz+JXnRvzLV3ZsjEIv4MUtK2VN6xYXh7O85i/2lxgD37kz5W984/IT52C9G1JLy0e/Nzri84DnWr9IWrWcpDX3JgXDxGdeNrx1mnKaVfiuw7WNhCujhLsTW0T+s7sTikZxa6PLl3Z6KG1olaZVhmHs0SpL6GsE+/OS0Hc4WVoD1VlaI41dz/quwBHwk4MlrhDU0rDRjVDKcH9aULdWYx/7LqIb0CjD6bLixa0Oae2xN7UxEhu9iMujhFubXarWFvQfxzD2yaqW07QiDkIezsqnLkzA0kvzorV+jMcml1ZppDLUq+vOdwUnacXtk5T5atcQeA67w4SdYcw0q/jRgxknyxplNHmpeOc0Z543aN3n/llG4vtcGke8uNNnsqz40+MJdavZ6oc4Au5NbV1GG9johnQCl7SS7A4ivnl1xJ+8PaXju0yUpTqF0UxTxagjmBYNdyc5juPQSMNGP+JoUZJVLceLimsbCQ9nJSC4vhFzeRjTSMNLOz16sa03DBKfs/DdHdGnvt4+9Sdc4JcKNzY65LV8XyTCIwxin8HlAUeL6lw1cmOjwzgJWO8F/NndKS9u9a1xzHeYFy2XhhHTrCHyXHxPcLQs+d69M946TqlbidKCfujxwwdLbmxIFoWkaq1uPfAEvuNwVrZobWhX8kGlDR3f5WBe0wkcekJQS812P2QY+1YSqO0kl/gukWtprl5oV7nXNjqME98qkKQ6v5nCwGGYBChjyCtJ7D854Fgax0YvfJ4GovciDlw8V5yf80ZpQFBUGqUhClwizw7MceDxF/tzjtOaRhqurwte2O7jug5vHC65udEhCTw2ejFp1bAsG5QRNK1mVtRkrUSuIhz6sUPou/iOsLUfA4tKstkLKZoWJRVg6IU+v//SJmWj+OnhksBzqRrrnVDa0l4/2V8wL2w9Yr0Xvo+acxzB7ighqxVKG3z3g7nx9W5IN/TwHHFe13mU1bU/LxkmPolvz9kktdlZ07xBCHhlZ8QgtoXbV/fO+N7eDK0Nz292aHzNOPExwO3jJVmtiTzN1fWYyHNY1C2vH6TMywYH2OpHnGYlke9xaRDxa9fWGHc80kajtebbb5yiAN9z2BrErHUNZavoRoq61VwdxVwZJ6S1ZKMbntOcea3Z7If2GvQ8PFdwMKv56u6QbuhZmbDzrp/haUmwnxQXk8IFnsBHhW0tipZJXp+Hmj2C6wg2uiFfvzyklTP2ZyWTrEE4gu/cafFdh3ESUEvNG3em/OD+nLxWXN/o2Dx6Y2gayU/3F4CgaiSb/Yh5LimkYqvj00QuZa0QjkOjbcGQlVNZGqt7v32cc5I2GODK2Aaw7Y4Sdvohs0rSSM00tdyss5IsGuyAvyhsLHfRKL55dchZ3nBl9G7uziOtOMC8aNnq/2yz87Wxkt9Gam5udPAdh6/sDtifFbiOIF8VopPA4zi1SpnYdxEYXt07I60kvdUu6vWjFN9ZcrosOVpWaGO4sdFjEAc2XkKAcUBpYQ2Crgs0OEbjuy4/erhgreMjjQHh0Iut1DSrJWWr8Byr6DlNa3wPpLa1iJ8eLLgytsXTK6PkfdlHziqGomzVR7qZ33udFo2tgUhlbMFa28l0mAS8c5KSNy1ZrThalCu/jMef35tyuCxQCnaHEb95a41WGh7McrugCK0r3MEhqyWecChbzWla4zqCqlW4jsP6KGTYCThYVLw9kWz1ImqpERhO0pr9ecVGL2Cjawf8ZdXgCMH19S6XhhF5K5llLQ9nJdfGMaM446cHObvjDlnV0ip7vA9nBdv9aHUdGm6sd59QLn0WuJgULvBM2J+XK97SKnSCVfbLndMcx7GmoOc3u2z3I370cI6LIHJdhl2fo3mFAI7ShiSwF3iycPjK5T6V1OyfFewvK3zhsN4PeTAtaDUcLUqO5iVp1aCNVamEnofBUgHSGEKtyWu70nWErSOMuiGbvYiXLsVcGcU0UvPaYYpGc7KwRjoBjDt21bksW94+zkjLlndOcwzinLcF6IQ2QkMbq1DZm+SMOsEH7qo+a0yzBs9x8AKHRml2RzH92MMV8JP9BVndsihtMf/rlwdM0hpjDMtaMuwELCpJWjYsqhYpNVLDnUmKIyBwPXphCY7dWU2Eg4PGdQ0CQ1E39ncXLpUUnGbWeHVlrUPRSq6udXh174zbxznLpuXmepfNfsBp1tJKRTuKOZjVBL6gH9soiFaapxaUA8955mRUsKvlslG8sNkl9B36sVXoSG1d057joJTkpwdLvnl1zGuHC+vjEA7CNTiuwzvHOd3YY1PFGKMYJiGzrOVgUZDWDevdkEYqPNehaCS90MMRhnEnoJGGZWkl0kprThc1QrDyNhjunxW8sNnlaFkwzVpubMS8en/OH78zRSlDL/Z4frPHyTJhUSmqVlO1isHK/V82mm5gw1rmpU0VbqTh1lb3iWswry2l+kmVcReTwgWeCZ3QZVlKktBjvWcLsPtzmxCplOFHDxZMC+spWEsCtgcRm4OINw9TskayKFs2uz6L0t6si6LhzqQg8BzuTkvyWtJoTVZLLg0j0lXNoG0VlTRIaSiahlECvdgjcAT9JOSdkyWB66K0jeV23YaTRYkDtEoxjgPGvYDdUcz9aU5atvQiD891uLHZ4Syr2e6F3DkrWJQNk7zl5Z0envPujRX5Ll/a6WEMvH60tAmbtWRw+enxz5/9ufc4W1Egke+eUwdHy4qikexNc76+O2SjG9KLfW5t9s5rOkLARjcg8e1Kd1m0zPIWow2nRYsrWs7yhrxuKRrbac1zwXU8eonHLGvOdx6u0PQjFxfD0byklpof6TPySlNK+96qVWAEV0cRp2mL7zjURjGKIw4XFTfWe8AjGuzToVV28Dxe2j4ZnivY7EdEvnsuKd7qhUzSmnnZUtSKN49SXrk2ZL0fsZU1ZHXDw1mB1gnd0GMmGvpRSNXalN9maSMxDhYledXiCIEnBFnVYBDsnWZcWe+AMXRDl4dnFYuiRhnbXTBwHaTR1iVdtSSBde53woBZ3jAvGvpxwEYvYlC2VFLiew5lI7k8ipFaM81blpUi8K1pcJQEBJ5DI989h4eLkkna4LmCF7Z6n8jXcDEpXOBjw+r47Urv6vhdWmW9G9BITdlIDhYly6Lh9aOU59YSktzl/rzkneOcqpHsh+W50qhRiknWIpbVKudGYrTAKIXWHkdpxUY35PpanwdnOaXSzPMG37NFZ20MSjtkVbPayks8x4bBOdhawVnW8NrBkh/dX/DSTo+rawnzsqFZFcg7gUvVaB7OK9C2wK4RtFIxyRp+9/kn5Y5CiPNBuajV+xrHfJ4YxD7Jdg9HvNu+9HBR8fZJyu2jlEujhMNFSdUqvnVjjZ1+xHfuTMhrTas0l/ox75ympFWD0hplNLUyOMbQGsN8KYlagisAACAASURBVDHYNogulkLa7Fr1TisNaqVK64ahVZs1GiPEytQleWG7y84w5C8OFrSrOs16NyD2K44XDQiIA4eNTsjxsiLxHRal3f09klGepvaztlaD+kfhUWbTaVrRizz+7O4Za52QB2cF37qxRhK4VvGT1by0M+CsaDmYl+SNZBz77PRCpr2QaVEzm9loja/tDvnq5QGTrMZUimXZMi9rAtfBIIgDh2olaU5rCQYezkt216wBsxd57E0LzoqGslVEjoPnuzbdFIkvHALf4ddvrPGlrQHffvOEjV7Edj/ia5f6GAM/erDAc+1kBvbei3yX01WcyM4g4vIwJvDdJ3pGVKsQQ6msqMB1nv36/CKb7Px94BXg+8aYf/exx78C/PdYJd6/ZYz58Rd0iBd4D06z+jzRclm9W4wOPZdrawk/PVjwzklGKa3K4vZxxsmypBeF1EohHOhF/jkvP4h9Lg8i7k7LlSxUEwUu60nMomjJM8kkrdmb5lwbdxjHPgJBVisE1gXrOGC0wTUwrSRKgTYa34OztEG2iv25Lc4WjQIBp8uG47RkXtQrg5PD/qygbg3rXY9O6FHUPrHvsj+vuDx6f57/9bUOZas+045hH4WjRUWrbOc5F8tn//jBnP1ZSd4qHpzlPJwKXtju8nBW2GiGXPL/3Z3gGGu0Wu+HLCu7Wp4VdsWL61LVLY+82w4QelZp1mqDVHbwV8oQ+FYCPM1bamlY6wS4K1lw0Wi8yOXqWofjtKGWioeLioNZiefaWsGtzR6LoiHyXe5Oc7JGMu6EDBPfdt9btQTVpuLyMP5Ig+AjWarnOEzzhmneWElnK4l8h7sT61I2q0Tc0LXelqN5yQ8ezihbTaM0Ra1W0tAKeX9CJwxY74ZobaiVJq8VlVDgODZyG00pDVLagSqtJG8eLdnohmx0A3YGMWdZjRAOUmsiX5DWNhjvUdBgVtq2pf/iy5vcPyu5PIp5fqvLH781oRO6aK25Oy3IG8Ww45OWitCDd04zro27+J7zvoC8nUHEsahIAu99k6rW5vya/bAOcV9Uk51vAl1jzO8KIf47IcSvGWP+fPX0fwr8ATaa/L8F/sYXcYwXeD8eSf+EePdnu3U1HC4qq5cfJZYvThQ/3F8Qew6xr3l5p8c3rowo65b/7QcHnBWS9Z7P9fUe09za+oWwA3ziu0x1TaM0ZWtoWsWeFlwdR4Sey/22IFiZ5pzQxhRUUq8GOEMnchHASVZzsjRUShN6Lv3YZVHUZJWNQUh8wbJsqXqKXuShTMtaL+bl7R4/2V+ubiq74korSTf0zrluxxEf2VP4s8SyajlNawyGspHc2Ojy1knKtKjJaoljrCO8UYrXD1N8VxD5PmdFTdsqylaT1pLTrLIx2NrgOaCMZhA51C0oB6SG2IPQd2iVoWwlwhirPjLgGUPgugxjj61BwlbPZ39Rsmwk06wmdB2WlaK7yjw6WNiV7aJq2ehG/MqVAa8fpVRSszepmRUtvufgOw7avKssa6SleJ5mECwayfHC7gy2+iFHi4rnt7tkq2iT02XNWjfg/qzgZFmTNy0G2DvLcTAcLiuMhvvTip1BRC9w2RpEnCwrQFBJQ1ZXjJIQpTWtUlStwhMw6ng0GCopcBwIfRvzHvkOs9ym+h4tK76006cb+fi+YlG0eELw3Chm1An50k6HsjGkteKf3j6hVYZ4JfCo5ZKjZYVSZqX6gtB3kdJOzpPU1owOlyX9xIooamkXWaFnP+O5D+iQd3ean+9uP0jqC1/cTuE3gH+0+vkfA78JPJoURsaYBwBCiOFT3nuBLwhr3ZDQd/EcQeS7581HTrOaspY8nJW2Ycs4RhqP6+MuSejyq9dGfOvaGN9zKWrJrf0lWlv+eVk0bPUC5qWNDmiURmqNQeMKgdTW7TzLa1op2RklbPUjzvIG37HcdS+yscWOI2iVYRT5COMglZW2Og40UvJwViGVplqpU1qliAOPF7a6fO3ykKJVdAKPl3d69BOfRmqur3W4O8nPw9le3O490zlrVsqqT2tws2mtcDS3zV00GVWjaKVtkDNMbLzznZN0ReVppJZ0fZeNXsjxwrpjW2nohz4GzTRvwAikNASOoFoZnxoJrdb4wnoaNvsh2kiEK2iNXWHWreZ4WVI01hBYVDYJ9/I44Xnf4/p6YiWnQtBIw3PjDr91a40Hs8IOctrw1ctDpDbsDGIcR+Bgexs0Up+n22ptv+vx83f7OGNv1b3t97+0xfNb9m9SxrYA/OJWH88VmAdzPOGwPwdhIG8krTZ4joPrC/xV2F4n8vntm+uUreTVu2c8XJYIBGd5xa31hF7oUycaYwxGazB28eIJQeh7rHV8fBfSWnM0L2mUYa1b89JOl3khuaMyHMexYYuxR1FbR34tJVklqaTiYK5olOKl7T6h55KVLc9vDlhUDVJB6AmWwqCMYlHasEnfcfBc8B2XRmme3+p9qOjhPDSxVR/4GvjiJoUhcGf18wL48mPPPb5X/PnPLP5Lhm7orYq5LfPC5h1llcRzBKPE5/60YJrbyIAbm12ur8f8ytUxniO4c5rZlVvdMitbtrshx2nFm8dLlrXGFwZjNEobhOMCLcKBVkIQCFzPIataIt+jE9laQCE1PQfWewGX3YRl1VC1hkYbBrFHFDjkVUsnDHAdwDgIFDvDhPWOjzaCXhxwfaPDw7MKhOG7e3P6sc+4GxD47rlL9FndosbA7eMUYz46tuFpmOU2Xny9Z2WmL2z17MAEHM5LBrHHi9t9PEfQCV3SWpLEPpHjcLQsSUIfBGz2IhzH4WhhlVmOEHiOi9aGShl8Yc9BKWuQ7950WgiklnSCDgZt6y9S4biCvG45WFasrZriDJOAyHcZJx7DJOTemc2XetTp7Pde3KBsFK8dLEkryc3NDlfGCbO8ZhDbYehwUVI2iq1eRC/yzg2CvfdILotannPsZSvPG9bEq97Hj5o0/d4LG0zzhoN5yaJoOFpUlK3i5Us+/dDj2nqXb98+sU2AMFwZJZykDQ8XFQYb1/Kok5zvOBzMS2pjf6e1vjXvSaMoG40TemA0ldQYrbhzkhG6Duu9gFHHNo5aVi23j1MaZXhxq4fRmnE3YG+SM+7YfhWnaQnY/C+EjewIV/HtA2V7TORNa/s9L0oaqYgjF9+xPaB//fr4A6khe76bD8zzeoQvalJYAI8yYPvA/LHnHr/znipNEEL8IfCHAFevXv08ju8CH4K91Ta0ahWjjs9XdwcoZfjpgc2Ff/s0Zxh7dCMfIaw6QjnCZvhXLXtTG89wuopXXpT2Js+VpTTuz3JcYdtqKmXpKk9YXlghaKS0Chdpi6WOcOhFPq2ykQyNNPRjH411HHsOuELQjzzWej4uAb7nkrcto05A7LmcLCveOklxHYMyghe3epDB5WHMtbUO87J5ZumpNubd1pOtZMDHf79UmgergbVoJC/t9Ak8h41eyLffOGFetKx1Q3ZHMRu9kGzVOnKaNYw7gTW7OYJ3TjMqDaMkZFE2uMJllPjnoYVKaTqhz0Y/pJY2S8n3oKgUdWtopVU37Qz81arWMMsqqgYcAWUt2ezHJAHcOyttYxnPwRcOi6phnNjC6w/vz8gbG1gYui7z3GZo3Z0W3JkUvLTdZ1G2KG3Ym0xt4XUQ2ejrx3C0qIg8h9BzeWG790QPBmMMdyb22uxFHkVjnfc3NjrcPbUxGh1lFwvr3ZC8aekELj+4PyUrFVdGMbUyDCKPVtuJpWwUlwchtVQcLEqMgiix/Sm0gcO5JJMNR2mFKwQGgzYQGs0705SzImAQBcyKdkVDtoSey8mixPddAtfu5Hwh8AOXVsPXr/RJfJ95XqMNHNSS3WHE3jTnLKsZJnbHjjDsjhOWdXveLOjxDoPvRT/yP5YD/1NPCkKI3wH+wBjzbz/D274D/G3gfwV+H/gfHnvuTAixi50Qlk97szHmj4A/AnjllVc+v2alF3gq2pWMMA5cbm50z52p1iiUWhey67KsrGntJK25tpYQeg5pWbM/s27o0BW4roPWmkYZtNbUEgIPHNdyn1pLNFbt0+8E5GVLJq1hKA4cesKjG1pT27xsCTwXz7GUU121zHODNpr1bkRaS/JaUSvbrL6VhthTtFpz+7jkOK2YZjYT6fZJyq0NS2XEgUscfHjHq0ZqTtKK2HfPm8a7jmDUsc3hnzV+wF3l98/ylqLxeXG7hxCCZSUJfZdG1dStZqMXWp/IJCP2Pf76V7fZHcUYA//gT+4ySWsuDxMiX3Cpn6xqEHan1iqN0ppCSrJ6tTrFUiMTaia6oVUwzWtqZWmwVkJlHrVYBRzDsmqYFIZh6LI/c1nvBYw7AVdGCeNOsIoFUbbO4bn0IjsoV63GaFYUocZzV2awlZM5q+X7JoWikfiey7X1DlfHCZ5rV/CPYqYftfp86ySlXLmpv747YNwJmK4ktwezkrdOMoZxwCStOJw1ZKvGUM+NknNH+/VxzGvHGXdOc0pp6UwlBDu9BKntjk0IQas0WoPj2j7iketQSU2rNXVjaFptTX7GoFf1kknestUXZK3G9wS9jk/geWx0Q7Z6MduDkJ/sSyZpg2OsdFcZgza2lvH13QHrvZDn1jpEvss0b+hF3lOb9DwrPtGkIIT4FeBvAX8TuAv878/yfmPM94UQlRDinwM/BO4LIf5jY8zfA/4T4H9ZvfRZJppfWnxU2N7PugnP1XHCNGsYJj7LUpLWNrrg0ap1qx9xd5JTNoqyVlweRrx5nPLdO1MOFxVrvcDyplVDq23cbywN2hHkRYMRBiFchklIP/KZZC2ua3nWRmrqlfoD4RFFLgfzknnWEAQuoyTg8iimNauOVbLFdRy0trxy0So2OgFHy/rc+GajIdyVictFOIJB7NMN/fOsnI/C4aJkWUpmtHTCd5Ufu09RLn0cCCHY6od2QvJdjpYVApv59NzYdkobxFaimNeS42XNZi/kpe0B24OIHz+cs923k0PoO9zY6PHGwYJGaltXaa2fwO7kDO6qqUE/DnCFOOfznVWvg6xqaeTq/1jJqufb6G2pDI7WlFLQC13++ld38F2HtW5AKzWdyMNBcLSo+caVIdfWEnpxQKM0oe8QeS7b/YhwZYQ8y60nYqv//ol0ZxBztKzoBI8Ks4pp1gDWZT6IffJGcmkQc/s4I/QF92cFWhnunRVEvlUPpVXLPG/BWJms53q2+DwvKRtN6AkeTHPrYnYdPMeh1TbYcVG2pLWtT3RDS8MFrkPVtjiuwyC2/gGb6Gt3jIHnEriCcScgb/RKhafpRh7KGEadkF7gkoQenmt3G9v9mF7k89J2j+NFxSRrySrFpWHM9jDi67ujc6qo/xkaKD/2pCCEeAGrCvoDYIIduIUx5l/4JF/8uAx1hb+3evzHwG9/ks+8wM8GSeCRjD1apXnjMAWsPvrWplWJrHdDDuaWHw49gSsEr+7NuHOaM+p4XF/rMk58fvxwwZvHKYHvsDsO6YQebx4smZQNw8jDcSz37ToNUtk8nGHkkdbSaueVdebWUmMQ1K3tmGWEYBR6BA4cp9ZX0EqFVILYd7i12WPQCej6Hje3uvzGzXX2Jhm+67IoGsbdgKvjhPVu+LEVRv5jyqzPqhHKc2sdTlMrp52kduDb6IV8dXfIqBOQ14q8abl/lnO8qJgVDS9sd/Ec0EqvdO4RL13qMkkb5lVL1ShqKekELr7jU7WSRWk9GWuJb+Oj04rGKLR5jMu19VWMgJ4v6MURceAg0MzzFu267I46/MatDX7zxjoH84LXDlOySnJlzRrChh3rMN4dJedxKi9t93njaMmf753x8qU+G73ofVHYj+NR3eARAtch9AXTrGXcic/lw2WjLB31qBHQ8ZKyVQxin7VOwKyorTfGKG6sRaz3Y6pW80/fPLUtSSOPrGopWk3TSpLQwXUEridYFA1hYJ3MjdS4rmC945E2diEwiH1e3umDsLudvJKkte2f/fx2j3luey4oraildUNXrSarWjqhImsU37oesNEL+d2ddU6WNZ3Q58WtHrFv+0wczCue31KfuOfEh+FZPvEN4J8D/6ox5m0AIcS/95kf0QV+YeCuTFSTrCarBbujmMh3yRtL5Whj8D2Xu9OMrJYIx6Zr/s7zG+zPSv7Z7Ql1q6ikohcFoCWVAmEcGm1YD1x812GSN9StxHdtBo8tQhqktPp5g1ndLA7z0jp1N3oRw8Rnd9RhktU0sqE2didwdZxwfcPGPnuOw5tHS6tC2u4yjHyS0HtmuenOIKITusxyW9B8RMV8GiSBx3NrlhtfllaP7zqCwHO4PLKd1mqpGMQBjmsdrm8dZ/zk4ZKTtEJpY38XP+C7x2e8frBEacNWP1zFMlivQhLaxkfSwHFao1pFszIteI5tZakVqKq1KhDhME48jIBpLokDj0HiszuMEcJwtCyR2lg12EpivN4NeOMopWokf3b3jL/20iazouUsr3kws9Hrrx+mjDvhM02qQggC1yH2HZaVZGf1vY/ivg0GqRSuIzDGFtGXVUvoeRRNyf6i5NIgJgl87k2XIKyY4uZGl/tnDu2yBDStsfUtp4X1rkcc+nQCl3uTnEJpjjLri/BdgdIwK1qMhsC36qubGwmR77HVtXHckS84TjVJ4LDe9ZFGcLy0dN161xamlbE7kHnRrvpG2IZAbx6ldCOPe9OcL1/67N30z3Ll/2vAvwl8WwjxfwP/MxfqoL/UsKmWMYvS2vYPFxVXRjF3Tm1bS3elinFb2F45MH/3+Q08V/Da4ZJBx6eTe9RKc5a1GGN5a4TA9wTjXshkWdPx7eRQrxzL/dgnrSTSEbhoxknAdj+kEwfcPsooGskgUVwa9BDCoagli0JgtOHyKCYOH/UJbrg6TjhaVKx1QxwhiPruh04IxhiO04qzrGFnEDHqWIpDCAFGkFYKsB27PiskgcfNzQ5Sm/NCYei57I4Sykbx/FZ3NfgZ3jpOOU6tX2C+qhtUdQuOHRE1hlHHJ1+ZmC4PPe6dZWS1puu6SK3xfZfEVzjGxXUFaysTW2sMrVJEnmBaNngIlDS4vmAYB3zj6pBhEnDntGBnGPFrz43R2M5go07A3jTn7mmN49T8k9uGRsJax0dpTei79GP/Ew0otlvauw11QsdddV9rOF5UeC7sDmNapdkZxmS1ZF40q0K0SxJaSSfGTmBB7PKNKwN2xwl3TnOOF+X/z96bhViW5/l9n//Zl3vPXWPNzMi9qrOqepma7lnUM2MjxiOErAcb7Af7xcYwxiCDjbziF70IWR5kgzEYhBHCWKMHGywEftBIzEizSD2a7p6u7q41Kyu32CPufs9+zv/vh/+NW7lXdlVWLl3xhSAy7xJx4txz/svv9104mue4lonvGPQbLr6rqaiTrKSe6R2UKSAvFY4peX9vpnM3lMKxDbaHKdfORChge5hSSi2YO9P28WybopZ0QpcLHZ+rqw32JilrkcfxvGCl6TJKCtZbAZFv4dsmUj2cRzFehCk1PYuN1pN7YE/CU08KSql/BPwjIUSIFpT9F8CqEOJ/B/5fpdTvfe6jOMUri8AxsU2BlArP1vXWpmchpeJcN9Ch5kpyvhsQuJamB2aaZ32+GyJLvX0+nOZ0fJeDeU7k2qy1XMZxiUKw1QvZm6bYpiApFK1AW2FXizpxXEjioqbfrFBK0Q1smo5FXtY4C2Vu07Nohw5vbEQ0PZOylORlzU+3x0Shdg7d6gUIBO/cHXM0y7nQD+5rpINeAb6/O2OclAzigre3OstJxLWNZd6w94xttQNH/46kqCgrtaS3bvUCJmnJ6+sR37815PrBnGlaEVqCOC2RwK1BwuvrTc51AiZpwTDRIT1ZIUmVxHMcRJwyyys802CUa0pxN7T132QIAlNwdbVJVpTUSk8uWVlT1BLLgq+f1ZGT26OUy6sNGm6DK2sN7gxivn9rSMOzCG2TvK4pC8m7O1Ns0yQrPX7jtT6Bo3dnT1LaPg5n2j43Do9QwJ1hwtW1Jg3X4lI/4O4w4d3dGWUteW2tSSe0WW+7fLiruLza4Btndc9mZ5Jx+3iO75gErsEPbo8oJfRDh2vrTe6OYqRUWJbB3WHKKNUuwLYw2OwEWIYiLyRZVWOZimmuXUxLpcjTgnbocneUkJYVSV5jmlp7AArfNhAIXlvzWG16KOD9vRmDme7bvbHRYi361Gq813QYzgs2H9iNHs40+SAvC1Ya7vMzxFNKxcDvAr8rhOigm83/LXA6KXwFEOfaeM00BJf6DQ5nmQ7AUZoPX1Q1d4cpu+OUYVIsrCJSNts+Ld/i48OYvXHGa6sNvTLzDKSwcDqCUVrSCV0CxyS0TeqsYl6WRB2P9ajN3iTn7nBOUWnLhVqBa1lkVUVWSm3C1/AIHJ3JfP0ooZRyyYJ5fSOiknDzKOHj4zllrbTDqm3iBZoVsj1K2BtrPvvhNF/Wv09gGmK5mjUXPkgn8GyT19aaz0Ss9iikRc2NQy3aWqtcViOt8F5t6t91qR/ye1JhCrAdC6/WjKi2sukEDhdXG3ywO2EYFxSlwrVgklY6v6CWGIYgl1oZbtumVk9XIJCsNhzePt/iV6+scDjNGacF//ef3SU2KqoKvndzSDdw8RwDf2zyW2+sU0vF9z4ZMIgLdkYJSkmO5rpJ2/YtzndCLCEYJxUN136kLcMwKXAtTTl+HExDK9ql1F5QF/ohB9OMu8Nk4RiqE//0d4OdYUZc1GwPU4q6JikqfEdrVnqhy9Es4/YwBaEYNj02uwFb/QZIuHk8xzQMirJikuY0XJueq1fmZVVxHBdIWZNXglFV0HBMBIYufQoIHU0LlcB60+NglnHjaMY0q7i00mQtcrVfkm1i2YLdYcLtQULk2fzypS5SaZsWgKN5QeOe8xJ5NkdlTuCaX6iv9YW6FEqpEZoa+ne/yM85xauDSVoipb5h47wir3TYvYkWdxmGwLEEmy2fQZxTuTpUXkrFwSTn1nFMUUviUt9A81yL1XoNj6zSwTGhY+oVaiHwHC3K8UMLSUbg2tiWwLctlJL4jsEwKalqiRA6jL7fcDEMxTSrkLWi7dv82pUVbMugEzjsjFPe3uqwM0qZ5yVHc+2eudH2lgyWoq7pNRzcB5hHLd/m7fNtRkm5zC64F5/H8vlpcRI+D7pkkhbaGTR0LQJHM6j+yjfW+OHtMYeznDir6AQu602fftOj6dsMZjlxofMOpKYfYZmCKHDwTJN5UWGKmmrBDLINg2IR4lPUujzyG6+vsj9J+OnOlB/eHmJgYKAtxata75IqqRjEOYFt8d5kxjAuiQJLJ5Y1XALX5Op6pEVbD/xtJ9DZx3oAvLr2eFsGEGy0POJcM5ZuHM3ZHqZUUieRXegFWIs4y7VIR7QOF6UmpcRCQ6Ancsu1mKYFrm1Q1YqV0KXtOxRVxd44Z6sXLMOA9qfafLDhWVxZDTmeZVw/jpnEJYahfaJWFwJI2zRYb/naawuBabIgNpRYpmCSavX90bTgOxe7tAKH41nO7jRjltWstVwOZznrkbe0Annw2lxvefQbjl64PCJb/Glx6pJ6ip8JncBhllWYBjQ9C98xOZzmuLZYDogXeiG3Bgm/sNWhGzr86O4IQwh6TXtRjoFvnG3R9GyuH8woS8VGx6XlWwuKorUwKZsQ2i6BY7E3yQhcE9A0zbWmTqn6+GjGwTilUlBLSVVDwzd4fT3iG7Xmkl9dbWAaJqtNl7SoFzJ/xRsbDd7bmwHaHdQ1dcN0qxs80Ygt8h0i/9klXT0tGq7FZtujrBUrTXcpItyfpIyTEs82ubgS8ltv+vz+Bwcopc3fLvRDvnulT1pUHMxyFrk41JUkqhSBY+DZBqYpuH2U4liKYaJpnSuRS1ZUTLOKtNJ0UQNYaXhsdQKGcUHoGHznYg9hQJbXdEP9WdYKzvdDuqHND+6MiLOSzmaTbuCyGrm8udlaUDDFfU6fSqmF+WJxz2P665OjOZ5t3sdQciyDaxsRaaHZRdcP50Sejis90/W52AuXn2Ve1bi2yRsbTa6shvyz9w9Zj3QuSOiYSKm9ln66OyYpar51rsV3r/S4eRzTDhwMIXhzs0Va1AzmWvFsm4Je02OaVkSOQ15ow0bbFAgD1hou5xYOqtodGJSSlDVYVovjWYFAUCsIXJMzbZ/LKyF/dP2Y4bxAoMuH3cDBMg2urDYoaolnGUv19gk+b8noXpxOCk+Jz9IKfFXgO+Z9/j+WCQrF4bQkzvW2d6sX8vWz2rZKSh3JCBDnJW+f9/Fsg6urDVYjj7Mdn25o8fFBjBCCc10fxzQZxDnrbY9pUmmvl2OJMBWvnW2w0faxhOD33j9gllV0A5uNhodpCqoaEIq60gpm39VZvqZRczTL2Z+mC5O0mq+thxzNtI32Rstjo+2yHvmfq679vHAijNubpAzmOZahWTdxoU3vNkvJWuRxbTNaTNKCrW7I7jjl6lqTf/dbZ7jQ9dkZZaxGDjsjreSuKknTd7jQF1w/muuIT1vgmiYZNaO4wjZz3jjT5GCWEec1SVFzvheQlJL1lk9dK45UjmEIfroz4Ww3xLHAdy2+ea6NIQSRb2uXUNtaCODUQwPZ0TznYJIjlaLpWvQXeo1y4VYa5zqq9V46phCCpKixTYNz3YBpWnKxH/DBwYyjWc7bWx082+Sj/Rk3jmImacHVtSa/dPGkJJMRehajpGSz5fOrV3rcHeqdwD/56T5JXrHVD3jrTJtRkvPe3owkr3hjM+LNzYjdSYYp4I31BjcGWptQK5hnNZO8Yl1K/sLlPhf6Ie/uTbGEzo4+3/ORgKnAsg1Cx6YTOmyPEqZpiWnAlbUG19ajpb3D0Tznk8M5lZSc6wZc6jee6TV7Oimc4gvjxL7446M5G5HPYF7w+nqTSkpuHsfsT1OiRRMxdBesmVLS9Cwars2dQcYwqfBsk/1JzjfOtTnb9clLxSwvOJ5q98lRUmIYBp5tcXeUEOeStJTsTjNqBW9uRrQCLb6aRq7keAAAIABJREFUZiW3RwWWoWmzZaVwLF2SSMsaxzTZG2eM05J24HChFxA4n6/R+bwxy0qOZwW+beHZBmfaHtePYmqp09gU0PIc3t7qsjNOGMwLlIKirNmdZDimRb/pstL06IUew7jUquVKEpeSvNQ+R6ZhcLbjsT1JcGyDwNX21rcH6cJcTi52KBaTpKIVWEzSkruDhO1RQrQ7xbNMosCh6Zr4rrYTUYtIz0mqnWfXWjoh7wTmYuVrCMFK5C77CSefje4P3D+RbA8TdkaaCvsbr/U51w14b3fK4TQnL2tWGg5X1yKtdK/0AsGzLO10apl0Q4fVptYLHEwzLvQC2kHFH3405sfbYwLbYppXXOo3MYXAMgTd0MU2tbXEuztTjuKcrW7IuV7A7VHK9jjBMg3agctrqxHrbR/XNrm2HvHRwZRhXNBv6p3w/kTbZKxs6knfMQ1MQ7/XWCjZZ3nFm5uR9sTKtXlkv9DKafdz5CY8DqeTwim+MNYiT1PmFje2YWjl6zgp2Z9mzLNah7y0fNJC8s7iJjvZ+uZ1jW8bHM8L1lsed4cJlxbZtdsjReLVSHQWg2OZtDwbqxcyS0rtFmkZRIG2Cfg3Xluhloof3RmTVwmeZdAOXXzL4NYg1uZwAi6vNMmrmqySVJXEdUzyexKsslKvOp+VEO1ZwrE+ZTl1FjYSDc/GMnUzFeDyakha1MRFpXdKC0sRISAt62WDPK/0YO7a2pok8SrqWuLbJl/bbNL0Xa72m0wzrTv50Z0hrm0TOCZ/8WtrHEwzKiXpN+yF0Z6BYxpM04qkqIk8G9cxeetMhGHo3IOdcYpr6dds9XymacXqPeazvYaLZRgYi/yNE1iGWIjzHv5caql7SLYlGCYlZxyLbugwy0ryUjJMdA7Im5stHFOz5OK8ouF9KobrNTxGSYUhdD6EKbQZX+RZKCDyLIqqotf0eHurzVFccLbrkeQ1R7OMduACgk7DpeE7vLXZInC1TuGtM20ajsneJKWotK9VXine25vyjbNttnoBZS3pLspoq5HHd6/qvOi0qEhLbQMihKDXcEiKiloqQtfENh5dMtoZp4wTTWm9d9L9LJxOCqf4wlhpuqw0dSDJNNO1bb1CslFS11Y7vrPwitE3N2if+F7Doah1Qtq5nt4d5KUezMyF3YQhBL9+xeH9/QnHs5ybg5jLqw3+rbfWudQPyaqaD/fnKKXYXzhc2qbBG+sR/abLuW6wiJI02JvqG/nb57scz3Xju1aKpmtzOM2JPJtZXnIw0QE8V1cbz6RO+yzhWrqEV9VqmfwWujr3+JOjWHvqdwM8S9t+hI5Fv6kbkJdX9KD68eGM6wdzLq+GXNtocb4TMM4LJknF1zYjXltr4pqC47jgXCfgYJbwoztjtsc5q6HelW22ffpjl51JympTs8YansX+OCerKgSC/UnKjaMZaVHxjbPtZcZ24Ji4lkHoWA/5GwGPdZR1H0P1vbyqQ48s0yBYsJjWWx5vnWlRSUXoaJq0Yxm8eabFreM5NwcxpgGRr+mw3VCriJOiphs62KZ+7bluQF7UTBdRpW9GHue7wSIlrub2LGYt8jAM+KWLXXzbpKhqzvdChknBPNO+Su9sT5BK4Vp6AdJwLVYjh1881+GHd0YLg8dPG+4nA3lV63jaE1LDRstno+Vzd5gwTkpuHM25sno/dVopxXDRpB/Mi9NJ4RQvBoYh7rPlLWvF+Z42D1uLdAQnaAaTDph3abgWB9OM9YXY5tpGwB8vGmyHs5zz3YA4nxHnmhMeeQ61lMssgeO44PJKg8Cx+N6NIR+OZkggL2vWIh/T0M6iw7jAtg02Wx4d36Ed6K8rq00Op9qgzzR00/DEVK2qlebhv2STAuhJ70HW62Cuw4PmdUVa1oSuxdWTpuTixZ6thV1b3ZCdkfb+FwKkgEu9kGOvYJ7qz2S16dIKbN65M9Zsp1JyMC0whKbltgOHo1nO2mLA2Wz7NH2bNzdbGEKwO075gw8K4kLywf5c9zo2Ir51rk1RS2zDeGblOs+2+Na5NvVi0D3BG5sRg3lB5Nv3/a7Id+iFWo3ddC26DR0RKpViq6f1Ne3AIc4rlNTurC3foe07xEXFnWGBZRjawE8YfONsmzMLRb/emRkoIM5r3fNZ7Eo+2JvRb7r84laHvJaL7IhP7ayHcUm/cf8ArhdYDxMb0mU+gvaxulcvKYSgHdhM0nK5+3hanE4Kp/jS8NH+jLyStAP7vgvzZEA+QSdwlgZ7kafZP0rBNC15b3fKOC14d2eGYxk0PIO1qKFXW7UOjRnGBaN5jkRRSkXkanZS5NtcWQ2Z5xU7o5RZWtMKbFqBQ1VLbg0SKinZWuwkTrIK1iIPqVItZHJejVukWriY5lVNezH53hkkBK55n0NrXmkPKcuAK6sBpmlom5Ks0o34Sco722NWGx7DlsfXz7YwDQNQXOyHyxLHjaMYhKATOJhGRdOz8R0L/57zdWmlwd4k489uDrAtm8CxaPo2QojHrvi/CCzTeGhAO/HpqqVie5QghKDj21zbaKLQCvHA1T5eh1PtM3UwyYg8G6W0225Zy0XqnuAoTtmfZcyykmsbTZq+zWbbY3ecEriavXQCbbRoMM10otzuOMWzNQ31+kL1v9J0GcQlriXIK/Uz2bNvtDyOZjmRbz+yzHmuG3Du85zHz/GeU5ziPsR5tZTXnwxAeVVzPM/ISsW9JU9tQqazfU+2u6tNF1NolgrAVtfn5iCmqHRu7uGsoBVqI7O2r/sKvYbDPNPMpMAxOJjnlJXi7a02X1uPmOcV7UC7Ve6MEkZpwUbbI/JtzvcC4rxeZkXfHaaLWFGtCj3T9rm08iRe/MuHuyPt0qqU4mK/we1BrPMrFgrzk0H4zkBnNCi07UVcVMRZTSq0M2hVaz/+uyPdXHYsbWWSlTW/crnD7WNdsmgHNllRM5B6UBrMc1qeBUKwN0mxTL0r++6VPt8610YufJheVI9msMgXP5pnOKbJauTyq5f6mIbWVwzmOtbUNgX9pl6wjBOdt2C3PdZa2rH3B7eG3DqOEQIajk3kW0zTCs+2GM7LZf6yb5t4zokViSTywHMMjmcF01RnKlS11po0PMFmO8B3nnx+aqnYHafAYlfm2U8U9X1enE4Kp/jC0IlZknlW0fJtbNNAKdho6/zYjUhvh28PYn54e4xnG7x9vsNa5DHNSn54e0RZKdZaLq+vN5lmFVWtOJ4XbHXDxWpUD1hJUfH+3oyqlpzt+vRDl51xRuhYNHs2my2PuyM9yI8SvcWfpCXuwkjv9TWdSxC4umFb1pJ+w2Fvkmmb6S9RfPZloqold4YxUsHZToZrm8S59mDKS8mNwxjLFNSLLIyslAj0wJRV2gdplussg7e32tiWSSfUE/C3zrW1Z88oJS4042s2ShjFOqRoOC/wHe0ndW0jWpr3NRZGec8zy/pxcBfls3wRuZqVNbcGMfnCSnyaVtwexjiWoOFaZEXFnWGGbQqKStJvuoySEssyKeqay6sNZnlJKRWH04xWoBXZhiHu25ndq8k73w15Yz2ilFL/LMOg6ZrsT3NuHidPTOdLi5p3tsdMkpL1loe3iFn9MvBcPy0hxF8F/ge0C+//o5T6Ow88//eBa0AK/F2l1O8+z+N7VfGi8xY82yQtdO7ACZ3Qs00urYRkZU1vYRo3TjUDJCvlMqjneJbrOnhe0alsBDpn2TF1mPpqpPMZTlScP9kek1faumB/nJHkmi3SCxs0PD0IHc0Laqn45Cim33Q5mhULq4tP/WNs8/685aZnU0n5ypSLHoZm36xFLnkludAPF7sqHXJUS7V0SBVCq8YPZ3p13G+4TNIShLYuObMwjVOopWAKtPtlVes4SlOY9BsGRS0ZpwVlrTiOjWVkqRDaCwr0rjFZaAte1E6h5dtcXdOMtnFa4loGo1hfj9NM02s1GcFhZ5Ti2oYW6gntEqsUFLVe4KR5g9dWmwSOSVJIViKXXujQWkSS3gvfMdnq6cVR7x4H2LVI99AG8xxjcU0W9SODJvXr4nzJHEvLmmlWcjzP6TfcZz45PO874B10VoIE/rkQ4v9QSk0eeM1/eGLNfYpXA2c7Ab2wxrHubxw+GP93oReSFxJn0fAF3V9YaWpa5OtrzaVF8NEs56zj07mnF2Eagm+e06K4H90d49oCQxiacx99SrvbaHtM05JaeTimyYWe9qZpPyEj2bEMHF7NXYJSiqxUnG371EotbbtPVuidwGaSlNiLkJeTQf7C4vk4rxjFhd5R2QaRb9FtPNycPNvRNg1pWSOlLgUqFK+vN9mbZJxp+fQamsGjm/ZacXvjMNb0yaR4oWW5kwyHEwGgUgnTrOTaRkStJJ3AJs5rug2Hutaium7g4Nn6uu6HDd7bm7LVCzEMLQqcLNh2T8o10H2CR1973dChrBUKdZ+q+0FEvs04Kbm0EnKxH3DrWJeRjmb5qz0pKKXunPxbCFHxcAazAv5PIcQA+GtKqdvP8/hO8flxQo18Elq+zS9d6t73WHfRJ7h3MjmxhX4QZS25PUjIqppKKuK4JrRtWr6mvt4ZJHQbmrev4x513+BFrlCfB4TQ1N1K6mbzOClZi4zlrihwLN7Y1JHou+OUYVwsE/JATx6haxHGBfvTjP1p9sjzb5nGfY/LhdcVsPTwuXenNc8r7g4TdsYpa5G73EW8LDjXDZguEtjaoc3b5z+9Nue51gHc2/jdGacM4lw31NXCMLDQyW+bbe+p6vuTVGdTe7bJxcXk8jTZG5Gng3uEOPm8KyZp+cSFzufFC1kaCSH+MnBDKTV74Km/rpT6C8DfBv7Ow+9cvv+3hRDfF0J8/+jo6Ms81FN8SahqySTVRnZPS0ucpCVpUTNLK626tU3WWi5fW29wNM+XN9wJPNukEzo/1xPCCbZ6AatNF8fUEZ3Thco8W5Qa1KK4faJuPp7nD/2M47ku5Y3ictl4fxLu/dwe1Ts4KQ1GntYlnOt+vmjSLxN3hwmTtOTOILnv8YarRWvTTAskq1oynBf0Qh2Ac64bUEvdjC4qyfG8eMxvuB+jWMecJnm9pJQ+LYx7jO62egFvnYmemFL3efFcdgpCiP8a+CvA3wf+EPhvgH/7wdcppYaL738shPgfH/fzlFJLZ9Zvf/vbz2T5cept9HxxaxCTFlL7IK01P/sN6BvVMHTJ6XxPDzDnOgGGYeBYBnkpn3mOwasEXc8udT3fMigqyceHmvrYbzpstHy6DYdRXCz7PPeiFdhkk1yrZJ9BSNBJGFIndLjYb7yUk7NnmyQLz64HsT/NtFmdgNfWmjQ9i1lW8fpak5ZvLzNEslISeU83lHZCh3leLRlKXwRfxAn1SXguk4JS6neA3xFCNIH/D/iPFrkM90EIESmlpkKI14Hx8zi2U7wYFJWey0+aawfTjKysWYu8x2YRJEVNYJuc6wR852L3vvLF5ZUGaVkv1axfRfQa2jjuJDsgK+sl+6VcnO8zbZ8zj1ldtn2HJK8XYUFffMA5KQ3mVc3dYULgmKxGXzym9FniYi8kWaTQPYiTc6aUpoNe6If3XXOGIbi61qSW6jMnvMNZRpLXS5X145CV2g7ds81lee9543k3mv8acBH4e4uL7j9GM43+E6XU3wT+wSK4RwH/2XM+tlM8R2z1AsZJsVSNngiHBNqz/kHUUrEz0s21UmYPKVRNQ3wpIeavGu6t6WuLaZ1TsdL47Gbk4SxjllXMMr0rexYceMMQHEzzxc89Ebm9PBO38YTrZr2lnXc9y1ge86NKnZ81IWRlzcFEX9+KbOm19CgcTDOmqc7kbnrWC2HDPe9G898C/tYjnvqbi+f/6vM8nlO8ODRca3kzlrXEMEBKLfB5FIwFxTEv5XJVd7ISfpkGmZcNvaeYDE7g2yYjShTa3uNpVsBP9XMdc5HBIZ5JWep5wbGMx+6qQC9UTnanT+qLWYYOMqpq9ZklI982mabVkr31InC6tPoK4EXrGD4Ltmnw2tr9Bm8PQght5pYvhFZxXnHzOEYpnij6OcXTo9fQNs7bo4TdUcZwXjx1v+dJWIs8Is/GNsVL6SP1efHJ0ZyslDQ864mrf8s0lh5Un7XyX400i+lFnqvTSeEULwUeZfD2IKRSTFMdXF8rtayX51XN43jgp3h6SKmYZSXDpCCwLfJKPpTs9XnxKu/msrJmlBQ0vU+DfZRSS6v17ClYRJZpPPUg/6LP1VdmUjhlF7362BtnWnkLXF0L6TUcpFI/U4nkFI/HwUyzbQBMA860gy+N4fIq4e5Q+0UN5gVvbERLaui5TsA4LX5mF9KXHT83k8LpoP/zjxNjPSHAEMaXwtH+KuPEoiSwLS70w1fY8uPZYsk2EoJ750jtuPvzt0MVSr1cKsOfFf1+X124cOFFH8YSxSIowzaNZZjMq4Jbt27xMp3LVx2v6vmslaKs5MLi+uXpAbwK57OWuklvvGTn7lH4wQ9+oJRSDx3kK78UuHDhAt///vdf9GEAmkXzwZ4WaZ+IsiZpyd1hgmkIrqw2Xhij4Gnw7W9/+6U5lz8PeNnP5+Es42CS4zsml1fCZano9iBeOp1eXAlfGqrvy34+AW4ex8wXavLLq4/ebe1NUo5nxWc2qL9sCCF++KjHX94R6hWEbWozMSFYGrnNshKlWNg+/2yy9lOc4svEycCfFvV9Dp3twEEI3fD8KosBPw+6i3MXuOZj1fUnfbF5Vr10flDwc7BTeNlwvnf/zN8LXdJCh8A3n3LFlVc1eSVputZpo+8ReNkptq8KVpou+5OMxj0hPKCNC1uPUd2mRU29yFk+xcPQfYb7z92D9/Na0+NwltN6SY0aX8gnK4T4ZeB/Qbuk/plS6r+857m/Afw7wAj4x0qp//lFHOPPiv1Jxt1hzEbbv89J0nfMn4nrXdXar0ZK6DacR4pnxknB7jij4Vqc6/qnE8cpPhdavn2fC+jJjiHy9OA1igsOZhlNz+ZM2ycpKv7k4wFpUfHmZsTl1S+uYXiZsDNOmWUl65H3yEzkezHLSgwhPjNA6FH3cyd07rOEfxQOF0ywTmiz0Xq+hIoXVT66DfxFpdSvAatCiK8/8PxfV0r9m6/KhADw4+0x26OMP78z5os072ulljmvZSWXIq17XS2PFyEyk7RccqVPcYoHcTzPuXkcE+fVZ742K2tuHM25M0g4WFiOHC0iTofzgqqWJHm9KHnA4ezpXEFfFZQLF9SyUhzNHnaQvRejuODWccInRzGzrHzia0/u57KW3DqO2R2nTzU+HM/0PX78As7zC5kUlFL7Sqls8d8SeLDY/reFEP9MCPGt53xonxvBQnASOCZPOyc8qp7oWiZnOr5eIbQ99iYp86xib5wt08o6Cxpc4JovPcPhFC8GZS3ZG2f62pmkn/n6Wn4qBqykFq2dlIhC18QyDXoNh7Mdn1ZgcekFNki/DFiGIHT1PXzv7ulRKOWnC7Gqfvgeru7pz5zczxLtqDqYF0tb8yehE+pj+DLyEj4LL7QwKIT4BrCilHrvnof/V6XU3xBCXAX+HvDrj3jfbwO/DbC1tfVcjvWz8O0LXY7muk74NPkAh9OMg+nDzA/Q7pIngphHRV32Gi7de4Lvf95wqjn54jCFwFnYZz/OdfZehK7FZtujqCX90OHG0Zy0kKw2XdYWITBCCL5zsfvMVM4vE4QQXFpp3OeC+jj0QxeltF7mwUH7hLnVCe1lGVnfyw12RunS1vyzsNHyWY+8F3KeX9ikIIToAv8b8O/f+/g9mQrXH3dCvow8hS8Kb2Hp/LSYLradaVFT1grbBKkedlw82wnohjqTWAi9CrHMh62NpVRUUuGc7hy+kqilwhCfeuwbCwp0XtVPLUI7UYbnVU1a6NXuLK9Ye+B1J7+jqCSWIT5zEJWLHfHThil9GVBKPfL+ehBPc4yGIR5raz1JSwSCSVpypq01C65l0g0dgoWtuW0aSKlQPPl4XtTE+6IazRbwfwH/lVJq/4HnTjIV+i/q+E5wPM/JyprVpvfEwbaoJPuTlKZnP7KBVNaS/UmGaxn0Gi7jpKDh2dSypOFZDOOcP78zxrUEr2+0CGyD798eYwptJiYVdEObd/em3B2kvL7R4Fcv9ZcXVC0VHx/OKSrJWuvTrOJT/PwjK2t+sj1mGJdc6AVcXWsuBzbTEA9NCJO0ZJaV9BvuI3cQWVnz/t6UnWHCSsvjfP/hhU5W1nx0MGOaVTQci1ag4zwH84L9Sba8BvcnGbVSHE1zsqriF851OdN5/ir0aVryxx8fI4BfvtSle0/AUFbWxHlFy7fv8yaaJCV3RwlKKYZxgWkIvn2+i2sbbI9SkqJms+1hmwaV1KW2UVwwnBdkZc1mx+d7NweEjkU3dDjbCZbnu6gk7+9NGcQ5V1YbbHU/XykuLWqO5zmR92yV1S9q0P33gO8A/9NiNvzvgf9AKfWfo8N43kL3O/67F3R8pEXN3li3PaTkkR7/oFcg3/tkwGCumQK/erl3H71PSsUHe1N2ximOZbDWdCklmAKubURYpsG/vjkkzms+Pkw5nObM8oq8rml5DklRc74XcnuonSvjvOLmUcy19Wi5sitruYxPnGcVP2ekkFM8AcfznMG8JC1rhrEmHjzOUK2WituDmKNpzg1zzq9c6uHeMzFkZc2/+OjwUwGma6Hu4TEkRcXuKGV/kjHNKvJKMjByNiqfW4UeQCdphWsZlJXCEILdYcK7uzM8x6Dh2i9kUtgbZ+Sl/kP2JtlyUlBK8clRTC0V47Tk8kpj+Z5RomNLbxzHjGYFpVS4lsG1jRbjRO/yd0YpR7OcSVby2mqDeV4zSvRn0fZt9qc5q5HuK4yTQq/8FWyPE24PYmoJ1w/nrDYfHyz1JGyPtCfTJC1peNEzo7e+kElBKfUPgX/4wMP/avHcf/r8j0ijrCVpWdNwLExD+5xIqR7rAV/Vkr1Jxjj+tBRkCrEs8YD+4H50Z8zNo5i1lsvOMAWhBUKXVhoooKhqtkdzkkJfTNOs1KsOs6S1ZXE0y7m8GjKY5QzinE7oMJjnuLaOTbx5HDOMc3oN94WlNZ3ixSDybboNm2Gs6DVtjuc5gaPLFeOkYBAXWIbB2Y6PQFMpB0nO0TTn9jBhs+WxFvmstVyKSqIU2h0VyIqKH2+PubzaoBc6/NGHR9weJtiWoOU6NHyLpmfhO7q0Oc9LJklB6JpsdQMmacEwLihlTcMw6YYvxidoveVye6izOO4NG1JKO+/qf99fhe429IJss+Xx/u6EWire2VZsj1LtIuuavLbSZBAX5FXNO9tjNtsBhgGeZWAYgnZgE3kWaVHxr2/GRL4NChSK4Twnq2qKylkewwnmeaX1I67FStPleJ5jmwbd0CEpKkZJSdu3sU0dBWqZgmdZmTtVoCyglOLG0ZyyUkS+xfleyPlewIf7M4ZJQSuwCRwd5D1fNJJuHM2ZphWuDVmpON8L2B6li1xa3WgaxAUYEJcVh1PFVi9EKcFKw6GsJMNY3zi1hEoqRnFB5Nn0G95C9KKwzZrjWY4Cvnulz43DGe/uzrh+OOcbZ1tUtaIbuqw23c/kTZ/i5wuRZ/Pt812EgDvDhHFS6q+05OZxzOEk4/X1SIe3ZLrebaKb0CaCO8OEwNYr2TNdn07gcK7jY5mC9/YmWKbJT3cnXO6H/OH1I4pa0fIt1rY8uqFDXtU0PYuvbTR5d2dC3VXLFbMQAssy6AQOr683eXOz/dzPT5xX3B2ltHwHM9R/7yQpOdP1CRxtM3Fyv96LrKiJfIvVyOVwkrE/zZhnNZ0AjmY558yAw1nOuY7He3szVpoutim4utpgnpUcTDN6TYeNts/7u1MG85xxXFDUko8O5hhCkVeKtJS8uzvhOxd6yyb3/iQjLWqmaUlSVMS5JmfapmB7lFLVinFScG09Yl5U+Lb5TPsPpyPIAlJpXcA8r5dOiEWlm0RlJfmzW0M8y2CWVbrXUEmkVDiWSVZWdAKHg2lG4FhIqbnMa5HH+V7IwTTj8kqDWVaSVzUX+yGuZfLB3oRhWhLnBWWtKGtFM7C5shri2xYfH844nubM7JJe6CAVKAlZKRFU7E1KVpuerhE3Xb0SOcVXDic9hJO+lxCQ5hVH04xBXLA/TbnQD4jzCtc2uLYZsT/JuDWYE7oW14/mAMRFxdE0ZWec0/ZtRnFJrQpWmx5JUeHaJqapy5mmUPzjP98lcE1WI5ffenOdvUnGLC9puvo6LCttN20ION8LXoh6d55XevdT6nS/D/ZnGAL6DZffvLZG6FoEzqeDapxrCu8oLvFsk8CpCTyTaqyIXL0zbzomh/OUWil+/WqfVuAwTkpqKemFNj+6M+F4nlNUirOdillWcnuQ0G04rEYeDc+irGqSUh/b9jDleLaHQPD1sy0arsX+JGWclMxzHctpGcYyua6qFZahdyPRM4hMfRCnk8ICpiGwLYP5NMc2BUUliXybUVKyPyk4nOYIBB/sTUBoG90rqw1Mw2BvFLM9TPEck+9e6jOIcxDw/t6UrU6AaxkkecXRLMc0BG9uRvyL68f8ZHvKauTgCl2vdS1wTINxUhK2LdJCMisqDMMmdE3e3IyQShH5Nh/tT1mNPHbHKe3ARik9Ec1zzVRai1wOZzlSKTbb/kNGfFl5ol49nUh+XrAeeSRFzZ1hzI2DOcfzgrc2m1iGFleO4hzTNLnQC7AMA8+yuDtMAUmcKyZJwfG8ZJIVfHQ45Uzk4zsWX1tv0PRsHMugYZj86O6QW8cJVS1xbZOL/QYbLY+slNiGwTe3WoS2zSQt2er5HE9zBvOCzXb9uWrnTwulFLcHCXFRcabt0w4c2oHNLCvxHI+ikhxNM47jgpZvsRp5rEceR/OMduCwHnn84UdHpIVeGF5ZaVAp3XTOqxrHdYg8C4nuU2y2fXbGKXFR8f7uFN8x2JvklFLi2QZpVfHh/pR3dyYcTFPG84yilBzPMhxT8PWNCH8x0Vw/nHOm5bM7SfjOhR7zRZ61AHoJS2dOAAAgAElEQVQNR/tRIUjymu1xylZHK8y/DHvz00nhHgS2xfqiJi+VwrNMrqw2iDyTvXFKISVHsd5GXumHvLbaYH+W03AdhkmMZ1tMspKiltimycFiG/j+/pRPBnPqWiGEtsS4eTzn+sGMG4ew0nDwHZuDSYFlmjQTB0MI7o4SnV8sIHAtNlo+R7Nc14bzitGBbgie74fsTlKGcc4krbjQC4mLkmohCfTs4r5eQ1bWfHw4RylYi1xWT/sQryykVOyM0+XknxY147giLSXnewHzouL6dsx4XrDa8rm8GnA8K3hvb8Lt44TtcUJc1LimwWvrTVzbpKoU7cBBCcG3z3e4vNpgnlV0A4ef3B1x/TgmryQGish3aHoW7+/O6DVtLMMkK2o2WwEKRcO1oSnIS8VPdyac6wZYhiDOa1aa7mOb4mlRc2fhLnyhF2CZBlIpPj6c4Vqm7pE8UDLJK8lsIQwbxAXtwMG1TK4smBc7o5StXsg0qygruH0cczDJkAp2RtlSe2AaBv2mg+9avL835Y8+HrAzjDnXDbEtOJzljJKSP/1kyOE0Y2+csTvJiHyLX77YJ7QNlFIcTlPuDmLujFLKSiFdE0MoHNPQf98o5S9/fY2ihmFS4trGktZ+tqsnHNfSuSFCCA6nGUUtyUvJKCk5mOZc7J9OCl8q1lsepimwDMHuOKWoJWtNj0+OYgDqWoIC2zLwXIvLa03GWYVp6sbUeuTRCRwsU7A9TJDSISm1GjnJatKqxrEtbhzF1LUkLSvChUnWKMmxLcE4qTAwmCQlTddikhXEWcU/ffcABFzph3ywP2FvknG24+PbBqsNh+1hzH5cEOc1Z9s+661gaY3x4I1X3aNeLV9Cl8ZTPD2mWblkwzhWjmcbrDVckqJiGJekRcH+RNehO3WNKQxKKTENQejqEkRRVjRsl1FacCEI2ey4WMJidxLz090Jf35nhGMZzLMS1zEIbIuyKmi6Npf6IZO04Ezb58P9OY5pMohz/tKbinPdgF+52GN3knJrkGBU8KefDFDAmbZPKeV9jJ97MUyKTxl1eUU7cKhqRVpI0kLSCZ2HTPlcyyB0TZKipvOAd1FW1twczJFK8vb5FgeTnKKuKeoK2zQRCMpastHyOJzmXFtr8kcfH/FH14+5fjjDEoKsqhCAUhLXECSl5Pr+nKMF6WOWatfTf3lryCgpMIBW6GAZBp3I4kw74FzXZ5RW7ExSxlnJj7c9fvPaGl9bbTDOdC8odCwOZjl5VdNvuMvJrxXYhLFF4BqErkX4JcV2nk4KaNbROClpeha2IfjkKGaYFJzt+BzOMvYXTd79WYZtmsRFyUrTI3AsLENwrhOyWkksU/HRwYRZVvHTnQm1got9HwNFXFSUUtF0TW4NYrZHenUnpMQ0BSuuyzQtEELSazr82tU+Hx5MuXWcsDNKeH9P1yn/7BOTXuiw0nBo+w7fOtclChzOdAI+OpjRbzhIFJYBl1dCTMN4SGPRcC022no7vdo8jbJ8VTHLSnbHKXvjhKJW7E9SbNOgVpJfONfij28M2B6VmMLg7IrHb1ztU0v4yc4YQ8DZjk/DNbkzdJjlFVle8f7OlNA3iNOao3nOh7tTQt9ho637CpFrc3UtxLWb1BKGSU7kObyzPcY0BKtNl+G8ZGeUUtaKNzYiLvRC7gxjfrw9xrVMeg2XeV6x3nr8DrXl24ziAsv81HTupHdiWwLvgWv6RGV96TGTzM4o4WhakBY126OUspKMkoKVpotlKHzH4oPdCaOspK61rfjuOGGaljiL+j0Ibg3mjOKSSioCz8Q1DfpC4JqCftNDSck41VYWlglhbXG27fH6aoTrGLy+0eJXLnX5nX/yIQjB9ijjziBlmOTM84rDWYFnGZzrBpztBIyTgpZvszPWdjeRZ/PNsx2anvWlkUq+8pNCVtZcP9CNtsMZ2IbAs02kVNRSsd7ymWcVP9md4BgWvl1xaSXkzQ0doFPWkk+OY5KiRCrdG7h5nLA/0Vs/A73F35ukhI7JuztjznYDRknFPKuYZwWObVDWglFa0MlcNlsh3YZLNLE53w3xbIPff/+QnXGGawoqFJstn1/YarPR9ggdk37DZW+iZfR3BgmuZRL59jLEo5aKUVLg2yaha9E/zTV+5XEwzZasNc8xuTOIuTNISMuab51r8+M7E2ZFydc3I852A7JC8ud3x7y3O10yZc50Q1zHZhzn/MnHAwDqkSQuaiZphWUIzpqCeWpSKclEKiJsHEP3vqZZtShpCi71GyDgzc0mK00PhdL3EYokl7QCmySvuNAP2Gh5n3kNrkUuvdBdTgaWIbi20cQQ96uoD2cZ28MUUJzt+IySik5g49rmwtPIouHZuJZgb5phCv3dNgSzvEbWknFaEvm2ZvtkNf2GzWrTJc4rbNOgE9pEns2P7k4pKsmFfsDrayFKGRgCxllB5FqMk4KsVvi2iWfr4/zkOOFwXiIU/OD2hL/01hrfONfm7jCl5VncHaUczjOyomaSlVxZDUnLmrgoKSrteDBNSw5nGcO44K0zLWaZyblu8KX0aL7Sk0JaaGfIu6OYyHPohDYrC6/zb55r41qCo5ku00gUv//eAdO05EI/IFhcAO/vTviDD4+wBKy3fc62A0LbwDLAMnR55nCakZU107TiYj8gqyXjpKCWknlWs2OmWKaWwNd1zTyv+NMbR+yMc4qq5kI/4PJKg7yWIGGrHdAObT48nGObBt8828YydfxfVYNEb2P3JykoaHgWSV4xzSqEgNfXmy91AtwpPhuH04zpwlKhqBV5rZkqWSWpasXxLGer75OVLpWU2Jbg7ihle5SQFBV5qVX47dChH7rUSlGjWUuylmRljW1CL7R5bb1F5JrsjlPujDLSUpIH2sLBMmAUV2SlYpSO+M3mGkpo7Y0Qgg/2Z/SbDvOipKgUb55p8dZmhGF8ev3NspKkqOmGDpYhuHE054P9GSsNl7yS91nRW4+4bgfzgnfujpllFd3Q4a0zLd7bndIJLLoNlyurDVabLr3QYSPyeXdnzHheYNsGVxsOu5OCUVoyyyokiqqGclIjDMFK08VE4bk2oWNwsRfy0f6MaVJRV4rtSczOOMExDS70G5S1YiV0cEwTw9B9DgRM0pysVEi0YO2tzTZn2gF744Q/vn6I71j84vmOzqpwTC6uNDiY5cRZvnh/ySytOJxmfL+saXo2aVlzaaXxzLMtvtKTQlFJqlpS1opBnPO19ebS6/yDvSl/cmNMw9GahdA1KWqFYxvEecVWN+Dd3QkfHcyZZxWmAZcdE9PQniYbbZ+iUlim3lLPshKpavYmKZZpcKGnyz2mIREIOr5NVtaM4pz9ccLvf1AsvI5go+WyErmcyXzOtD08yyCvFS1XC1huDmIswyAt9Gqs32iQljV1LfnR3THnewGGEEtK4IuO5T41vPtimGW6yWibJoFjcHklpJZ6VV7V+vv5foBUWjwZ2gY/vTthZ7zoLQQWeam4NYiZZiWH05yma2EJLYJSAkJH0PAcfu31VSoJN/ZnpJXm7pe1JM5K1lo+liGQStu5R57F3ighLyQHE03P9m1Tky+qmrXIY6XhLieEw2nGKCkZJwWBY5EUNeuRxzgpKSvFOCnZfESeyINoBzZ5JbFNgUQxTHS/YJSAY5lUi9zknUlGK7DpLfQ801SXsKLAwTqcczjJaHrWgsFnYQiBEopZLolCgzfPtPnpzpheU9PD/+XNIfO8IkkLfEdnm0ySkklScrbrc6EbsDNOGc0yfNfCMmre2GxybSMiLko+3Jvwwf6MeV5Ro/3TLvYDklLyk50pnm2glF68Nl0LQ5xomXLGaUngmJxp+9QLp9ZWYDNOCnbGKYFjcaEXfC79wlduUqhquVArCyJf1+UarkUvdMkWdJ2sWPi/jFJkrbjYDznfCbUF7lBrGv7B926TVjWBrVkRSDic5myPM3aGCUWlVz6h57MaeuS15M5A0/iqWnE8L0Aomq5+/+3BHGHo1cX7+3MMIYnzmtC1iYuKS/2QlaaHZRjcHWccTnOurknagUVT2rimyWbbpx3YpMWncnshwBDQcM3FTe28lGlPp3h62KaBEHpyj3yH1cjg1iDRTVCgUhLPskjLipWGx/XDGZ8cJQySgn7osNULKStd0pznFYmsqMqKXCmKSpEXFcIUmJXkD94/JKslRSFBSFzTYq3t0QsdGq5JaBtc3y8pK71rmOU103SOa5mc7wfUtcK2TYbzHN+xSMuaSVKSVTU/2Z5QSUVVS8739KDnWgYt36ZqK7qh/chJYTDPOZjmRL7F2U7AWtPj62ci3tufYhq6zNRwLWqpy0mRZy92SNrn6NsXurxzZ4xhGDiWzdUND8sQdEIHxxLkeUVcSgazgryuMQzBwSznn39wSNM1mSYVs1xnTAxiTVftNlyGccEkqTmcZ4zTkuN5wTgp2Z+lrDU92p7D/iTnX904JiulthyZ59RSC2anWUFaekySksA2sEzdOL95OCerFe3A4tpGk+/f1j2N3UUo0CzT49Y5fAZxgZTa7iZ/SofcB/GVmhQ+DSo3uLzSQAjBxX6IEHoLOoy138kkLbWmQAhWWg6bLX/pmTLPSvJKcTzPOZrn7I5SGq5JXNSaCbLoMygEpYRPDuaMGjZJIfFtg1gpJlmBb5n0fY+4qtgfZ2SVRLHwjSkleSUxUdRScmcgGMcFvmtjGorBvKSWiiSvsExBUUpkLemEAY5pMKlLVpouZS3Z6gbMs4r9acbBNGMt8hDAue7TO7qe4uWCZ2u79VFS0Pz/2XuzWMuyNL/rt/a899lnPufOMUdGZlbW0F1d1UN1G8wgsFtiFCDwA7J4MYMQAvHAJGgZWTIgsGRZgJBASBg3gwSCJ9xu2o2x3UV3Vbu7ujqHyCHGe+OO555pz3utxcPa9+SNyIjMyIzMjBziL4V045x7z7j3Xuv7vv8QOHi21WxO4DQpaIcudycJtYZe6BK5Fq4NVVWTlpYRPrlweRyzd5pwOC/ItKAV2EhdmTZSrsiqwrDtbItSKpQCz9XYc7gyamEJ+DvvTdif5viuxSStGCAoa0lSKnqRSy9y6YcurhB0A4+/+cYhSSW51A+ptUYpwSubMVs9k3Z25u569UMcTc9Cpk6TivW2mektcknsOwSOw/GyZBR71Erz+t6cn+7O8Wyac1dhAa9tdTlY5Nw/TTha5lgaLDSnyxrbEhSlpFKaUmmE0vSEoJCSw+McpRWWZbNIS6SU1BIWWcmbe3PyWjNJKnzPpqhrpBLkhWK/zjhx3l/MDG1cMm55oBWzrGaW1WRFbVTWRcXJsqCWmr15ju/YlLXk6thUGgfzgqyU3D4288M4cIxxZuSRlRmR98mzVr5Wi8L7QeWKskmSqpXm4iAy6k1lvE1C1+baeswsqbgwCCml5I925+zNUvZnOaVSxJ6LVIpFUXMwz6mk5nhe0I0cAtcwfhZZySSr2J8X9Fsug8hlFPuN35FCC5Da7Pik0viuYBC6ZLVCoPGa8tt3bA4WOQOliQPX2O4qxSyveOdoyb2ThLRUXFuL2elFaODyKGIU+xwtC+4cJySFZJZVjDvBB7xWvmr4OmQ4Hy9Lbh0lnGYThi2fSpq2wmYvxMa0GXzHInAtRu0QIebMC3PB/83X9wkdm7I5niJPUimF0BpLm3aq1FDX4ApwHU3oCdJCU9UKidHbLPKaeVaBgLSQjDseeW0EbNsDn9h36EUeW72Q/XnK/dMlf+/eDK01bx/MuTiIubEeE/vuytwRjGX0E+zGABMydXZxnecV7x4umTczgXbfDIS7oced44R7pym704z1ts8krbAF3DxYcDgv2OpH5JWkHXiUdc1PHyw4XZYUlcRxjHK4HZjI0oPZWSKdpuU7jNsh87wgLQBhNE7CsumGTRdAKfJCooWg49vUWlNJxe48pZQ+N9bMe9+dpAjLJisrXt+dcmUUcX0tZneacTgrcCwa2m/FWifAsy16UYhvW+zPCmLfoRO6dEKjzA5c+yOjPj8KzzNP4S8B3wN+X2v9b5y7/ZvAfw0I4F/RWv/kaR/z/mnKsqjZ7ISPtZJd6/i88WBO6Nokec3bh0tC1+btg5qskuSV5Nq4xbRhXfzg+pBh7JOVNZVS/NHujHcOFozbAT9/KcSz4c5JBkpSlAohwCugPwipK8NoUFKhtEXLtWkFLvOsIi8llhCEno0jBGFg4bkWgWsTeA6+r0lzSeRZjNoBx8uCpKixLYvQsfAdwaIQFKXCRnDnJOM0NTuL6GWHduBSVMYfZZEbe91x22cYu9xYi1cBPi/w5cPuNCMpahZZxf48o1aaqjbCq1ppykpymtbEgUNdS0LPppKSvDaUzcnC9NtbgYdrW6y3PVLXxpICS1gEnmJeGo69xGxabDS+7VI5FXUNaM3d4xSryVJwbMEodilrzaVBwIWhYcX0IhfPtrl3mvJglnHnJGGWlNi2wLM9qloySZ4cN5lXkr3GXfh8VvlaJ2DcNvz9dw6XRJ7FvdOKb2536Lc8Xt3okFdGB/TXX98nyWvmeUXsOYS+QynBsQWBDVfHLY4XFcICJSWVVCzzijg06mXHMheiolaktaSuNJ7jELqWGb4gTBvNd7jYNx2FUWxmDkUtKZVCaUHgWoD5DiLf5v4sYRj5zPLKsIvyCt+1OZrnHC0L7k0Sbh7M0Qg22h7D2JABZnlJVlkcznIkmmVR89p2h3ePEo4WJVu94KEF9pPgeeUpfBeItdZ/QgjxXwkhvq+1/r3m7v8Y+BcABfyXwD/xNI9Z1JLTxq30aJk/dlHIS8n+NKdWmrsnCZU0/cf9uRnM3NiIWWsHVDLHsy1uHiwYLEqujFtcH7f4O29bOEKwyEoQFt+9NGB/XjJLS2pdUUmJEjBPJJO8oFQgFXR9c/xM04KygmVZYwlBUioCF0LHwfYEUpu+YVYpEl1Ta80yN8KYWmpizyHybZYLSVVXTDNTooaeRa0cfNuiGzp0Q5fYd5imBT+6OyUtKjqBx84geKFe/hKjqCWTZUla1Sslbsu38WyLB7OMQirSUhG5FvcnKb5jmdZQLXFtgQAkJmymrI0jb+C5BF5Ny3LYneZIpbCEwLE1UoKNmaHVUlHV5njen1fYIgc0ceihtSb0XapK0Q09bmy0+fnLQ+6epLy1b2zj700ytDYbs1Hbpx95eI7NWtPmPJ94duY+vD83GSSiEPQaMZpUZrMTejaRZ1xah3HADQSx79ILTSJh6NkEtgm+qpVp8VwZt9juBdw/zdg7TbhZSkZtn2lWUtQKJaGoJHHgsNkx1hKF1JymlfncsxoljJvA8bKgHTgklSRuwnMWRYXV2NhklVFkp8uKWkrQinbo0UJzf2KqAKXnDGN/RZ1Ny5o/vD/nmzs9ZlmNEBaha7EoJb5n2nAbnYBlLnn3OKGSmo1uzfUkXpFHsurRZOOPj4+9KDThNyf6WdLp4ReBv9H8/JvALwFni0Jfa32vea6PtFVUWnPrOKHl2US+TVpIuqE5gE6Tklpphi3Tq5xlFbvTDKk0W72A7X7E4TyjHTjszUxfdKNjHCInScU7h0t811hde7bFVjdgnlUMWh4vrbXYnWY8mKX4ts0ohrK2TV8UOM0tbKEQJg6LybJEonGFMD1e1yErJGiBbZt20iKvSPKKYcunkIo8lXSCFr3QwbYsFBqpBLYFsW8sd/dmBZudkEGkaQc2V0cx3ZbLWjvgd29luJagrDWRb2OL93uMRS1578gIcYxQ5vP3uX+BjwfPtgg9m1lW0g09dvpm4a8URJ6DhWAUG6bbsqwbAVZmhr5DY4h3/zRjoSs8S7DMS/7w3gTHEUgFSV6RVybBzbMNQcG1TRupVpLSsCuxtbkwtkPTy17veIYJ5Vq0Q5vjRcG9Scpb+zP+v1sTZlljsyLM8fnNrS5FZVpWs0wyS83Ma6sXUtaKg3nONK0oKpMT0o+8VX989zQz6WYNtXq9cRH4pt1ZJasVteTtgwXvnSRs9nxkDaO2T60039rpUSvN2wcuy6Lid25NVuxBC4gDFwS4jk3g2QTazCK1NsxDpTQ2MM9KLMumHxg2ViUVbz5YEgdOM7MLsC1B7FuklcYRFlJqJmVtDC0tcx2QWjOIfJZ2CVh0I5dJUvHyeovAFdw6SlDK6J9e2YzZ6Ia8nsyIfWPv3wsNjXfU9hox6rNv+j50URBC/CLwF4EJZgf/PwAjwBJC/Ita6//rEz5vD3iv+XkGvHbuvvPTkcd2Fs9nNG/tXGhEYDU3NmLcRn24yCvun5rAcqU1652AduCw0Q2QSnFjrU2v5XGxH/J7t09puWbXcXeScm0csTdVHC9LYt/m3iTBc2yEBS9vxFwftzlalvzdt4+xLQvH0XhCYAnTMmp7Nr6lkUIjHMsEeTeZud2WS+TZTJc1Smu6oWv0B1rjOy6OBQ/mhgsu0GR1zYUgZK0T8t7Rkt3TlLRWuJY5adPcZ9z2GbQckqLmvZOEP7WxSTdy2e5F7M8KhrGHIyCramZpRTdyWeTGfuOtgyU3Dxb88vXRJ/wqX+DzghCCa+MWF/shR0lJUdbcOUm4f5oySSv6oWHruJGFZ9vcOlqSlrXxIApcei3PsIFsi6yQLMuaWipavkfkWShtKJ2yhgqwbXAtG8tVLPMmUhNohxYX+iHDpoXzYGpo1hcHIVqZIBtLzHnvaMnBvKCsFRtdwS9eHpJUkh/fOSX0HJTWjGKfSWrSytKy5r2jhGXjX9SLXHb6Ie3AfZ9Ozft70bNt6Zli/2wOschrylojEFwexviuxTyrV8Pyb213eecw4c6JxLcFuWXchxEY92OtmCaiqZA086zGEhaRZ0gdRS3pRC6d0CV0fO5MMk6TAoVikSnSvOJgYRwLur6D79gUUuHZFnlt47lmRz+IQy70Ir59ocPBzLgmDCOP3akRIAo0Sam4M0np+Ibae22YYNsWV8ct0lLy8nqbUew/Vr/xSfFRlcJfAf49oAv8FvCntdY/FEK8ggnJ+aSLwgzoND93gOm5+85XIOdyn879wrmM5u/87Hc1GOm7s5KjP5xvevZjL/J4ZaODEIY9cUbX+kdj33jPzzOySvI33zyirCS90KEbeYzbPr/73ilJYdLQJmnB3rxgVtQIrbi2Zqh3Nw8T41tfGBqb7Qhcy0Yqc4ChTXBJXtYsC2XKygUruXonsPBcx+TJqoJKQlHUZoaQm5NbY/6u6/vUWmLbgiiw6YWGq5029shgkt2GsYfGDNfun2aUteaXrg3pBG5jMqYIPZe0fPay8wU+XZS1Ii2NW2Yl1Sr20XMNP/3mwZz9uaE/xp7NIDatmHHHJw4c7p4smTRWES+vt/mlqyP+8O4ph4uMP7w3ZX8uqRUUdYUlXALXQipthqLKDJkLqUwAjQWuBhcIHJtCSq6OIt7aXzLLKqSGtbbXePaYfn4/cJFa4dsWl4YRw7ZPWBozxgdz4xh8fS0m9Gw2OgFZKdHaeHWFnsWlYeuhFEMwnkmha9pHj9q3nBnGDSKPOHC4OAwZt32KSnG4KJgsCu6fZry61eHP/vIVfnR7wm+8vs/BNDfDYscmXhrBqGUL8rJm0Zx/eWXsaDwhyCvNNCmoaonnWISehdYus6ykbH4vSSWBY5HaipbnYNuGDZRXilzBIHQYtX3WuwFHywqpBb3IfLfLrGZ/VjDLSqSG40XOIrPIa0nkWHiOoZ+/vNFemf19mvioRcHRWv8GgBDiz2utfwigtX7zGUMdfgf4c8D/AvzDwH9/7r6JEGIHsyDMP+qBXNvi+lpsQkPOUdhi31nxpHvNfCFwbb6x1fnAYwSuzY31tnE0fTCnbrjVW/2I71zsMU8rtnoB09Q4Lw5aLrcOU2wEvutyddzirQdLHAvKWtPybJalRlUKGl8VqaCSkkVekRXNSWeBdA1f3GqqmW9utanqFj+8dUpRSUolsCyLjY5N6FvsTzMqaVSOF/stfuHKgGvjmN1ZxryoiQNjFXw4N4Za2/2Q0LX5yf0pShmPezC7q1+5PmKzG5BVcmWH8QJfDKgmd1sqjWvnKxPDzd779hCz1Ch4904zyloxjH1yqXjr5oJpVlEryTyvuTqOGbR8Duc5/dgllzUXRjFSCU7THKUFUpkEr9gXoG2SosbzbNM6tQQil7iWaauUUjPNJL97+5SilBR1jWryQKRUjDseLddh1Pa40LDhfv7yiCvjFm/szbk6jtid5mz3Q2Lf5dsXukS+Q+Ca5711nKC1x/GyfGjADEbR/Li52LwR9AFMkrKh7Rra+U8nU94+WCAluAcLRm2fcezxMxd6HM5zXrfmLIqKJJe4jsUgdml5LhpNVkruTRLGLQctNPcmKb5rU+Q1eW2YV+PYBTRKCxAghGkxnTELQ88lcAUXBzEnSc7+vCByjftpO3A4WpQooKwtOqHLrXnO3jzHtQUb3ZDtToiUkkobdqTnWMSBw9HCGOONP+dK4fxOPXvkvk88U9Ba/74QIhdC/L/AHwB3hRD/vtb6LwD/EfA/N7/6rz3N4z3JfvdpswJ2pxkPphlKGWZDUUtcS3B13GLY8jlNSq6uxWwPQqZJhW0Ltgche/OcZVFzf5IhGyFRUdUEjoXv2ESOoKg1pdREjk1ZSQqpKcxagWNDWlUkpcYWsKzMfGQt9rk8jHgwz+n4DpXU9Fo+h8uSludidWy2+gGXhhFb/ZC7pyn3T1Jj2GcJfv/OlLW2OVCOFyUXhxHf2u5xtCgeYh5ZluCl9ReBzl9EaN6PijStBMGDWcY0K/m5S30iz+HauMWyqIwqN3CY5hVaafJKcuckxbXNYFYqze/ePmGWGpsEQ0yAnWHIuO2yN8+ppTZUTGFRIQh9l27sEjfun+ttQ2UupeK4GZ7enySUzbG8PWzR8W3yWrI7yfj2Th/PsfAdh3bokJY16x3TZ7ctQdt3uDCIGbV9pNScLM2xudkLmTXU8bSon/rz8mzD7tmbZkySkqvj2IReuTb3JimjRvZZHbMAACAASURBVJxqW8aCeneaMU0K3jtOOJjntHwTKdrybWZZ1XQEKpKiZqcfIbXRRVwfGevt+4UkrSSebeEKi1oIhJD4DXHEd21ks9GLPIerazFbnYAHb6cEja7gwTQzbSOteGmtwyA2s5NO5FJr4xS71vbY7rWY5caw8639OYvcBPdYwgzXa6kfqzuSzbFwPkToafBRi8J3hBBzTG8/bH6m+f8zTTTO01Ab/IXm9p8Av/wsj/1xkFeG0QEwzUq2eiG2gEJq0tLYRLiWIK0kFwcRvmMUiN3IhJDvTTP2ZgVWIzTTWjPLa2ZZhd+s3i1XsCylachq8B0appBLVikUsglI1xwvKvZnOevtgE5gEzgWtZIsMkk/cok813CRI5fr6zG+Y/Hbbx0zTcuVXcDNgzknic+N9Tad0Oy0tnohm40rpVT6har5Cw7bEmz1AvZmOVcGLU6WBZPUoh24TBLzPVuW4OIgQinFT3fnDNs+toA7JymhK5rkQGPLklfGdtow32zSWuHbPgrY6YXcOUlBCBTGoTRwLYaRa/rwvk1WKdJKETiWqby1ZndmqLCuJWgHFsvSZDtfGcV0Qoer4zZvHy7Jq5qtro9Umr/9zhHTtKIXelxbayFgNfsDGMY+G12TJvhxmHKBa5hGaSlRYEgijsC1LeaZJPQsXl5vE7gOtTTD9NO0ZpaaFk2/5RG5NT/dm1NUkqQwVZYtYJo6CGEsRGwLPFsb+3xtPl/Xssgts+C0PIdLw5CsUmSVYtwO+OUbQyLH5cEs5eLA5FkUUuLaNpOkwrMBIcgrQ1X/2Ut97p6k3DxcsDvNqRT8wpUh07TEd2xqD0qpGDUOx84TRB3vHS3JK0U7cLj8MToBH7ooaK0/u5ikzwEny4Ja6cZv5fEfnGtbuLYgqzSvbXVZ7/jMsoq9aU6tzNCpqM3uYlnUDW9ZMGr5rHVKlNbcnyRUWtANXOa5ZneaGiaEMAfJIq9IiopaK7RsrH89m/VuwJ2TDAeLXtshdGzjI681apbTChz6oUvoORRVje+ZNtflUatxSqz4w3tTxrGH0Jpu4CClYn+Wo7Tm5Y32isoHppR973hJVqqH2hAv8MXELKvRylSyL41j0srYPnu2QHVNK+HBNGeSVmz2IopaIbXmV26M+Mm9GXcnCbvTHGGJxmrZ5WIzR5NL47ipUOSVQipNVpqL4JVhxM4w4t4kY5Ebg8a6obuWtjDqWQWRa5NXkm7koKTgpe2YWimurbV4daOD1BrPsnE8m5uHCZZlk2TG5sKzbbQ23kTAQ4LKcWNetyxrKqme2ryxE7r0W8bGJXQtOoHH7ZOE17Y7dAKXGxsxRSW5fZxwmtZsdj1uHduEhaJSJqch8l0i16bWoJWpiiqpKCpJVteErkPkOVRKE7gOw8gmafzTbCGoasX9WcEg8BjFPuttj2UmuTlN2J+mgKGuXh6GHCc1w9g4uJ4kBUVt49pGi/SNTaM9iH27CQ7SrHd8FnmAEBbrnYCXmnlCJ/zgZVxrbcz4YGXf87T4yiqa57m5sIO5GD7Ju72SitPMyObTssaxQ4axT1FL9qY5SkHsC7Kq5t3DJduDkO1uhLGxE9S1opQagaaoTRZsJSVg4bsWNzZj7hwb35WyUCgBnjCiFzA7GdcRFBLSqqauJYM4QAiIPMMGsYWF7Vjsz3IuD0zL4K2DOctc0gldfv7KEFAM2j5//Sf7/GR3xrKU3FgvVnMQMLuLrDQHyiyrXiwKX3CcXSi1Btu2GLZ8tGIldoo8m7QJbk8KSa0U909TQ630HTY6IWmp6AWm1YRlcZKUpHlFvxVwuiw5WBi9Q600ni2IPI9CKt7YW5CUNVJB6FtUEioFWkuk1Fi2IPIsfNduKt6a25OUP/XaOpUU3D3NKMqaUpmYz9+7fcLt4yW9yAc07dDmYF6w1QuMG/HS2HCfCa/uTlIWeY3rmCH507Q/LMvYgUuluX2SkpWSX7w6RCrd2D40e1whGv+knGHkczTPeXPPCAHXYh/XMYrq945qNro+s1xykpRUtcYSCkso+pG5RtTaeBRZgNA0C6Gx3y9rxU/2Fvzk/txQzCtNxxdUSpCUmn/6u9tcHUX8rZsn/NHujLunGVppJsuSUdvn6jgiKyXfuzRgrR3wW28eUNSKl9bb3Nhor9rjs7Rif54TB85qBiOEYKcfMmso9B8HX9lFwT53EJ1xlz3b+sDBdf805XheIrWm7bursA6pWB1EW72AW8cZtcqYpRW/dCXEmQvefGCCOiwhGEQuIChqmuByQeTaFJUpMYVlWEIm/1VgN6X6MPaplKQsJbUWSNujHdg4lhk67fRDBq2At/YXpKXk/3n7iK3DgNe2enRbLlpqHMfiG1udlRNqHBgBWyd0HqqQzlSmaWmiEA8XObPULA7PKo1/gU8fF/oRp2lJq+Gkx4HDO4dLTtOSwLW4sd5Go3ljb86o7XH7OAENwhKG7dPyuNgP2OpH/OyFHr/+o/sopehELl0sKqkolQnFaQeCNIdSSo6WRj8A0I9sXh61OU5rbheJsXi3NcKyCH0XrSCrFL3Q5eIgomg2HllpbKevj1v8ZLcm8kyr9ErksDMIsYVFUUtu7i84zUpGLZ839+fM0pIro5hSms1LLfUqJvNpIIRRWF9fi1fn8kPQsMgq3jlcMIg9TpYVebOxs1AUdY3ruNyf5pRS0w8cNIKy9sjLM5NLG6mgZzn0Wy57k4x25NLTmnkpCR3BsOVxf5ogEEzSCs+x0VohbIdu4DJq+1S14o39hForxm2fi/2Q3WlOVpfsTnN+9VsbXBzE9Foed08S3niwAGGuR0lhXBciz+FwkVPWismyZBz7K1aWyaj++Of1V3ZRaPkOV8ctaqlZFBU393NCz2Qun4djWax1fJZ5zYVzua/jttkJuLYxGgs9m1c3O0bt2AtxHYu/paEVeDh2zbgT0A9d3tyfc5QIpIRlE1TSa3ms5TXLvMICLGExbLn84OqAtw8SlDbCs3cOEyqlmec1bd+lkoanXFQZR8uCWipGsU8pFZPESNp304xsbnZU18cxvcjn6sikrn17p0f73LC9aMrIYezhWYKf7Bubj1rpF4vCZ4S9Riy52Q0+NkPEc6yHsrU7gcso9uiGxlJCKpObUNaaB7ME1zYXYte2mowCzf1pxrwwO928kviOTeBZfGu7j+9YzFOfP1IzAtcI3MpKcfMwoawklgUCl1uTDN+1iDwLhMV616MTeEyXJZWGzW7AlVGLq+OY9a7Pmw+WdEObrDKVxkbbY29WcGMjRmParDv9iEVRkZUKpU3kpteca/dOE66OYk6Skk7oPrH1+1EQQqxaX93QZVnU/N13T7h1lGDZgrSU7PQDHCF4Y39Oy7MRlmCR1ZSVwrNsAs/l6tijrGIOFwWBbcSo612feV5x+zgjaeaFlTSU4VHsc2ncMlVZVdOPTGs48l0MQUng2oJZWnOSlRzNc0LHZmcQsTOIuHWSkuQV89wsJu8dGovztbaxulAajhfGwPO1rS7d0CWvCiLfxv0Q06gzgWw7cD9A5z2Pr+yiAO/z/x/MzSArK+VDcnqAC/2QSkoGLZPUdIbANYHfB/OcvWlOy3NYa/usd8zJHXsOG12jHt2vagLHptty+dVvb7N+Z8JxE+E5iAzH3HdslqKmFXiErs2rWz2Gsc+DWcFxYtSR37nQZ5qVHC0KlllFUkoWhaSqFePYZ73rE3kOvcjlG5tddvohP74z5aARu13sRVwbt/Bdi0HLeNskhbHQ7YUu+7OceVZz+yThZFkwTSv6LY+fu9T/XL+Xrwuk0pw0JAbHFmx2n101vtENOZjndEKjM/Ecm7xSvHuUMIxcaq14eb3DybLkYJGxe5pzuqxY5hV5rRnGPldHLb690+WVjTZ/448P0Jh263Y/RCOQaHYnwti8a0M1LaVk1DZOphvdANcWDCOX0He4Oor5xWsjQs/m7YMlWSV552hBP3RNKpxjrzQzV0YxvchlvRswkB53ThIC12enH3L/NOON/TnjOGCaVc/s5JuWNbeafPWyYxYfpYyZ33o75LXNDqWSuI7N1bUWNnB3knO4yLCE6S5cGoT8zE6PQtb8368fsShNElslzRwyL2ukhrRU2DSbzLbPWsfnWzvGibWSin7o0vIchAW3TzJi1zEzk1oihMWwHTBoBVwehri2oFQarQz5pVaaK8MWjiW4vh6DhlJqnCaXYq1j/I4+ijxy+yShqBSeU/LyxpNZh1/pReEMm92Qo0VB9zG7jqNlyVv7S7MrLyTfudB7qOTUjbHVJC3phNGqD3+4LOiGHoPGorfWsN6OuLYWM46NcjRwLV4/WPD7tyfsDEJagcMyr+hFhnr30rjNLJON14ygHdjMM8HFfog9bOG5NlobDWfkO/zgSp+1TkipjDpyf5Zhi/eZRO8cJdTKpGYlhTETS4qaWV6zFnu0Q1M1JIWhOHYCl81u8AEu+At8OhBCrHIPwk8pNnHQ8h7qEb+62TGxkmVFVtTMl5JKwrDtcWEQ0vZd3j1agBC8uhETNNXypaFho8yzipMkR2E0AI5l8SdvrPHe8ZJ3DxcczEs0RpjWCT3WOwGL3NhLi2Yutt2PmothQFEpfnJ/SlEqFqLm2jgm8mxcx9jEHC9zbEusBsjnxVcXBhF5ZdpGZf1Y3erHgjpHmpdaM2h5XBm36EUO6+2QRVFRlIp+6BN6xpDStmziwKYbedw5Sbl5sEShqQrFLK+JA5vrozbD2GOxWxEHHrZds9nxjHllUvH9ywPWOoHZlJU1rmWhAM+zjZK55THs+PRClwuDyFiP5BW2DXmt2exF2MJid5pxoR+yP8s4mBdcGIS8vNFpTPvqhzKan4ZNKJsP5KNckr8Wi0I3NPa3j0MlFdaZJaTgAz3ItbbPreMlnm0hm5V7kde8c7QkcGxsBFpBN7C5PIqM1XatuHeacOe04P5Jxqjt4zk2/9h3eszTkkWh2OkHfP/qkHZkgj0eTHP+1x/fw7ct+rHPP/jKOgfzDKlMYMpaJ2TQcrFti+Us5+39Bf3IWBcM2z6Ba9MOHA7nufG+KWo2uwEnSclpYpxZf3A9IvYdNnuBaWtIzcubTzfE+yrh87LWtgS8tG7Myj6LLF0wj/vyZodFUXNzf2HyC1oOg5bPxUGEY1v0Qg/QtAKHVza6OLZANrnhy7JmpxehlOl/K62Z5ybm8TSpqJS59G8PYlzL2FZfHEYssnrVgnj7YMm9Scbf//KIUeyt7GSujlr84PrIzLaEMDbzs6IxtavoRy6TtKTlmbCrwLXZ6gWkpWSt8+wkiNg31fwkqeiFLr5jlOC11GSVXFnWV0rSdxySsmYQuxRKsWzyUVqezWRhxHCha2ELwStbMf3I48o45u2DOfenGb3GrG69E2JbcPskxbEsvr3TMzGay4KO72Jj8QtXBlRSIaVhCH3/8gAw9iBaw6VhhMbopNqBg2Ob+U9eKe5NUja6wSdq914eGgvuJ10Lz/C1WBQ+DBvdAK27VFLTCV1Ok5JSGqfIcdtnmlVIqXn3cElS1oxil3lW0wvNUHq9dxa1aXY6i7ymqCV5qXBsmyiw6QYh/8ArY+LAJclrsloybBlx2U7ftAPuTlLiJpmqG3pYwjCTHMtif17QDlzcrk9eGSvsvKoRwqPX8kzqlbAIXZsLwwjXbtpHjsVWL0AgVj3VTuDSDtwXzKPPCY/aNDwrjpcFlTTGZ2e7w7Pv+8KgReRZ1E0uyNGy4KVxzCKX2BZcHES0fJth7HO0KDhNTE8/Dh3akcdOL+RHd07Z7gUsMsVax0cqCHyLXmBTSfjmdpdR2/j6O7bgzQdz3nywxHcl06ymE3rcWG8TuDYbPePK+75vERwKozqOfYfdacY8q6lVxrVxTCc0uQrDZ/h80tII3jzbYppVHC4KlDIX6Vc22saSQ2kj/AocTpKStu+yN8vwHYfjvObSKDIRtghunyQgFN3AYb0b4Ds2bd/jNK25sRZTN+2folZcHsbc2Gjz5sECz7Y4TSte227TDz32Z2azNs0qfMfmcJZztDTpbC+txQSuWRil0g9VAABb/YDbxwnTtCBwTere+dzqp4WxD/no4/Frvyi4tsXFYYtpWnJvkjFJihXzx212VFIbltAw9lbshkg4XOhHvPlggRaGglY3lhqHM1M2dkKHX7o6pBN4JIU5aapKst41lNODecZvv3nEu0dLkqJCaROMstY2Ap6krLl5sGCWVlwchghtuORSaS70I17b6vDeSUJWSnzXYpqVjVI0wrIEw9in3QSdpM0ube80Y9DyGbU9Iu+z+fpfZDB/NljkFQ/O0azPR1X+dG/O7iSjE7pcGUdN21PRCV1+5aUhtdSMG5W7VJqb+3P2Z0Z7s8xrXlqLmSYlg5bLO4dLXl7vsBPEFJU5JmuFaR0Vku9fbhH5DvPMZCjvz3ITZ9lYtt8+TnjnKGGeVVwbG2dPME6uN9bbVFKtLk6VVNw7TQGzqXqWzco8r7hznDb/0yxyE4B1ZRSv2Eu1NFYV3cjl1c0hJ8uCvamhbl8aujiOqZbyUvKPvLbG37s35b2jhKSo6LdMhvLhIqff8swF3nXY6pm22VrXx7Jg3PLRWrPdi7g8ijicFwxin07kslYbH6a3DxNKqZBa8ce7c+LAVGCP28WvtQOO5gWV1Pzx3ozIlGyf+HP6KHztF4UznPUfbUus/Dsc26IbmraQbRn2R+wbW2oNZojblHW+ba0O7qSoiX1zgqSlIvI0908T8koxSUu8gxm+43B5FJHXyohTlMZ3jRx9siw5WZbkza7HsmDvNGeyLJnlJmClVmdcdYe8llTSYrKsOHUqvnux/9CQbq0dsK9yFrlkf16QNqXxq5udF8rmLwnuTVJOlgVZJYl99yEVq1KayLVXC/03Njq8sb+gHZhULq1hd5pSz0xm8e/dOuF3b5+yP80whYxF5Jt8ggfTgkpKHAuGscsf75l5Wi9wGbcDjuY5r+9NWRSSZSHRWrPRNcZz7cZ3a5pW5JXk/iTlncMlLd8EP0mlee94SVWbBWq7FzYaCYVjWWTPaMpYnZtD7M9zlrkJzYkDm82uYRbmtVzNUywh2OgE7J5mlE1LaRB5/PT+jN1pRuDYLEvjTpBWpjtw5yRHSsU7RwnrccCo4yElfGunS1Ep7p5kWMJUZWlpLHAO5jmBa3O0yLGEub6M2j4IuDyIsJrN5zwvn9jaObPgqKRCavGQ/ugMZ3HDndBZvcdPgheLQoNBy+QTbPYMs8KxrFUZd2nYag6IlDuThGvjmKDRIIxaPi3PoRe6CAxjoagVncgxGc9tH6VMpTFLK+6eprxzsGS7FxC6NqOWB0ITR6bvO01rDhY5aVmz1gnxXYe9aUbZLD63jxN8x6bl2yyKGql1s1CZtCeloR188GsdN3S2M7HTC3x5UNSSaVphWxaRaxSs5329LEvwMxd73J2kXOhHjDsB44bKqrXmD+5NmWeGadZveYZC2ex8HMuiE3mmdSEVoFjkir1ZZvrWQpCXit7IZb3jcesk5Ye3JrQ8E27jNZXtpWGLTuhw5yTl+nrbhNm3zCKVlXLl9FrV5omNUNRQWcNG6LX+jAFQg5ZHJY2XcDuwuXOSEbgWG91wdS6PY5/DRUEvMqSTwHOQGnzXouU5XBm3mGUld08zTrICG6MG7wYu43ZIUkq0gH7oMM1Laq24Mmxx6zjBsUyW9YV+RFkr7pxkRK7NsOVzZ7I0ZoKV4sIg5PpazDQtiQMHV1gcLXM0ml7oPUQjB6OlyiszmL86NpT6x6m8p6kJGZtnH08J/iheLAoYpsPuNMNuVICP40WnlaSUitN5hWdbvLTeZtT2eHWrzSQp+cZGh+OkpJTmZGiHDtu9CMcSzPOK0LO5c5KwyCvKSjHPSw4XBaFn8Z2dPlWtaAXWKuRENzm4l4amBN2d5NyZLHl1s83eNMOxBNs9w6AIXJu8Vlwatgg9+7GCFbv5/bW2z2larkI6XuCLD8+2aPmNalkbf/+kSHhlo706Vje74WMpr6dpRVJI47HjGC+t71ww2VU3NgwzKPYdQJAWsrFaF6x3AkqpeXm9Td5XXBwEzcJhxJL9ls+1cYuTZUlVmxmcEIKWbxhzP3Ohx3Y/wnPMvKNu5nRrHZ+kqB9yGHiS28CHIa8ku9MMr5nLieb5N875e4Weg2tbzfszMG3g91tUoWtzddxinlVsD0J2+hFCmBbSwbygE7imresaRXnLc1Ba8eM7p3R8F9cxHlWGIirIa8Vmz+fBtGAUeyzymmtrhiZ+9zSlHbhcGoZYwlrNm86M+pZFTVKYn42hocXloZlTurZFPzKBOrYlUEpz9yRdzYgAhi2P/XlOJ3A/8YIAz2FRaAJy/qXmv39Za/3XHrn/tzEeEBr481rr3/qsX9NJUqyCPdqB89jJ/qDlGXqaNtTVvJIN48ellnCSllweRrx1sEQ3fOi9aUZS1mz3QnzH5tq4jWNZbPcjfnxngtv4q291zY7rB9cG7M1y0qpGK3Oyh57NWjtgHAd8c6fD63um/3hGJc0q1SRHCa6OWh8p9HFt61NJZ3qBzw9CCK6OjUL33aNlI/j6IK1Qa8PqsW2xqiQc25AMWp7NxaFhI41in195acTN/SXwfmXp2jW/fG1tlU74i1cHKG1EWZ3A5nBRMm4HBK7g77sxwrUt3jtO0Bom2QlXRi3yUq4Wp7V2QDdyySvJu0dLlDJtlWetCADePVwyz2ti3+h2Ht1d25b4yOdZ5BV3JymWEHznQo9By1xct3sh2z+zQ9a0jrSG40Zvst71Gcc+Ra05XpaErsU3tgxRZVEYoz/PsShrzSwTXF9rr2jEV0ZmEZ1lEq1N7kmtNKFrcTA3Mz/fMd9PLTW1NNTyjY7Jaa8USGksSd48WBA4xtH1TIz26IL3SfE8KoXf0Fr/N0IIF/gh8Nce8zv/kNb66X1znxEt3+FkWSLEk224fcfmpbWYk2WJbQmc5uKbFKYPmpUKzfu89DMvJYCTxPT/rIY1sN0PjQ1yUnFpEPGD6+NVHsTVcUxeSW4dG9FNJ3A5nOccNjqLb+/0ePfInMxx4DJu2yyaSuSTKj9f4MsBIQQXBhGnSfVYRerRsuBgZtg9V8YtYt+0ma6MW2itH7pw2kJgWaCUWTi2eyF5pVjv+Kx1DBHiwuD9IKq8qrl5mDBoufzc5QHjtnEyDV2btJRIpVHK5InYlm5MH63mbyWqafcnZf3Y/PSPg0lScppWHC0KdvrhJ6b7noX6OJb1kKbhDKHnEDZkjG5kHAbOev7fvdTneFkwCN2V48H5a8cZ7TcpTOaFY1v0Wx5pJckqE8J1ZWRyYA7nOZOkoqrNnENg5oiOZTUqZfO3Z1kTYKjBWWkyMD7tiv9zXxS01rebH+vm36NQwG8KIfaBf1VrPfmsX1MncHl5o42AD7Ui2OqFdEOzKp/9nmUZ7cLV5gu+No7JSkkncLgzMUZ4g6adc/skZZnXhJ7F5WFM1pZs9HxCrxGpNV4tgWvzyoZpS+WVsSjQ2vQMtxsL7EVRrUrJT+Jv8gJfTviOjWPX7J5mHC5yro/j1bF4vng4X0mctU9qqXgwyxECeqFL4Nj4rsV2z7RffMci7ATEgYMlDGEiK2VTOQvW2wG0zUUeoB24/OD6kLwybsJHi5LtfshmL1j5cIE5v3pRTa30p0KFPouxjTxjzfFJWyWDlkdaGvFo/yPOofNMvbySJGWNBfzo3pTYc7g0jB6y+p6cO2e3ekZgerQokEqx3vFoB95qYT9bhO+fZgSuzWbv8Qtdy3d4pVEiO41bgf9IuNingec5U/iXgf/jMbf/M1rriRDizwD/AfBvPfoL5zOaL168+Km8mKc9sM5ziJOiNkO40FupBQPXXn2hZ0MhMKX9WYuqrDVXxi2KRt1Y1op3j0zK1qVhRDtwH9r1tXwbqSS9yEXzvsillulnEsf3Al9sJE34TFUb8dPZojCOfYQA17IeGzB1kpSrYeTeNCd0jcJ2u6GVHi2Klff+0aJgf2bor5Yl6AQmwzwp69UmB8zCcNaNXO88XhlvWeKZLSvOY9i0dwU8U7vEsa2PlTNwhlvHhgZ+6zjBEsIY5cUeaw+9Rp+DeU43dFfzgncPlzyY5Qxilx9cezgTfdwOGD9FW/f8pvVRPcOnhc9sURBCbAD/0yM372ut/3khxC8Avwr8k4/+3bnK4H8H/uzjHvt8RvP3vve9T5wA96xwbWtVgp+Vyk+CEILNJtJz2PJNGdqUotO0pJbmbcxzk8lrikiDUdtfneSqCcipmwD2F/j6Ydz2qRoblfMXBssSHzovCprB5hm9USlzDAshmGVmsVjkRgfzqMhdCPGJLqCfBYQQz1V8KYSZWbR8B98R+K71gfnFuO0zbr//Gh1LkDTtZDSkpaQbfjHP389sUdBa7wN/8tHbhRDbwH8O/ONa6w8Qk4UQHa31HJO+9u5n9fo+DXiOsS+upX4qpeAo9h97MLcDl5ZvjK/OdkGj2ISF2EJ8gH54fS0mLSXtj7lTyBp9Qi9yP3Wl7Qt8fog85wNuv0+DbuTykmuEXI5lsSxqikYhP4o9jpaGbWNbxvrZEgJL8JG2CF9FpGXNIq8fe65cHrZY5DXX11oIIZ5KBBq4Nj97scft44R+y//Y5+7niefxyv5DYB343xrPnT8NvAz8nNb6vwV+SwiRATlPqBS+SDDJbc/2GGcD5vMQQjwxHMO1rY+9y9DaCIeUMiZoz5LN/FVXLH9e3kjPA+d71bqhXQJs9gJe2eis7vuw4++rDqU07x0ZVtUirz7Qoj3fIv44GLT8FcPpi4znMWj+c4+5+Q+af2itv/f5vqIvH/LK5Dx83AGTaJi+XzP/u68tPuo4Od+itF4cFCsIE5nQhPs8n8/lk57jnwa+uDXMCzwWB/Ocw3mB6wheWms/9UFjuO4tlkX9tWwHfN3wYJZxvCjxHIuX1uLH0pW7kctFIqOkfcFgW0EIPZrPlQAAIABJREFUwbVx/NzOlTO7Csc28aIfN5zpWfFiUfiS4TzzpJIK23r6MvaTlr0v8DC+DO2lM/1MWZtQev8Jx8mzaga+qnie58qZB1QtNaVUX49FoWEf/SWMJuH3tNb/5rn7fg34p4BT4P/UWv8Xz+M1flGx0Q3Yn+Ur//nPAl/1mcHXAZvdgIN5Tuw7L0gFXzKsdwKUzglc6zNzMv4wCP0RKTyfyZMauupUa50LIf5H4C9qrf+oue/XgL+ttf7Np3ms0WikL1++/Jm91kehtRHPWI3jItowgvwPyTx9EqTWlLXCwtDaPg1IramlbvIYHk6Qq5V6SFT0KG7fvs3n+VmeQWsopULAh2bHnkFpKGu5Emt5TxDwrN5zw+I6/7dghGCfZcv4eX2eX1V8kT9PqTRKaxzbMjGmSq/EpRpWx9/ZsS6V4myq86Tj97PGj3/8Y621/sAJ91wqhYaueoYKk3t2Hv+JEOIU+Le11n/wYY91+fJlfvSjH33aL/Gx0FrzxoNFY7ZlrcLTn8aqVinNrSYj9cIgpB243JukKzHRRtdfeSk96blvHSekpWSzG9BuqIOPHkzvHC7ISuMp8PJGe3WRvX2cGItujBHa43aP3/ve9z6Xz7KoJWWtVu/1/OdwaRStKLjzvOLuSYrvGHdIqTSVlNw6TjlNSmqlGMUB19ZaH9hRzdKKH946Bm0My76x1cW2xGomA7DVCz4Vr5gn4fP6PL8u+Kw/z0oq3msibS8PW08lDitqaUK4jhIjUC3qhuLrY1mCludQScW47bHTjziYFxwtCua58VTqhi6XR9ETz/vPEkKI33/c7c91piCE+DYw1lq/fu7mv6y1/jUhxEvAfwf8icf83aeuaH4anFUJZ7i21iIv1WOtqh9FUtakhWSSFCzLmu9e6NFveSyLGtDsTY3X+pn3zKMoarXqE9+ZpLiW2V1cX4sf2l3HvktWmoSm85XC2eIhxPNlmhS15O3GNHDQMgrtovHBty2xEliBubBrDXml2J9lxh9GKrSGXuTh2IJLw+ixJfZJUoAWpKWkknrFs+mGLtO0Qgiey4n4RcSXYUbyeSAp6lU29CyrPnJROBvm25ZxNa6kJq0kncBlUVRcGrTIK8nd03SVs3xl1DI2I5HLWtsnaqJIv0h4bq9GCDEA/grwz52//UzRrLV++0l0sOelaLYso+pc5BX9yMN37MfuuPNKcrwo8ByLcdtfCVxqpThNmzi+RcFWL+TVzQ5JUfPekTG6Kp4QWO471ipS07ZMXrRUmryWq0UhryTtwDFRnLaxEj6LCt3ph7QDM4f4vJTQaVkjEA8J+2qpV22f+6cZkeeQljW9yCTZec775ffZouk51upvXNtavY9R7D1xCOc7xm56re3xyub7FtOBa/PyxgtrkBf4IBxLUEpF6FkrL6Sz3b/v2B9obT6YZpwsS9qByze2OkilmCQOWaXY6oX0I5fdqVk45rmJ3hzFPq9smFz0L6p1/fMaNDvAX8W0h/Yfua+jtZ4LIUbP6/U9DlprlDbmYuf92WupOF6WBK61ovXdP025ebCkqBTf3ulybS3GtgRrbZ/DeY5ji4cuzC3fXMjnecn6EwLLhRBcHBr/mLyS7E0zc4FsXsv5hWWnH9Jvecwy034B2O6HHxAj6cab33WeTpX5cXAWbwowbnv0Io/AtWn5JtS9qCXd0OG9oyW704xXNjvcn2ZcHrZ4+3CBUkZQ9eqmEVSVtWJZGoM2jTYukuc+w/ocSyMpao6XJd3QY9z2V06XL/DlR15JjhYFkWd/qq2/opL8dG+OAJQ0VfbBPGeSFNTSVLE31o3A1LEt8rJmWVTcPknohi5Xxy3WOgH9R8RpO81G56f3Z3QjF/ecmeYXFc/rbPlnge8D/2lTDfy7wJ/RWv/rwH8mhPgmYAH/znN6fQ+hkoq3DxYoDRf60UM0vnunKYfzogkTMYEmu6cmOrEbuitHybySvP5gwTStsYTge5cHANw9STlNS5ZFbWyyFwU7/cikVEn12It14NofUEBXUq0G4KU01YY65wcsH+MNfLgoOJwXCMEnsk34MJyV4adpySyr6EUl18YxoWevPGH2ZyamMPQc0lISujZF/b7NclbKld1AyzcZ2EfznJNmx7U/y5FKU1Q1ke9S1iZt6mRZMM9rNnsBUr/g33+V8GCWs8xrpmlFHHw0s6qWCqU/msBw+yTh/iTlaFFwZRyzKCpsYXGalgxj0xV458hs9MZtj1lasT8rcW0TvrM/z0HAqOV/QBOy1g74lZc8Dhc586xEKc2FQbRyRX4cylo1s8uH399ZBoTvWFwZxZ9JtfG8Bs2/Dvz6Izf/TnPf4xTPzxV704ybB0u8poVztiiYwfOco4UJ6Wl5Dgq4PIrY7IZcGISr0HLHEsZXXms05oI9zUomSUmlFG/szRi2fTbywER/TtImxtNlvRN+4Ms3B1jNWsfHty0O5hmnScmo/b6/Ur/lIfX/z96bxFqaZHlePzP75jsPb/bnQ4SHh0dEZkYOlVWVlZUtqtS0GmjUYomQWIEQYtHsWbBALbGDFSBAqFdI9KZbAoS6Kaqqu4asznmI2efhzffd+X6zmbGw6y/cY8iIyIwcKiPOxp/f6+9+z7/3mR075/wHizYGYwyni3ytpOk+q14niif+D59WPNHur427thQCa6Eyhph3H3IpoRH6bLdd0ixri9ZOiz8rapphxN2zFeNVycks4+75Cl1bNjoh7djD1pbv3Z9wMs/ZH8TUNez3Y7RxiqGJ77H9nvnMLHM6/J3Yf0aw7PP42xFPNnf1FKLsw6KoNbdP3zX3SUK19pH4AKQaTm9sntd0Y4975ysCpejEznltsip4MElpBj7zrKIT+2y2Q9LSY6sTkleGk1mBNpbQUzwcr6i0Ya8b00ucPH5eGWrt5LRLvSQtNIES9BoB7dh/yrvC/dzWumr5ab20aVphjPNvWZX1B6rh/qLxeV39MWKRV4xXBRb43au9iwz/eJzyk8dT7o1WBEoybEZoa5DC0kkCfNWgvR5Ce0qy34359r0R2li+/2BM5HtM05IocG5s86ximlV8/8EEs77GyTzneFZwY6tJc/0A1NpcyGq/eTRHCcHxLOdSLyEJ1DMJZNgMGS0LjqZOBlkJcVF2b7cjlBAEnvzUhl3WWm6fLskrw2Y75At7HU4XbrEcz3JOZjlXhw0H35OS7U5IqV1LQFvLo4lDaCkpQLjFOl4WPJpm3B+lXO7HdCKfbuzz+uGcO6MV42XBTx/PGLYipIDrW022uxH7veSZe/FonPLjx1NaoUdWhvQbwW9sX/fz+ODYaYe01zOlj2rD5KW5qDofTVOscW2i5zcb72vz9BKfw0nG1WGCsRYl4J2TObGv2GxHXB4k1LVFRc5y1Dkw1gyaIZd6yUWrtKgMR5OMP39nxKqs8KTkG8/32GzHeFJwb7SiGXn0jQM83D5b0I4DYs85uF0bNijXYAp417viSXQTn0Xu5mwC1yr9tAfVv9VJYZZV1NrQbwTvK9NqbSg/pD0D7pdxNMtohv7awjAi8iWLvOJ47tA9Z4uC+6crztOS7XZEpTX7fedyhRW8c7wgLTRRoNhqO8PwqgYbWo7nBVcHHsNWyItbLd48nnO6KAgq7YzDxymh575vkTs1y69f7eOtMc1xIJ3bm4XAl+6UISzDVrj2gq7Zake0Y4+nQEh48t2FpKT4ufxxn46s1JwuHJlu2HSSznnlVuIir9hqR+x2Y07m+QXsdJZVnM5zKm1JAkla1JwtcvTCcqmbMM9rIt8N068MEnzp/G2329FFSf3W8YKjec5onjNJS5K1N/CydE5XiS85mjnTkmlacTBJmaTueXh4vuLGVpuXdlrAByeFJ1Xdr4M89Hl8cGhjeeNocWFm9VHRipxVZ6VdK+ZklXO2KDEWXthyMvVni4KtdogS8sLPQBtDNwmp9BJPWk5nzmfiyjBm0AzpxQHLvOZSz834Qk9xdZi459l3LadaG07Xrc7Tec6//coWzdAnDiRpWdNPnGNb5Hv8+OEEa90G74ipikbgEfrqfVLobqjtM88r7o/cvPByP/lUmem/tU/8sqgvhqza2AuYp+vVGe6NUrSxDFvBBxqe/+WtM370cMqwHfIPvrhD1o+pjXOu8pTEWo/pqsDzFLU2gGW3G3Nzp80qrylqQ15rRsucQTPiaJbTjn0CzyltfXGvjRTObu8790b8+TsjGoFimTso3OmioOErsJaNVsSjsWaSlTRCj+eGDQaNEL8jEAiOZhk3d1oXs4gHWc0yr7k7GnG531gbpyRM04rH05Rx6nF1kHwqYl+Hs4y00MwzV8oGnmTYcovmaWhtO/IZLQs386gM//rWGQI3o7kzWnE8Xd8fmdOKPG5utZBSMlmV9BsBv/9cn9cO5hxMUs7mBeO05PbaM7sd+bQjn8vDhMhXPB6n/Mkbp1wbNtnuhASeZJY5n4BSG25st2iFHj9+PCUJPK4OGhcchmaoeDjOeO1wRuQpXtltc3On/eE34DMQvymQVW0ccq2oDFmlnwF8fFA8be6TljWTtFxXGZKzRcnRLONsUXIyz3lxq3XRXuo3AhqhR1Zq7p+vaIeKtNDUGh6eT8krzTQtqYxlrxVxOs/54l6HOPS4d56SBIp/94tb/LMfHlJUmvNlwZtHM64NmoCgNoazRc5mO0ZguHcmeTTO+Jt755yvCna7DXa6EV+61OHxxM0crw0b9BuhS27znNGioKgNka8uZoifVvzWJoWnmdpPvloWNfdHK8raUBtD7HsXp9qnQxvL7bMVk7Rinjtf1EobxquKJFCsVhVf2A1J1qfjVV5xbdhkpxPzym6bfuJzPMv5y9sjXj+ac33D8HvPDTicZigpKLThndMlNzZbTFclbxwtOZxkxIHHVy93CDxJVWseLN2D53sSJSSFNhxOcu6eLnl5r4PWbmDVbwQUteHBaEUUKCJfcvcsJy0156sCJQQTVfLm4QIpXHWQVfpTOQVHvlswvvcuxM5XksCT+E9VJXGgeGW3A8BfvnNKWtboypI2amZpiVKwLCrnRtcM2GyFHM0KjucZjcCjFXr85OGUx9OMnzyec3O7QTPyMNZyuZ/wu9d6THNNUWl+erCgNoa3j+dEfpfnhg2SQNJvxGy0AvLacL4sMdby8HzBLKuYZRVpocmqmiuDhINJRuJ7dGP/M58UflPCUwLfE4SeIvmYEi9Pdwu+frXP2dKtB20s989XjFcFHeszTkte3e8SegptLDvdmOc3mrx+OGOWV9w+WVIZ6/YPbdx8wBoenKeU75xxc6/Fi9sd6lqz10v42pU+f/xSzT/97iNOFxlvHs7pJcEamg7zTLPdEWy0Y0JfcTzPSQKFLyWb7ZhAOb+LxxMHe52mFd+8PuTxxB1YPOFseC/1YxqB4tE4pRl6a+vUX/A+/8Kf8Bsarcjncj+hMubCuCYta6x1m1YSKmJfXTgmrQqHCorXPfmXt9tkRY2nBCfzgnujFYuiYr8X89J2h2sbTnny770iee0gpBX7bLRDekmAlIJxWnE8KwBL5CvakU+a17x+OKeoDYu8phP5hJ4gr2oCD6ZZDrazdnVyzlhGmwtEUYLEk5BVmtO569N7UjIvKrBumD1ouiFsLwkYNJw5+3Yn4miWkVeaSVqy0w05nGa0I/8DiXKfJPa6MZ3Iu0A/1evkdDjNGGcVw0bAlYFLXO04ICtq/uL2GYeTnF4jYKMVscw106ykqDSBrwDBNK/JS82Ds5ReI8B2Akqj157BPr1mxM4a3rfXjTmc5dwbZQwSDyUd8a0Zu/bbsB1yddjg0SQl8BRXh00WecUPH07xlSDyJPfXMyMpxFpzRhEo8RtHLPoshxTiGc+Hj4rVU92C2li22tFFO+bNozn9RkClNUI4EAgW7p4teft4sR4kR6Sle32vG/FwnHKpn6AEzPOSRab5/vmYqjb8mzslp7OCZuRfmPNI6dj054uSvLK8c7zg1b0uxlqmacU8D7k2bLLbibk6aFAZy8t7bb58qcN2Nyb2n8iwOLl7h8Sr0NogpGSrHbLTibl9uiQr9QUi6xflIf1WP/Hv7bP1k4Cs1AgEe713ET3jVcnBxA2Knttw9PZv3Rhyc6fFqqh5/XDG6TxFW8E8qxlnJXmlaQQeeW14eadNLwloxj4/fDhZO7FJNtsheaW5Omhw/3zF3fMl58uc0HPeuFg4nhfUxjLPKmoDP34849XLbe6dpSyKmmsbDSJfst1xTlgH05RJVuHPMp7faDBJS5R0JyhrQFvDeFUSBpLYV3xxr4MQgrNFjpKCa8MGlbZYa8jKgs6n4MI2SSumaYWnCrbbEffOV9w+XQGGvNRkpWGnE9GMSg7GK07mJazZ261IIQVIIdnu+Awart2TVzV3z1dsdUKMNcxyTegrhq2AXhLwtf0uQgqyUtOKfF47mHE0XXH7RDNoBsSBh0By52zFfj/hdFGQFprv3huz3Qn51o1NvvFcn6N14t7rxbxzvOTmTotXL/VIS0Na6M+s0cxvQ5S14WThvKifRpo5zpGzs52v24raGB6MnfdyUbv2zptHs/XzKHg0ySgqw5Vhg5vbLfa6Mf/njw+5N0q5dTZHIThdFq56NfD9+xMqbbi51WKROd5MbeEHj6Z4nsRow71xyh+/uMmXLrVRwtl1fv1qn+tbjtymjWW/F/NovMKu4PbJAmsFzdDjyiC5sEcNPUlWajz10YisjxO/1UnhveEp+T6NorSsmazKi79X6/6cEMKdFIqaO2dLeo2IeVZxOM9oRwF3ThfkleVomvH60YJ26Pr2zdCn0pa9rhtMW2t4PM340YMx/99bJ6SF4YWtBje2EgyGN4/mzNKKvHaeu7XRvHk4Z7yqMFimq4pW6KqeO2crpqkb0uaVoRl5PLfRRAi32QdSkNfGlaLSoxP7F3ODnY6DagqBa4GtWz5Pt3h+njiaZbxzsqCxpuuXtea5QYOqdpC5JPBoBIokcIPgJPS4NmiwLKs1XFQipSTyJNY6H+u3ThbcOl6SlprH4xXbnZjdSKG1g5xutGKK2nC6KJhnFZ4nuH2y5HjuEp+fSRqBxzKv+OGDMZ6El3fb/OTxlFtnS04XBbW27A8aFJWhHXmsckO/ETLPKiZpycksp9JOp+rz+NsXZt17P5vnGAuv7L5bYRxOs3UFYek3A945WvDOWnpl0AgJlOC1gxnzrOZkUTBelpSVYasTYYyl3/D50zdPeONwhpKWQRIgpWTYCHlxq03oS45nBVJAVhu2uw4gMU7dYbIV+lTG0sLnr++c84fXB3zrxpDXjxY8Hue0Ip8rgwZHs4zbpytmmab0LD9OCzabEZf7CcNWdFERXOrFdBKf2FcfCLf9pPGZSgrvjbSsuXO64s7pksN5xs3tFl/Ye/fhmaUV08wRpb58ucvdswVpYRDSsZsfj1N+8GDCvVFKEipmeckLGy26ieL/+skBx+vh8j//4QEn04LcVPSTiFVZ86OHM/7NnSnnacF4XlAZQ+A7qJ02EPsCbQSbzZB54bD1sSfoJR4/fJRhEZwuCtqxDwi+fKnDo0nGqtAIXMvo6VNurxEQ+nLdHlEXzk6/yENU1obRoiQJFIezjG88N2CjFVEZh4LKK402rhf89vGCwBdcGzS4PEiQwlVdh9OM0TLn4TglqzSvH83Y68YczzKysmZVGkKV88bBhMpaQuXze88F/ORgxv3RiqP1cNgTYI3lcJZjjGWz7XM0K8nLmrujFV/e75KEikVWMl6WKAGhrzhbFtzcauMpQVN6dBuemy+UTk7kV68h/Hl8nDDrTTb0JEII0qKmHfucLQoejVOSwGOcFkS+R6k1t04WXBk0GDZD3j5esixqrLVsNEOmWYmn4KcHc3Y7EXlZc+dsxSyrmKYFAkkr9hDS0px4/M//as54lfNgnLLIa4w2xIFipxPwxy9tcPdsRVZpHoxTaqNZFgYpJQjYasfsdUJCX/FwkvLm0ZzxsuTFrSWhr/A9weuH5kIex3EXLCeLjO12jKdgnBYYa1nkNbGvaEbep8pX+EwnhUpbLJbXDqcEnmK0hqsp4SCJD8euHxn7inbk0Y1DHp3POJhmDJsBzVgxWhWcLXKqqcFai9U1jyYlJ4vMkVjOU4racJ4V1LUBUxD7rtwra0sSKLQAz1N017IPUiq6kc+rey1WteXHD6fciVbklWZV1CS+R1bUKAH3RylKwHfuj1FC4EmBtvYDiVlPD5Y/DS8GXzmOw5v350gEt06XbLRCBo2Qd07mLAuNMZbaGB5NUiKlWGSav//KFgfTHITl1tmCHz6ccLbIacUBJ9OUN49mzFYlaalpxx6TtHSY7FKz11GMFjlSCg5nKfO0pq4Vi7ym1BaNIfQElXZl9dmiptKGt48XbLUjBw5IQipj+Padc7LSAQle2Gjx6n6HYTPibJnTjHxWZc3OLzhz+Tx+OXG8hnvWxs2yAqU4mGQIASfzgk6sqY2lGSnSwlJow8HEIYMslkeTlFobGqHHoBFxvio4XxUcTjNOZxnjNazUl4Ks1iSBpKwNB2OnYHA4Tx0k3Biy0mCWFavyhKLWvLo/YJHXRJ7kzaMF1loCT3G5GxP4iv1+k812QF4ZDqY5R/OCrNI8v1YCvrxuNye+R+xLXtxusSxqHoxW5LWrNGapa2v3GgF73YQv73c/8oCnjWVVOpLtz+LnfKaTQif2KUqnyz/PK7Q1vHXsCCs7nejCp7UZ+yzLGiHgdJHRbYS8dbRgrxuTlRopQWjL+bLkcJKBcMNgJZzG0SzXVLXzC8irmrtnKXEo6CchG63ItXKUYFFUCAvGGHqNEKEE43nB2bSg39QgpGvBBK41tNeNOZoX5LXb9DZaIW+fLIg91x66OkjoJgH9X5I8tBCCy/2Y262IUluy0p2+/ubuOSdz1355YbOJ73nEvmKeVaR1zf/6V/foRD6twOP2yZLRomC8KljkJYHnsSy0k/m2Bm0t7dgl5shTGCRpqZksSxZZjTYGhU8UKDzt+CdKSXqJTxgoZquCrHbfU2qNRfJgvKIT+dw6XSAQDNsh7dDnYBLy/GaLaVayKmuwcDjLf2n37/P4+eNJBSfggugVBdIhdbISYwxJ5LFMa+Z5yb3RikboIaVk0Aj4+pUeJ/P1xu8J9roxFri7XPJ4lqGEBASBcECR0lhWleH++Yyy1tTaECpBqqE0hqIy1AvDX98bM1nVaOuqVmssVW3oNZ2q78u7bfb7MfdGKVeHDR5PUypt8JXCAFvtkG4ckJcGrWsCT7HRlMyzijhUPD7PqVqWQEmkgLK2TNLyA+/Re+PeyM1M4kByffPDRSE/00kBoBl5bHdjJsuCQSPEGKfXc7LICaRkvx/jK4mxFm0tg0ZEbS2Dtdrh710bcOtkySx16JV7qWtZRIEjtBzNCoQxaO1MI4yxhH5NWiiGTYGShmE7xBOSR6MFFnfCbYWSHz+aMc1q+knATjdypaqVtAKPOPQYryr6ic8sqzieOeyywVIJwRtHc948nDMvKm5stXhpp81uN/5UvXi1cQvm1f3uBaTuO/fHvHU8ByvY7gS8eqmL70le2Wnx/7x2zJ3TJeergiMp2evF+NIpw0olaUY+RW2wxmKsS6IId9+zSvM7V3pEnuKtkwV3T5dIKWkFCiMNG3FAZQyX+xGNULEsNDvtiLtK0g4E262AVhzSb/jcOl3yvUdTJquSTuzRb7h7OM9L3jqac74swFp8pZyR0nuirA23TxekpebFrRatzz2vf+Wx044InkCflZNIbwSKt46WNEMPbQ1Z6bg9xkArDFDKzQx7SYBSDtp6NMs4meUXh7i81PRiH2MF7cgjq2sqDVlZr8lpCl/AaV5jrGDQ8Ah8l4xCTxJJxfEso9Zu3phr10I9Wjixx1lW8f37EzqRT6/p87XLPbY7MT89mDnZmbU5Vr8R8u0757Rjn997bkDkKf767hlKWkJf8tX9Dp5SLArNlX7ywdId1vFyngBJnuiRfZgS85P4zCeFzXaELwTDVkReaYSA0aJglleczArqW4btdkQr9vCl5A+u92mGPq/stng8yXl+o8XfeXGDzVbI//7t+xzNMrLCorXh9YMFRVWzKDTWqTagLfjK4evP5jmTtEJJEBYmWYknBVvtgNePF5ytxeoCJfjugynjZUkz8rg2iGmVAcuy5vef61PWEKia00VBFEgWWc2N7TYPz11v882jOcNmiJLyU0sKs6zi0ThFScFuJ2ZVav7q9hmhpzhfFlzfaCCl5CcHM27utPDEGt5pnW5LHIh1b19SG4utLZNVReRLQk+y6fkoJakNFLWlMJrvPZjQDiWPpwWLwmAxWCx+KlimFfNS4wuIQ4+9bsIqryhqQ60F56uaONRMU5eYjbF4StAIFN+6scE0q3njaM4bB3O2Ok5/qpX4XBu+3zzpfFVwa62po43l954bfCr39PP4+CGleKZFmgSeU9ItKpZ5zf4gYbsdsdOJyMqa2lgWueZ8VbLTjnj90JFXb58uuHW25Gyes9kJyWvLVicmlDDLNWcLB5V2p3npmPZao5GgIasMkacc0EM5tvKqNJwtS4qqprYCYwwIz60XkWOAfuJjjeFgu823XtjgC3sdjmcFu92IyarkX75+TFppNlsBnUOPRxNHtBNCEitJpeHGVgNPqfeJ5j2Ju6MVaaHpJj77/YT9fsw0reh+BPv51+mn8N8BvwP8wFr7j556/QvA/4TbQ/9za+1Pfpk/R78RsD9IWOQ1G62QV3adv8H3H0yYZSXNwCeLXethktYcTVN2uzEPxykHs4xuHDBaFby026KVeM7rwEKpLcZWLAunv2IATzrtkk6sWOSaoq4paouQ7r2iMtRScjgrCZShrB3MbLRwsNWiNhS1JitqrgwTtmVCXlk8b22iIywvbLZIAo/fvdbjRw99Hk9TfOkkq9uxdyEBrqTTSxot8wtOxyeJxdo5qtaWo3lGVTutpryJxKQMAAAgAElEQVR2TNNSW47P3MaZ124W8u0751TacKkfcbooeOdkzmRVXbTEcu14CKUxNALf9XuTgHeO52RlzTyrORVQGVd1KdzsZ5q51/JKoxScpxWRUuRrjaRJVtIKPU5nBbGv2G47FEleGf7whSGeUqRFwWhZMmgEBJ500MOd9gfOXhLfw5OCyloa4ef+x78pcTp3RlVKCa72G7yw3SRfo8uOZhlvHi2otWWcFpS1wVjD6bxgllaOO7AsWRQa0A5RtK4cSm1QQlBpNx8z2qBxbOJBK6AVBjRD5UATq4Jlrh37Gkh8QRKHtCNFXhpqA1prThYF2himxZSiNvzRzS02WiGh7w51pTa8dbzg9gmMlyXdxGl15bXmfFURT3NKbfk7NzY+8F5Ya0nXplzOyMtxtz6OsdSvy0/hq0DTWvstIcT/KIT4urX2u+u3/xvgP8Tto/8D8A9/yT8Lv//cgPGqpJv4DrdsLZutkHbiYSxogzsFFM4oY5rVbLRKsJbRouBwkvEvXz9a8wlCCm3JipJKW6R1/xEJa4RMjUU5rZ7CYhGOtBV6+NKdgDCWIHAeru1IsSqf6DRJirWvwBuHUwIBmD79JGCyLJ0JT17x0m6bnU7M7hdjfno4AwuX+jH9JLwQq3NaTDkPz1M+iUCqMa6V00sC8krjSde/fzTJeGm7xY8fTxkvC9Ki5tbaK+GLl5woXlZpTqYp46XHJK04mmV0IsWwFRJ5ktNFwck8x/cUzUARSofVlkogpcSsy15PgrKu6hJCIHiirAqZhtBzv7NW5LHRCmn4kkmac76s6TYCuk2fv//KDtk6gSnhFk5W1gy2mnzpUoebO50PHcYloeL6eih443PDnl95WGtJS03kPyv+mNeGduwhgLeOZ9w/X7LXi537Xm3IyhpfOdReoTWrvOJqP2a8yvFVSFbVTLOKk0Xt4KTra0jh1mWgJKU2FEh8BBvNAKxgsqrwpWCeVqxyTVlZEKCkq2C+drlLO1CUBu5PVkxXFbO0JK0tpS55NE75/r1zNjsRW+2Yr13pcTIPeRBIOnHA4SyjtpbNZkgn8rm/ck5u7fjDt2+xVi6YrdGTnyR+XZXC7wP/7/rrPwG+ATxJCj1r7SMAIUT3k3xoUesLe8xPArVshB5CwPnSoVwWeYXvSW7utNlct5UWRcXjSeYQRsaSFRrfcwPlk0VBVlYMGgEbzYCWL1lmoLW9aBtZAaUFW1q0KYhjHyElSliUUISeZDBwIl+TtFxbSFrywrAq3SDakwI8j7NFDkLwYJLxeJLSb4Y8nmZrkljMlX4DT0lWRe0GZgKWuaYZmgtZj2VR0wo9amPdwP0j+oxP4sE4ZbkWrHth690NsR37HM4y/vr2CG3h8TRjqxlihKuAqspw53SJFDDLczwpySpNrSt6ArT2qGrHvXC9YsF+L+ZglqOkAmqUcvcy8tcwxFJTa8ustjQCLqaPxkAjlLy42WJZlbx1smBV1hgjqI3lhe0Wm92QZe78GpaFIa0qeknIbiemHQccTjMGTSdLMFoWjFclvcSZ9pzM3SkNcPaLTzFInXe0Zdj8nPT2y4rHk4xpWhH6khc2m09xcVwFeG+05N5oRVlbbp0s2GjHnM2d0JzB8vA8o6odJPtwnjJb1Wy13YZfa8N4UVJUhk7sEwdOjXW7ExB5PvM059Ekx+ASU+h7+ModlMJAEVaOhCpxScFTkihQPJwVTNKStKhJfIleCzH6UlBry6NpxjSrmGdOaO8fvLpL4CtunSw5WxScWHf4/MbzQ2Jf0U0CYl8xTcsPbQlvtMKfSx7+15UUusDd9dcz4JWn3nuaTfWBO/t7PZpXRY2SgjvrdsWTHporEe0zLYAnvgHvPQU+njgZiHdO5pzNchqRz24nYrMTc3/kNFJmeUmlnayzMZqiEoyXBfW67bHyNUmpSWtDoY2TTfAkkbBoK9yw2ljSypKZCiUEwv1/MAhCZThbuvJTCggCybAhkSWkRc1qbcQT+Molr0Lz5smC61YTeW7YNc9qsqrmcOoGtc1QkdeGQdM5n/UaPmmp2WiFtCLnDbHMHQv448QTKd+iNhcS4qfznHFacjzLLiqCFzdiRqkmDhRncyeLvd2KKK1GAudr+O+qMKR1QaAqhg2PQRiz1415PM24NUrRtaGqNXXtqP4C0NqglEJJyJ3wKvPC5QSBaytpaylNzV/cOmee1+SVJvZd5dAJPO6cLbl3mjJaFGx1Q8oKPOmYrX91e8Q8rxg2Q/7uy1scz3KshZN57pzcfMWEaj3vefdxXeTu4ADPam99Hp9uZE+ewcpcQMjPFjnvHC/YbEe8uNPiZFFQ6wor3fO5LGpakc/hbMkbhzPSUrPTipjmlRNLtBYlBcF6plXXmqx0SKVKGg4nBYlfkJaaXBsipZCsDwHaMGiErEpNUVskTusr8FwlczrPmaxKRquKtCgxWELlESnoJB5COM7BqtB0kuCiwgiUYLMV8ONHY+ZFhRQSbQ37/YTQE7x1PCevDF+53L2Qw89KzfE8pxGon1vC5teVFGbAE5ZYG5g+9d7Tq+kDj69PezS/+pWv2rtnK4dSWdvmVdo8Y1TxxJ4yKzV3zpYAXBs6OYtKm7UEQs0sq7g3SpksS4YtS22c/WbkSR5NcmZpSbZu5UghKWu3UVtr8ZS6oKrX1tKNPWcsoyHwoBOH+AoOpgW1rklLVwkYIJAgMTzOSrJ6PX+w0BASJRXbbUcOA0noCXpJBFhCXzFLa8arikvdBG3g5nZrnRwqWpEblD4tkvVE7tda529grOVSL/5YlZW1lmaomOc1l7rvqqyeLgqshXeOl2y2Im6dLThNHWyvH4RUlaEZKpa5R7+R0G/63DtLmeQlk5UzAEIKFnnNoBGhBIyWOVo7LoSzL4XUSTxRa/CtRklJ6Bvq2rWSAg90DULC+bLgL26dkxc1Re30bXwlUMIptq5yp3S5qmsOp5bnh02+dsXp0tw5mzFNKxLfWyOUnPZ9K/KotWGeO02sy/3kmQPHM6qzn9s0/NJitxszWhM3nxzufrhGk50uSv7eK5t847kBj85X9Johj85TauParufzikBJprrkbJmircRgyUrNZjt2swRS0sodtNJKU1U1oa8YZzVFVWOta/kKYfCUwpNuL6jWroFmrRyw1fSJQt85IAqo6wopoNYCjaYV++x1EwptKGp3mL253cYYy//2l3e5N0qR0vEWzpclgRJ4QvLqfofv3BuTFs4462mE3NHMEViXef2Mcc8niZ+ZFIQQ14Eta+1fvef1bwLH1to7n/iKLr4N/GfAPwX+LvBPnnpvLIS4hNsb5x/1QRf9cCvY60aUxjBsOpzvk8NaVml6wGotiAfvmlMcz3JO5jmzrKQTBbyw0eBtY2lHHpfWEgeLoqYRODtIIaAR+Gy1AsYrx3z1PUWxThBK+QRSgPQcSUQIrIAkkDw3aFGbKaNFTlXXGOM2ucpAVVikeDcLNkInprXTjdhoRWxNUqZpTRgo/uD5IZ6Ee2cpSsGwFRF4kt1uzKqsmaYl07RmVeoP7XlPUseSBsc4fq9u+wfF2aJgmtYX3/MkOuvWUS928tjNwInS1Wu/hHJtiF4ZS78RUhtnbH5zu8W9sxWrQlPWbpM/mmU8Hq8otKXWBouDhQa+RHlQ1W4BCaARSJTySMsarMUKgVFO8FAgyCqNpxQbTYUQgmbgcbnf4GSRUxhDZTQtXxH4CqXgxnaL0bLk2rDmwXnKcxsNunFAJ/HZ7jj0yWjpXPaefoaeRDP0uDJMqLWl9ynq238ez8Z7fdK1sSyympOZ80ZYlW5T9DzFPK/Y68fcOV2yzDWbrZBHk4xAOTXSWV66w4Jy7OHdboznCR6NCxZ5QaAUxlPM0orKWGJPgRB40v3+08q1qy0exgqEFHjK0o0Duo2IjXbAwTRnpxsT+x7nq5KsdO3X7XZ84eF8uiy4ud2mGXn8+dtnzssl8tmMA64MG0zSCmvcXhF6kiv9BtambLWjZwiWSeCxKvT7fOA/SXxUpfDf4/yT3xvz9Xv//s9zUWvtD4QQuRDiL4AfAQ+FEP+VtfYfA/818H+s/+l/8VGfFShnkZmE6pmBSqAkg2aANu+ye7uxUzC01l6cnn0lOZ7nlLUz3Lk6TBBCOknswvkSNEO3we92Y6SUXB4kRJ4EIThb5ljjkAxKSAxcaCbNi9qR0SxklSAr51gcJR5hKStNZdz7noKydL0zX0E7DvE9yZ3TFaW2/Dtf3OX26ZJW5HE6z/ny5R7XBk1O5hm+LzhfVlgrCH3nGdsIfJqRembx/PRgytE0Y6cbs/VUEgjVB58mam04mGYXAoLPlHBPtUe2OxEIiD3F1Y0m90cL3jpeoCUMGxG+JylqzTwtOV3maG1RUrLVjphmmsArGS2cVlJZOZappyQbrZBZ5to0dS1oBDA3EPoQex6B79FtBGwLQalrzhYl2rjfbaUttbZstUJaie+EEIVgnJbYzHAwLhi2Qq5vNmiGPpe6MffPHcT2ha0W/9bNLTpP8Q+eLLBG4PGkIHg6IdTacL4qiXz1Gyei91F+CH/b4wlJcrMVMmwG1Npw/zxFCvjalR473RhjIPAy7p4t2O/FHC0cmqifBEgEmTZstQKwlp12g7N5Sekr8lI7+1y7VtANJYF0hNRSu0PcMqsJhKAVSchBYIkCD6UkvlIsM83ZIqcb+YDFl4J2FPDNFza4vtHAU4LzZcHlfoM3j5d4SuIr1xXY6kT84QtDtGENyfZoBD43tj1e2Gqy1Y6eqVC3OxGd2HeJ7ueUsPmopLBlrf3pe1+01v5UCHH157riu5/xj97z0j9ev/4T4Jsf93OEgMuD98MphRDsdp8VM/OUfB/ufLsTcamX8OB8ydmi5Oow4bm1q9P9czesakcelwcxJ/MMJSWbzYCsNCwLTVZpIk9RaEvkOWLZoBEyWZXEypWfWMvpXBN5FUno9I3yWtMIA4QEa1xVk0s3xFZKEvmC47mDi4aeJPQ9hq1ozQyuGS3dqagZBXzn/phVUbHdidhpDxk2A9JSX6gogiPf3D5ZrRFHGd+4PuDasOEqnw+Rhx6v3IwCHOJmoxlS1A67PVu3p4xx9pv1evB6ZZBw72xBqR2EthF5aGNY5JoXttooKRwRyFiOp4ZO5DFZ5kS+R+RBFbjTvbTwzReG/MkbJywKJ0dSaIm1klBJ56rVcD/PVjtmvHL3zZMQeIqyriiqmrSSfHN3wLI0bLUj0rLiJ49mjNMSYS373ZhLvYDAUxxMUtJS85XLvWcSwtMRB4qXdtrrluG7J7Gj2bvOci9sNT8VGZHP4+NF5Cu2OhGt2Ge7HTHNSvb7MRZLI3SSDpcHCULAfr/BaJFTW8tzgwbH85xpWjpggHCtynleEXqShvXohs533c3wKtJcsxQWT7gXnxTMylN4wEZTkRaOe9RLPI5mOauqJlwLTyohkIGiFXpO4gbLyaTgztmSx+OC65sN2lGLq/2YGstoWfFXt8/56uUeie8qn4Npxhf23o+O+zBU1ieNj0oKPwv987dSPnKWVe40mbyrIPrKTotlXlNrw6qoeXm3TVVbfvBwsm5tGLqxRzcJudRr8OX9Dv/61ojxw4nTY8f1qbWFQTNksxNQ6QazrEQWMFlWlFrTjJwZTmvt8OQrgTGWbitmvMyJfEkzVDRDhfIUpc7xBOy0Ezf0bgVYA6fLnMNpju+5oVheOblfbZzB+ONJ5pjRvmS//0ReV9GOPU4XrndprUPx/Cyf2zhQF6fiJHAKjNa6B/t86dA4gScvEkISOj7E42nO3dGKbuTRDCXNMKITB1gL+/2ERuhMQY6nGT96LFHA3XFK5CmysqTWko2Wx3hZcmXQoDaWsl5jxE3lWj+BQGDICs29c2eC1Aw8+s2Ar1zu8i9eO8H3PUBy62zJoBEyTUuu9BPSTVfFNUKPjXbIlUGDvW7Mn719yjQt0Q/GF3r6H7S5uwX37KJ7cp+EcCfKz+NXF3m1BnoUNYuiYtAIySvHLRBruPFWO2K0LPj9awO+++CcmzttjmcFSeg4J/O8RuuKci2znZcV5dwQBz4bTZ+idu3MRaERwmKtJvQlvhRYHFx1txPiKcXRPKed+DQin2boM14WTNKKOPQuRPsMhllW0U/cnjBeVbRjn7zW/MOvXGK0LPjnPzhgmdWIvjvkKukS0+mi4PEkvVB8NsbyYJzycLxyhlSRz42t5rMzrk8QH5UUvieE+E+ttf/L0y8KIf4T4Ps/1xV/jfG0RWetzcV03vcU+/2YN4/mRIFyJ9zAY7MVsQxqBg2f02VBErhTfnNt/9hvBheooMAXBEpRG8ODUUZVO3q5FAJjJUoJ4sCjEaq1H6xwjF2t0cYRYYSQbHdjnt9o8HCcUtaW6xtN9voRt0+XJKGiEztXt6LUbDQDer2YVqgIlKQZ+E6Ebo3ff3LKB4ez/qMXN/jKfpdSG5qR/5HG5+7haiHEu+0Ta52GSugLrm828JXkUi9mWdQMmyFZpdnvJ86HthHw3EaLrDLEgUczchaHnpRcHTY5WxR4SvLKXpsa1/Irq4BRWlIYuH+eEnmS59dWhKfznDePF5SVJqsNJ/OSZelUKn0luLHZ4wv7HbLKcrkfOba4EBzNCtLSsN8TPLfZWg/Vncz4Xi+hm/jrpK2oag9tLK8dzLmc17y43fpYvdndTrx+Ppz0wufxq4nDaXahjLrfTxivSjZbEXvdmDcOZ/zo0YReEvClfXeyfjhOiXzHAt5sBXRij+N5xqJwBlStyGejFbLXTVgUho1WwEY7ZLeX8J175xzPcrKqJvJ8Am8tF19pGnGAVJIv7XfYmEYU2sGlrw4SHk1SEIJW7KG1Q+SNljVZWeEpSa8R0E48FnlFGLTWLo8ll7oxVwYJl/oxrdiZbuWlxVdibarjQBCPJimHk4xlrqlqe+Ee9/Tc75PERyWF/xL4Z0KI/4h3k8DvAAHwH/xcV/w1xgdZdGal5miWURvLXte1oeRakuHKwHkeD5oh5nhOWdsLxuvXrvY4mWdU2p1WlYRZVpOVmko70xwloBX7DBKfvW5ErS2b7YBF7garZ8sSbQTSWpLQJ/YlX9zr8PJui1bk8+bRbD1Q9ZASJIJlVjvf11XBnZFYb0KKwAOlBFnloHfbnZjL/YTTec6q0Gx1QpLAuxB3yyvNPK8+UnL3vRtc6EuuDp30dVlbGqGT5e411mQ2AbudCCng1f0uu+t7mleaHz4Yk4Q+x/OMybLk7ZMFZa2RQrLXiVisIbf9ZsgbR1OKGmot+cMXhnz1cp+DaYbvKW6fzskqx8wWCMp1yy2rLPdGOceznGbocXUYEnmKw2lKO/a5PHDJqhM7tnQzckJonhRYK7ix2SLtadLCSRJb++zs5GeFlOI3bpbwWYh0XSGMliWhL3l13zU3RsuC00XB/VHKolnTS3wOpxlvHc9JAicdP2xGbHUivrTf5YePprz+eIavHG/gUi/h0TRjtx1xbavpDJeSgNa6ndQOHVN+0Aw4X5TMc0d8e3CeAZbH45ReErDVCvmdK32+/2BM7HuUWjJoOjhrI/BYFhWLrOZSx7WLfAn/6u0zKmPwPMGVQYMv7HYYrQouDxoMWyGt0COvNI/GGQcio9SGcVrQCDw22hG7negjD3w/K35mUrDWngB/IIT4I+AL65f/b2vtn/7cV/w1xLKoGS0KOrHPfj+mNvbCovNkvWkCDFsBkacuhtBP/lwWNaEn6Sc+pTaczHOuDhr8x9+4yr947ZgfPJowyyo6oU9tDaNV5SQXpOSl7TaXNxJGs4KjecH50hnRz6w7GUvPyVPMsvrCTvPlnTaVtizyinboU9aWXtMn8ASLrKYZ+ZS1wRp4+3RJM/AoKk3cDjmZFygpeX6jQVpp3jpyhj3b84gv73eJ1wviRw+njNOS59ZyDh83+o3AoRukWHs5uHjiXncyz+kmPje22hczHW0sP3485bXDBVJYIt/j1smcu6OUq4MGX9hr40nB64cz7o4WlKWl34zJippO4tOOPBZ5Ta8RsNuNqIxGa8iqmrTUzDJFJ/IIPElR12vxspp20mTYDNjtOQvFF7ebFJXmR4+nvHm0YKMZ8vxmybAVsshrsspwfaNBrxEyz2riQL3Plc6Zx9tfaNH9tsVHDbLv/7f/3i/t2judiEfjlGuDxDkYppVL+oGTdek1fDbbIQ/HKffHKQLBLC8Zn1dc7huMjdnpOJ2k5bBacx/c2vvm9SH3RiuOpwXjtEQqSaCke743mnhKMkkLpBWURjt2c1qi13yk++cpm+2Ib70wJK8NldYkvqIysNMJ2WzFRL7kJ+nMrSlPoIQiLyveOpnTbYR8/WqfSVoSKMlWJ0SJiGbk8c6xg9bXa0veJy3Qwaeg6PuxeArW2j8D/uwXvtqvKQ4mGeXaF/mV3fYzmPwkdFr8T6zs5nlF4Mlnhq/Hs5ysNMzzimboc7ZwwnU/PZjxcJLS8D3yyln4dUJFN/bZbIZcHSbc2HK8gdNFySJ3PW2L84Td7oSAYFXU5JUjm3kSaiOoa8t4VZGXmnbi8Td3z9loBjQDj/1ejLBwfbPp1CFD7wKp8L37U+ZZze3TFVeHjfUD6hQj88ptdLWxnC6cx/PBLOPF7dZF/3GyKi+IWx80gA49xfXN5vtef0IoCpSk0pY4cC2notaOEZ7VDBoB1jrD9IPpWlZYG1691MZXim/fPuNs7iTMdzohWDevuH2yZJRWnM0dH2KnHeMpBzlt+MpBhkOP3W7C/dGKrbalEfq8tNVCSMHRLKfWlu/dnzDLnM9tw1cO4SEFWWm4e7Yk9BQn85JmFDhE1XviCfcF4Oqw8Qyy6/P49UQj9Hhpp8290Yo0K0krzWhZsteN+erlPi9stsgqzcPzFcFU4nuCG8Mux1MnTBd5Em0ssa+4vtHgtYM5RWWwMbx2OCctNXdOF/hKOg6SceihKFB87UqPf/LX90E6qZxpWnLnLHUtIl+h1qi7R+MV58uc43nJy9tNrgwTdruOJ9WKPPKq5mheEnmSOBDcOcs5mOacryreOVnQS9xGf23j3Wfucj8hrVzLdrGGSH9alepn4qmOfUVZG+c89p6p/GYroh35SOHcwcCxdW88JeGQBMoZxidOh0Qby3jlStPRsuDBeIWwjnW81YmZZ86DWAnF/qDB4bSg2/Cx2As2cr8ZkBWanW5MpY3DIVvD168MiHzJqtJ01/pCJ/Oc42nG+bJgsxXyyl7n4nu3WwE/ejxjWRiuB84M6HSRc3e05KtXenx5v8cPH44Bp5r45Ti48Hg9XxVc6sbPDKSeMHLfew8+KjaaoWN2NgO6sY+/XmzffzDhbFnQDj2GrZDYd8zuk0XOQeGS8Z2zJZd6DeSaeIgAX0gybTjJnC+D5ymUgEbsX7ToOnHAsqi5sdVyc57Yd5pJvnPdutRvUGq9rgZrZlnJF/c6TFIfaQ2FsdwdpwS+YrX+zMmq/FDkhiMqvvv150nhNyO2OxGtSHH/PMUYSNbggMCTDJoh89zZ3fabAS/vtgh9xVY7wvMkN7eb3D5ZUdQag3BoOVvTSwLiQPH6wRyLWw+R58iuQsDxNOO7Bhqhj7FOsG5VGnqNgMRTBJ5gsqoBwZ3zFGsFq6LkreMFD8cZl4c52+2QF7fbCCRCuH3KSbqwbglLVnlNoBRniwIhIVIChGC/n9BJXCX+abctPxNP9X4/ZlC6Kf/bxwuakcfeU3DVYi2loKRzY4vXdpUHU0dyudSL6TeCtSaPG+LM84pmlDNNJVf7DR5PUpRSPDxf0Q49/EggBVwZNLi/dl/7g+cGCCH407dPmaxKFqWm1wjcoFpJdrvJGmEDndhj2AzoNXxOFwV7vQQB3Nxp8mic4itXbdwbr3hwntEIFUcLB63zlKAb+ywLN+zdaEXcO1tdIDOuDhu8ut+lqPUzMg3gFlJZOzngj4rRsmC0LOgnAZvt/5+9N4uRLMvTvH7n3P3abuZr7EtGRmZWVWYtWVXdPd3TrWkQm8TwAAhaICFeWARCAzyAhGA0PAFCLQ2IQUjwBDM8IBAzL2imgR7RU13VtWdl5Z6xePjubvvdl3N4OOaWEZERmZGZkRFRkf5JLkWYmbubH7v3v/+/z/+4/nVeMIpy6tqk09+93OXGUcQ0LTnXC0w24tp8eBizPUoJHJtraw26DdPAP5xnZEVNs2ux2fXZaPvcPE441wu5eRRxHJmSYFWbjebtcbr4myrOdQMarsXeUcrNowQp4eX1FoOWz+9ea/GLrTEHs8K83pasLvZSeg3noca+G7oLTQtN7zHqUpzis8FE3wkguDgIcSxJw3O4vt6i1vqekl9ZK7aGiQkMXYt24HJ5pUHomoXG4yjHd8xWskCx0vTZ7Ai+c6FHw7c50zFTaUfz3PTrAjO66jkWeVUb/rBasTM2vQSlNLlS/NalNX6xNWaeVZQLWdo4r/FtG9fBCHMJQZSV9Jue4U1aTPJZi2XX9bbH77ww4MPjhJWmx+1jcw/7tiH9u/oJQjlfBF8JpyAWjeO9aURRKUNFG5gZ4nlWLfmQoqyk6TsMGi5H85wkr0moF3VtUz9fa3u8tz/HseAvvbDKMMrYGaeklaKvDa2yZxvnkpY17+7N+YNrKxxu5EgpGcUFtiXISrP/cPPYLKtMUzPj/qObQ871Q5quw3pLEXo219baOFIQFyWd0KOoRtSaBXlWwErT6C6stjyqWlNrEz01FjzrF/ohR/Oclm/f0zi9v14OcHW1QVap5fd+Eg5npgR1MMs/xrMyS0t+cOOYO+PEaE6vNZkkJXuTlJ1JhmMJrq418W3JwTzng6OYlm9xfbNNP3QZRjlxXtNv+Xxjs03gOSSl4rXzHcZJycWVkINJSl7D/iylHdp0A4eDmVkiCxyJEBKUZrXpklWaTsPllc02V1ebDKOcotZ0Q4ffurrC23szoqzCsawlZ9YsK+kG7rLZbklxz+7HKZ4OpklJWpjd/2laLhmAznIAACAASURBVJdWbUt+zKDJxVgqQC90eGG1ge/eWxo+nOekRc1Gyyy+lcqI01xsenz7YpetUcI8KylqRdt3eHmjyWo7YJ6Z++/GUcKt45hKK6SAqysNxrEh1yxqU3Z+ca1BK+ji2RavbLYRAo6igsMo53ies9r2eWWzzdv7M3pNj25ogrfAdbg8aLAzSUnLknlmstRhXJDtTllteY/ERvBZ8JVwCidoB/ZSjq6ojLZqUZlNWlsa+T3PtogKUxqYJCWWFPdEzZPE1NyT3EzNfONsl7PdBuf7Ie/szQDBasvl9nHCvKj42daYd/bnixE4Dw1cHjRI85pzXZ+dWcbuOGGclNw4jhYcP4p4oe+w0THTMWKRxWwNY5q+jSUkg6bDmU5Iv+EyaHnYAoaxEdE40w2WzdBu6PK9y31jZD8l1bQtSfMRm6id0GG0oOy+H3vTlKwwJZ7QtTnfCwFNXmk8VxKlFcN5TqVZqJ+5VMpslUsh+M6lPklVE2eGWLDpSm4OE0OOV2sC1+b8oElSVOSlQghB6Nmc6QmizObVc11uDRNs28L3zPl5tsU4LnirnBG6Nr93bZWVk2330KGqjaqVVop/+P4xZaW4tNLg62c7j3Qep3gyaPo2R1GOQHxqCc+SgrWmx82jiHbgMklL+vKjseFO4LAzTgk9ix9vTczkmWeZhnRasdp08WzJatPnQk/Sb3l852KPrVFKv2HIJPenhsq6ETj4tiQuFC+u+8zSgqJW+LZkoxsyS0qurDb5w5fXuT2MYT9iFOWkVY1lWdwaxlxdbSKF4QG7MDAUGK7tLkg+A358c4xAkxQVgWNzPC9OncIXwVrLZ9DwDCmV0rh2gZQ25/shUsA8qxBCLKPDpm8M1EmNuaoVtTKG82AWY1smCr8wMF/fvthHK827BxFRVnG4XyBahj3TtgRxUXN9vUngGJ70pm+htGAcFay1BC3PwbYtPEvSH4SEjkXoWsRFyTiu2JumtDyzPf3KZpuW77De9bm2yGKKSpGUpuZ5v6F+VIGNz4Kz3YCNtv/AGryZCkkJXMnZnk/gSFZbPt8418GyBLePY4ra1GCvrDb5rcsev9yesD/NKX2FbUkGoc9mW3B7mBANE+YLkq9SKbq25MX1Bm/tRdyKY9al5Btn20gpsYTAtyUaTeg69BoOaaGwLQg8CzRYUrLR+Wg5bbNjSoSOlExTo7ZVK5YZ3CmeHYSuzcsbJtp+lAWteW4kNY/nOWWtWGv5rLRcNjsB5/shg4bLziTl9jAhK2uitIKuGWE/jnOurbdZa3qUC00DKQ119clwRSf0ODcwbMxn2iFpVTHLKi4MTDN5mhma+hfXW3R8l4NZxrnFTkXgGucjJGaEte3TDR0ceW//UwiBEIL1RUZe1iZT+jLGoL9STgE+osx2LMH1+8jiNu4LCO9eWsorM3lSVpozi9JM4NpLfYLl6y0Tybx8psv5QYMoq8jrepGJKH62NWHQcLm82mCWlXRCh+9d7jOcF7QXSzYt31nyM53rhby1O2WWGidkWZIzTRdbStba3j17Bq4tHzgZ9LhxNDe9hF5475TOSY9CCEE7cPnDl9c+dtNeWW2y0fFJ85qf3B4R5RVnuz6bnZCjyOhcb3YDznQDNjo+b2xPERIsJJO0XO5bjKKCoja0GvO8WqhLCa4uKEo+OJyjtNnbuDRoEmWGXn2zHTCKC0LX+ti28kk5reE5XFwJmSUVr3yGcd2nheed2+hB+Cx6KU3fZqPjk1dmKggwpIaL+10IMwFY1opu6PD1Mx0avm32ilouHxzGjNKKTmATeg7zxX3bwaFuKo7jnH6jxdW1Jo5lBizivGa1ZQKerFD37Pv4jkXbd/jda0Y1Lc4rqlrTWZAoPqisC4Y14UzXp1Ka1ab3mc7gs+Ar5xQ+L7LCNICtxXx+eyFME7oW7x/M8R2Lcz0zyXOxH5JVNY6UvHc4RylIioq/uDnCkgKtzUVSlJoLgxBLCv6ZV1v0Gp4Zj3NNM3tvmrIzSTnfCylrTcs346QbbZ/Lq82nNv1ytBhnPZob/iUhBHdGCZOkJHA/GlkdxgWj2Oxl3E1WGLo2oWvzzQs9tscJaanISjOyKoDVto9vS0LP5h97eZ2bx0Zo5Hf6A9bbZi7dlZLDmaELWG269Bve8sarlSYtFE3PXrDH+hzMMpqe80jCI64tee1cb6kXcYrfbKy1fFxLLoWn5lnJWtunVpqfb43ZGiV0AqPr3W86XBg00GiG84Ki1gyaLrPMLMhdW29xvt/i7b05Ak1aKr55vkc7sLm+0V7sJxjalQv9EK0NL1boGvqMolLLUe+srBdN8ke/jx/HHsKn4YlblYVAzr+++O/f1Fr/7fue/1MWYmXA33hWFuXagW3qzgvW1RNvfus4JiuNotmJUpeUgtC1maal0WNwJJNEsNkx2sQXV5q4liR0bYZxTi/0FhKf/tKwjeKCcWxKF54t6TfcJafOxZWQtKgZxwVrbe+hkcWXhW7oMFz0Ek6MZlyYWekoq7gzTLBtoy0NRgv6QZKAtdKGmlgZ8kFbmumQXuiwNUoRwmRL3dDl6upHXC7n+yHDuCAqSs60Q1abPg3PWipQWdJIEc6ycikm9HlKZ6cO4fnBybXR9OxlCeZ4nnNnlKKUZhQXvLTZYbXpGk2QQzMAMksrxklBVta8sNbkTDeg5dl0AjNiHhcZvvMRQ7MlP8pWT3B39n5SfdidpEYjwTbqcXdH/clCj7wbfj49hC+KpxFq/n2t9f8ghHCAHwJ/+wGv+UOtdfWAx58axGI2+H60F3Tcri3vMc5ZWS95lqRwONsLsaSk4VpsdgOGC5KsVmU+gqJS1FojF0RrnvNRuuktiO9O2BvlwtCCoWG4fxT0y8aZRS/h7gt5sx1wFBlB9MmyDm+efxiVxqBpxoRtKVDaZpZWOLZYluQmacU8MzrKgo+iJNuSfP1sh1tDc3Zrbe9jN8/nlSI8xVcHLd9eUF7Ay5vte7RHNjq+Ia7L9YLTygyfBI4hhjT6xyXfvzz4zPK/YOg5wNz3ldJGgwXTx7h5HKMUZmrpM+wKPS48caegtb61+Ge1+LofCvgTIcQ+8G9rrUdP6r19HvQbLm3f0PPeHVmejMJpbWirTyac8srMTZ/tmZX0OK84nOc0PfueHkbbd7i2biKME4P3tTOmCFrWCimNwtOTzhJOcP9N0AmNtOckKbgzShECrqw2lmn7g+DZ1pLKXGvD9DhPS7TL4kaD3XHKPCsX298fwXcsXtp49uv9p3i6NBifBM+x+Csvr1FUisCxTNZf1ZztBnQCh07gcDjLOJjlNFYbXFtrLjP5Lxp0nFQNGp51T79BCGFINNEPZdsdxQWTpGDQ9B5K8f5F8DR7Cv8m8H8+4PF/Xms9EkL8EfCfAP/+/S+4X6P5aeNBRs+1JVdWG2SlYpaWzLOKwyTFs03ZKFjUGBuezeWH1BQfljo6luTaWsuwnT5jW7XdBZ22FOIzpb5CCJK8BgTTpOTrZ9uMk3LJ9Fo/UJj1FKf4YnAWgjam12CutVFcLMuNa21/IfokHmsA9kn3/ZXVxlJO835orReLcpBX6W+WUxBCbAD/630P72ut/yUhxPeBfxr45+7/vrsyg/8D+Nce9LPv1mh+/fXXn1mFdNNQNXXGKDcfssBw7gePsBz2STDzy88mKVvofr7LqtdwOJ4XdBdaF4FjGalD/cXP6xSn+CT4joXvmEz+fkP7WRrBjwOebeE1H3y9CyEIFrQ7jc95n30avrS/Vmu9D/zB/Y8LIc4C/zXwz2qt6wc839ZazzDqa59XA/qZQidwaJ9pI4SgqEzI+6wa9KeJzY7pVZyU4QLX4vpGC3UfdcEpTvG4cSLD+pswcXZlpUFRK7wvyYY8jdrDfwqsA//74vD/KeA68B2t9f8I/D9CiBTIeEim8JuIkwvt1Bl8Mu6/IT+v+PgpTvF58Kw7BDD9PF9+eUHS02g0/xsPePgXiy+01q8/2Xd0ilOc4hSnOMFpGHaKU5ziFKdY4tQpnOIUpzjFKZY4dQqnOMUpTnGKJU6dwilOcYpTnGKJZ2vz6SuArKzZHpslthMCva8a0sKo2n2Vz+Cz4HlnQX1WN56/LIzjguMopxu6zyQVy2mm8IRxtFB5miQl8/yZond6YjiOPjqD6Ct6Bqf46mJvmpGViv1phtbP3u7tqVN4wmj5JjmzLbHkdv+q4YSaw7Y+GxXGKU7xPODEBjR9+5nMksWz6Kk+C1ZWVvSlS5ee9tv4XKi1pigVCMOE+jACrCeFW7du8STOMisVWmssKZ7rZb4ndZ5PA2WtqGqNEA/n6HrceJ7P82ngpz/9qdZaf+wG/I3vKVy6dImf/OQnT/ttfC4czjMOpjkAZ7r+ExHQ+CS8/vrrX/pZVrXi7b05AL4jufYUqIGfFJ7EeT4t3DiKiHPDUnNtvflEHMPzfJ5PA0KInz3o8d94p/BlY56VzLKKfug+dlK2QcNbiM4bfdavAmzLKKHNs+qBTbaqVhzOczxbPnUneYp7McsM2++g4XKmG3AwywgeIGt6it9snDqFT4BSmtvDBK2NjurjFryw5IOFe553DJreQw3+/ixbKs75jvXEGSpP8WDUSrO1uBfSouKFtdYTF3d6VvC8T0s9lYKuEOL7QogfCCH+TAjxx/c999eFEL8UQvypEOJjWgpPEkIYww1gP4KyUq001Rck/p8kBe8fzDmcZ1/o5zxNfJFzOCHAu/vsPyv2pikfHM6ZZ+Wnv/grirJWD5x8mSaluf5m915/8p574fntA53i6WUKt4G/orXOhBD/ixDiG1rrX931/H+gtf6Tp/TelhDC6K2mRU3T/+SjysqaDw4jAC6tND63+M3+LKOsNNk0Z6XhPVTmr1wY3WeNRTQraz48itD6853DetvHdyw8Wz5SWSIrazxbLqc48qrmeF4AcDDLP5c28/OOnXGyOBubq6v36gPvzzKKSpGVOYOmt3QEd98LrU+5F07xm42n8ukutBZOUAL36yr8F0KIMfAfaq1/8eTe2cfxqGI2cV5xEnjFefVQY2iW10wa3g0ceg33HuW2pmczrkoanvVQh5AUFTeOYgAuDsJnyvDFeYVSH/3705yCUprtcUpR15zrhfiO9chqUndGCZOkJHCtpTi6VpCVFZaUrPunPYm7MU1KSlXzq50paaFYb3tcGIR4d9Ewt3ybYVQQetbHMrXPIuxUVIo74wQpBOd7wUMlWU/x7OGpunwhxKvAqtb6rbse/pta678uhLgG/E/A7z3g+56IHOc0LcnL+p6I6WHoBA7zrEJp/YlN46N5ziQpuXEUc2EQsl7US51igHO9kLWWwhImG3hQJpAWNbXS1EovIrdnxyk86jmcICoqpqkp8xzN83t6LGlRI+WDdairWjFJCkCQFjVaayplRM89xxi0tbb/uf6GWmmGUY7vWrSfobP9IhhGObuTjCircC2Jso2I0f1ne6YbsNL0UFqhlP5EQfqqVsyzirwy1+Dd/Z9xUizkVc19NGh61EqjtT51EM84nppTEEL0gf8W+BfvfvxEjlNr/f7DFjsehxynUpqdSUqtNGe6wccioKys2RomAOSV4nw/ZJqW3B7GdAKHC/3wnsUT25Jcusu451WNLeXHnIljSd7fn3NzFFNrRfiQiaZ3DyKKSrHactnsBPfcnC3fYRRPKSrFRufzGb7HiYNZxiguGDRd1lr+PefwSahqhSUEtiWolb7HAI/igp1xitaaq2vNewxOnJf8+NaYWVriWpLNTsAwKtibZtw8jhg0PZqeTZJXJGVNN3A+kyHanaRMEuOontS45YNw4ugepUT4aWLuRaU4nGXYtmC97RN6Nme6H7929iYpb2xP0MDFQYPr6y2kNIqBUnykR66U5oOjiJvHMUpp1js+3zrfW17vDc9GiBww7//usuKzlt2e4l48FacghLCB/xlTHtq/77m21nomhFj5Mt/fLCuXN/5xlLPS9O656IUwX1qzNMhv7kw5nOUErlzWvmuluXkckZXGcXQCZ7l/YEkjMam1JvRslNa8uz/jIMoIbIudccpay+cvbgyRUjBoemx2PG4NE0ZxwSwtOY5yskpxdbW5fO9xXpGVprabV09f0f5onpOVNXWtWWsZQ1Mr46sflmHllenBKAVnuz7theHWWnM4z7k9jImzmsMoIyoqrm+0OJrnKGWM5Tgu2ZkkBLbFattjZ5KiNRSVZmsY0XQd3juYc2lhgDa7wdJYKqW5OYyZpSUXByH9hkdeGdqNlm9z4utProGnAa01Hx7FpEXNyiIweBiUUnxwOMe1LfJKYUuB0voew1sphWNLpDC9nkppylpzd3VvkhS8tTvj5nFC07fRaLKyRgBRXjGKC66tt3hh1Xz/PK2YxAW3RwmzrOLyoMGg6VFUCt+WvLTR4me3x7yxPaXfcO4qK5rMYn+aLQOb53mJ8TcNTytT+BeA7wL/5SLa/o+BP9Ja/7vAfyWE+DpmMuo/+rLegO9YCGGi1eMoZ2+a4tmmNm0anRaXVxpkZb0sg5zYN6XBWfwnLWvSwlztk6SgEzjEeY1Gc+M44cOjGEsIQk8yjAv2xyn7k5ykqFhte/xqe0w7cGk4FpOkZBRn5JUmyksqrWg7NsN5gSCi6dmstX0+PIrYm2ZsjxXXNz59TFZrM1ob5RWbnce/JJeXNXdGKWstF601SVFz8zimVppzvYBaaUqlWW95S6eblQqlYJoV7NxKGDRd+qFHy7fZGafcGSbcOI6RQmAhiLOSo6hko+1zvh9gSUCDY0vGsTHuu5OUpm+hlOQ4MpHzNClo+w5ZWbPe9tnsBmSVyQIniQkM/uD6KndGCWmhOJrnvLTeInCs5XXwNHBSGgSYZxWbnYe/9s445TgqUFqz2vD4B/sHBI7Fdy/16C8+a8+26IUuRa24cRSRV4pZWnFxENALXSqtkUCtFZbU+LakKBVv7c6YZxW+I/Admze2xhwtJuOO5+a+caUEbZYx06JmnJRICS3PZmdiXutYJkNRWtNvuMyykqO5WdyU0pRNnxV8UQLC3/SR1afVaP47wN+57+E/Xzz3ILnOxw7fMaLwHx5G7E1TZmnFpZUGaVEvywUNz16WLZTS9EMXS8Dl1RbWwrjZAhwLlBb0G8Z5rLc95ot+hGtZbE8S4rxikhSMkoKNtk8zsPBtySQpsS2L9w/mvHymw1Ek8G2bvKxZa7vM04pCFdRKcafSNDyLg3lGWStans1xVND0HEqlyIqa5uIxxxbL6LKsNfPMEM+NFyWGx4lO6HDVklRKc2eUUFRqOde+P0uxLcla0ycpKtq+QzdwqGtFWpqG+eE0R6N5Ya3JtfUWRVWTVoq27zBNS4Zxzv48Y5YWbI0iXt68zO+/uMYbOxPGUUHoStKypt/w2B7HzLOSZiDxbI9pWjPLS97anTFJS1ZbHsEiIJDSXAdlbcTay1rh2gLLEk99cc62JKstj3lWLrOvhyErFWe7AZUyY6ZxXnE4y7jQD2gFDlKY/opnS24cx4zjku1JQuDY3BxqDmcFTd8mK2sO5wW1Aq00N0cxu7OM8/2QVS/kzjgmrxTjtKDl2xSlCQCans3+LGWeNtgams+/E7g0XZt2YJMWFZtdnwv9j8qKGr3MxE+X354tfKVnyxxLYluSTuBS1ppO4Dx08uUoyilqTeA6uAuHcPM44kc3R4SOxfcuD5bpum+byaGNTkBaVlxebbA3SRknBYFjmpdSCrSGoGWaoh3fIctrLM/GDyWVqslKBQjqWvPjWyNsS+I40PUd8qaiqBVlpXjvYL7kTbpVxgSO+Vgbnk3bd3BtSTuwmWcV/cbjN3brbZ/Dec4oKpimlSlVWALHlnQDm1FcUivFwbQgKxRbwxjfsUnLGkcKHBvyCjxH4tmSTAr6DRvPlvSbDrXS/Gp7ynGUg4A3dyd879KAvKxJypq80si85jjKeGN7wqDhc34QcG015GCaszNJafk2Hd8hLU3p4jsXe8uxTNeWCCAuKkLPe2ZIyjY6/iP1jM72AoZRvujJaN7em9MJHCZJyTt7cywpuLrWoLW4FjqhQ16bbfoorZAYcra8qrEFfHAY80YxMdefhkHoI7sajck4KgWDZoBWCqS5j7Q2AcH2NKVSmutrLVxb4NsWyWIiTWu9PFvPtnhxvUWt9GNnCjjFF8NX2ikAXOiHjJOC6xutT9yetaVAo3l3f86vd6e8sNZkb5JxOM0JXcmNowjfMaR2lhAIAW3fYaPjc64X8OudKTeOY2zbot/06AQWQljsjhOkgNC3OE4yAq9BWSqajsXWOCHOay4OGviOhS0Fh9OMvNYkecVa22Nr8f3rbR/XsggdC42phbt3NSgfdftUa1Nr/iw13hNjI4Eor3FtyfX1FhudgCiruLbewpKSOyMzipuXit1pxCguWGuZpvDV1Qa+a/P+wZw3d2dUteLVc116gc3b+xGeLSlrjS0F7+1HXFtrcWeU8P5hxLluwF/95hm2hjGVgklWcFmEeJZkmOSstV3agUM7cMjLGs+2aPkOLd/0fz44NO+l7TuUj9CjqZXmYJZhf4EJp8eJpmffM/r7W5cHZJXiKM6YT0ravkOUeXR8h37DJS1qKuXy650J07TCmUnOdUOurDb48w+OGcc5tiUoakXLd8jrkp9ujalrjSMlV9abfP9yjzvjFN+xGCUlFwYB7+7PcS0LiaLh2ZRKU9SKSsGdcUIvdOmEJnCaZyUanpvprucJz7VTmKYlVa3oN9yHRn+ubZrGn4ZB00OjeX9/jm1bbI9TNto+wzg3ZY1xwtYwIXAtrqw22eyY5mdWmsmPvFK8uNbi9iih1oq8kkzTFMuCWVqZue5RSllprqw2KCrN0axgpeXRCWz2ZilRpsjqCpAUlWKl6TPNcgLHwbMlmx2fXuiSV+pzM5CeNDcHTcNv8yiYJAV3RikazVrLoxua3YuVpsfKXWUYb63JPC0ZxTmTuDQlHAH78xyBpum7HMwyLAFRWbM7Sfj1Tsk0LShrjSUh9Cw2u4H5HVLgOaZstTvLOd9vYFuStKiQUvD+kTFSlpRstAOivCIpaoZxyfUNE6WeEBKmZcUwqumGDnlVf2Iv4WieM4zMgpxnW0tD92WhVppbQ9OjOd8LHxpZV5XiF9tjagWuJbh5GPPmjmnyFqomLzWDpkdSVgS2TVUbJ77asnhrd8J7hxG708xMJnU8rqw2saTgYJZxNCu4NYoIPZur601uHie4tmSl5eM4kvO9kKZrszVKScuKb57r0AwchvOCrKipa7VcuJym5XKy73zffJaneHbw3DqFKK+WF16t9GOJ6AYNj6trTbZGCVdWm5zrBjQ8i0lacus45mie0/BsBk2X0JVsj1MmccnBNONsL+BonrPedlG1icgPZ6YcomrNixsNxkmJJSRCCxxbU2uFRnO+Hy6iOxjGGdOkJK80lVK0XBcEhK69rIPfbzSOo5xxXNBvuJ9aK7+7ufkoKCrF/ixDaY0UgsCxH1oj9h2LKKuoak0nsAk8m7d2pkyzgp/fmfBbV/poZbKeCwOTwSWlKaPZluRCP6QduFzoBeyOU1qBSzcouTBo0PJNtLzadjmc5uxOM6ZpweXVBv3Q5f3DOe/vR1xYCbm2WHSTAgJXkhamP9MPzdkk+Sc7Bcf6KMBw7C+/1DTPyuXM/ygpOOs+2FnfGsXcGWVoNGlRsTNJF4GB4N39CKXNeHWv4RC4Ft++2GVrnHIwyXjnYM7N4xitBZtdj999YQXbkuS14mzX42dbU3y3zTSpOJ7nKK0YNH3e2ZsjgOOowHME622PSyv9paG/vtnCtSVb45gf3hzy/cuDeybSKvWbTd3/POK5dQp387o8ymV3d70TzMjqzjglcCwu9IPFdIep3zq2pO07HM5zfnhjSF7VvLDWwrYE87Tizjjm7d0ZHx5FZJXi971VuoFD4EiOZgVZZaKmOC9p+zbdhovnWLy02SJ0LHxX8oMPh+Sl4oXVJpdXGniO5Bd3Jpzr+fQCm1mmaPs25wcNBNwT1StljIJlGaoIo/BkFJ8+zSmstz2m6ac3N8E42w8OI4ZRziQtuLraZBTnFLVitWWWlaRgea5ZWbM3TVEaeg2XiysN7gxjJknBOM55c3tKNzSPv7Te4sOjmMNZztmejy0Fo6TCdyS3Rwnb45TDWUboWkzTgmGUc+MoInRtbCkQUrPZ83lpo8X2KOXN7SnTrMRzJN84a0Z56tosqSVFzdfOtJmmFZYUn0rjMGh6uLbElvKJ1MND18axBVWtaT/kvVW1CSDMRnLOatOnUib7PN8LsKTAtiS705Re6CAEfHAUIYXkhfUmah927Zx+w+Kb57u8uWu4o5JCsdn1efVch8O5ybwHTZf9SUZS1EySnLKCvVmCJczEVi906YYub+9N+UfvH5tRYq1peDa+LXntfJf1jmf6FY3TLOFZw3PrFFq+WTArlfrEC08pzY3jiLRQnO0F9BsutdIcTjOqWjOvK/ZnGcOoRGnNJC3ohx6TpORHN4/5s/ePkRJ6vo2QZqolzhS7E7N4lVc1v96ZUCvN7WHMrWFMM3BI8hLHkvzo5ogXN1p860KfV892+eX2lLd3Zvzi9pjAs1lteShtSMjWmwF705S8gnbg0FhM8tydBWmteedgxvsHZoT1tfNdWr7NLK0eqX671vYfOatSWlNUahElSg7nOYOGR7SIag9mGZYUvLDWXDQjAQS+I9meJIzjknZgs95ysa02e1Ozk5AUFbPE1Jz7DZujeUlWKTxLEhc1fa14Y3vCwSxjteVSa81Pb4+IsorvXRlwrhOwPUrYGacczzKavs0oKYiyit++4i+Xwd7cm/KLrSkNz6bfcHntfO+R/m7giS5fubbkpY32xwKXE0yTkh/eHJLkFRcHId+80OGDg5j9meS3r64wS0t8R/LG9hRLSt4/jOhHOW/vzZmmJd863+P6Zotuw+ZolvN3f7lHVtbkVU0ncLhxFKOn5gAAIABJREFUPGMY5fzla2uU2uyj1Bre2p0xTSuS3JT3Bk2Pc70QjQmqfnZrws+2JpRVTV4rOr5DrTXzvOKljTYvb7af2Bme4tHx3DoF4JFqvXml7tkzCF2LD48iZmmJFIJB06WqNVvDmKwy46pVrbnQD02EmxQINO8czrkyaHM4y5gmBYFnI6SkrGqivOYHHx4TupJRUjBNSgYNm91phiUlt4cJf/7BMV/fvIJrCyZJQaUgK2rGcU5ZKXzHYnsc89OtMYPA4VuXegSORVxUhm9Ia6Zxzs1Rwo3DmNC1yaQiLUyj+mGUGV8EzqKkM07yxZZ1zs3jiJWmZ6ad0opxUlDVNY5lcaYbmHNLC7SCN7YnlEpxpuMTujYvb7Q4mOVkZcmfvncAwGtn2mSlounbzLKKrjA/t6hqoqwiLSrqusa2HIraTCkN5znvHM7xLIufb8347qUu5/shSteLjM+MbkZZhUZzHOfcPI754DDia2faXF5pMooLbEuw+ggZ05PCNC0pavUxosRZWrI/TdmbZtRK8bWzHTxHMmg4JEVtpsBCD4Gm1jVxXvHKRos/++CYutYIYLPjE2clvxhPGMUFeVkROJKbRzEKzdYo4a3dMS9tdtjshLyw1uAokqRVyQdHMUobTq71jsc0LaiUKVM1PIvKEvRsi0HD5WiWYwnBPC050/XpBA8P2IrK6Bh7zqP1/U7xePBcO4UHIStrlNaErvnTfUeahbOiInAsfr41ZhgVnO0FrLc9+g2PP3v/mElaMM8qvn9lgBSCsjKG7lw3ZJaVCCT7M8M+mVc1k6zi2+e7RHnFrWECWtP0LVqezSQt8RyLtQYcYxzTJC35f989YqXl0mmYMUmtNaWCv/vLHYpa8YutMXvjlNuWJFeKb53vs97x2Z9m7E4y04ysTQnBcyQXB+FSyObLYlPtN12+e6nPNDWZT1EpXFviOZKf3xlRKc2vdiZcW2uxP8v47asDAtdinBbERclKw8O2BK+e6xC4kvcP5vzwwxFZaXhyjuOChu+yt+DtmcY5UaHYm2SkZcVGJ+CF9S6TpMC3JbVSvLsfoYWmVoqLgwAF2BImiWYYJez88A6DlkutFOd7DXxb8JPbE6LcjNMWlWJ3mpEWilfPdbi61vzUc0iKit2JEZ05e1cp784ooVKasw+gUvksiPKKO6MUMGW7uzecV9seaVGjlCYpFQdTQ1WR5DUvrDd57VyHrVHKq2d7/KMPj+n5LnfGCettn6NZRuhKotw48O1JSlWVxEXNNDXUFsdxhSsFSV5zFBWstQI8e4NLg5CyVuyNM4QQWNLinb05b+3OubzS4C9fW6MdOBzNcrLaZB3TtGQUF0RFze3jhFfO2A+kIKmV5r2DOUVlgplTXY0nh6/USafFR/wrJ6UiIQQXBmabcneSYkkMxUJRcXWlwY2jiO1xQsO1WW/bhK6hEigV9BsuL240uDNMmWYF80wwzyr2pinnegGl0lwdNLgziikqhdYKpY1j2pmmvHauy0pLUSmFLS1+sjXClZKbwwjHEgznJVFW8OvdKd3Q484oZXeSYktBqTVowUubLW4cx7yzN8V3HJquafSe64W8vNnGkoLtccI0LfEdi8CxWFnUxD8rqlqxN82olFoYOYuqVmyNDIdUpdRCGMcyvZNSMctKtDZb4Cdc/TujBNeS2EIwzyuEFPzo5hC00a1ueoaps0IT5yXbk5TVls8kzbm9nVCUCtsWCATjqODWccRa06Pt27x7EFHVNa+c7fD711bIKo1jQ61ge5yyM86YZYY+xJICS0he3mhyaxibHQZP0vJsxklFw7OJ83sb7ie9qvvLOAeznLSoSYuaXugQuja10ksqlWGcfyJVxafhbraQu7W8a6XJK8Xrl/rcGaWEnsX7h3OmSclxXNBrOBzMCs73Q947mHN7lPDhkbm+OqHLLCn5h+8e0vAc3jmYE2Ulw6hACEFWKkJL49gS3xakeUlWVUyTkvWmx+9eX2O97fPKZodWYCPRvL0/ZXuccxhlvLDWoFJmEa/jWDQ9i9Wmxy0Zs9b0mKQFh7OMzW7wsfO8PYwZxjnTpOTySuOe8epTfLl4bp3CCYdOWSs22j62JSlqtaS3zqv72bqhGzr85FaBFBKB4Gd3JriWacTVSpu5+dBlf5pxNM8JFkbWtQRZbraNlVZ0QxfHsnjtXIdxmvP/fSAoCkXlCI7jEqU0ldZ8cBjzykYLBOxOs0XzNKeoamxL0AkdJIKirLl1ZMYBe6HZWD6cpBy0Pc70fG4eRgzjCkfWXLjQ40wvIHAttNbUCsZxSVkrbh7FXBw0KCr1yKR1d+Nwbpq5o7jkcJ7z7Qu9JVsrQL9hShRv782J84p+w6UV2Jzr+Hi2xe1hQlrW7E9TorwiKmvWfZsbRxGzxYSNZUkGocPl1QbtwObDo5hKG6M7Tyvz+wCpNAiNbZmyyiyrmKUFriXphQ7fu9TnTDfkR7dG/OCDYzbaHr9/fY0rKw1mScXfe3OXolT0ApthyzHnUtesdwM6oUcrcOiFHud6HxnyvKr58DBGo7m80lhmm2B2BaKswrHFcnJJLvZVtOae134ehK7NpZWQstb07iqL3jw2I8QNz+Z3Xhjw41tDfvThiL1JzmGcM4pyHEviyg7TRamzKGvyynAQRXnF0VzQCm2irFwKJJkdA03DtXl5tUFW1cwzw39U1Yp3jyLW2j5XVpu8er7D3tSMTKe52U0Itc3No5jzvZBRlOO5ktA1We3V1RZpWWMJwTAucReBynFkHOta2wwp9EOPhmdzba31XHEjPes0GM+tU5illRn5xJCybXYC2r5p3Ja1YvW+KZy8Mvw9Tc9iteWamfbc4rioubTS4OXNNlII3tufYUnDZXQcFRzOCiZpyeE8I8prhNCsNHxWWg43hwkfHMwMdYID87xEArZl+HyOo4Jf7kwX26cV+7OUtKjxLIFlSRwLolzRDCS+o3Ech6xURIVCSrPM1Q89NnsBSanoBA7negGOZXYUDub5kv47rxVFVRMXFd3POVfvO9aSgM9a0EKErs1m1yfJa3oNh59vmU1YKSBwLDq2w4WVBmUNb+9HHMwjsrIm8GwC22aWlUtCQa3hbDfAdyTd0GyXn+nWbA1jY2gciZQWlqrxHImDIC8q9isNaJQW+I6i5dv86XuH/Hpvyt4kY5JWWMJkTK9fGnCmK/jpnRE3jmLuTJKFE5X4WlJVmqN5zm9fHXysjh1l1dIBvncQYQlBv+lythuw2jLspLYUy3q/EPDSRguleSxG7f7mdlbW3BklOLZEK83OJOHNnZnpZSmFqjXTtOS9/Rm+Y3EwL2h6NtOkRGCa1krVZEpTzGscS1JqzUrLYxSb2r/vOlxbb3F1tcn/9tNthC5IippxlPP2/pS4rGj4Do4Q7E5TSq3ohy7Oolf26905vi159UKHvWlGVlYgBK+d7zBNTBZmS0N/vjNO2ZmkOPuC6+stPEfSbzTwTzeenyieW6fg2nIZpZ2knkKIh9IGnCyQrbQ8zvYCJnG5aAQLLg0aNDybn9wa8X/9eo/9Sca1jQZFBaMk52CWI4UmLQrSShPlNZXWrDR9XNei1pAVaiHpqdno+TgIpplilhZIAVvDhKio8C1BXoMtNbYwJGLb44Rew+GFlSavnOnyk1sjqqrm6lqLF9ZbfPNilz9955CjKGdaVFzbbONZkr1Jyp2RGUE0VMhNylrdE/1+FvQbLq9f6jGMiiUdSF7VZkGtabKztm/x3n6GxlArDBoeDdfBtsyi2Tgx5HgrrsVY50ziAq0N+Vvbt+mGDtfX23QaLr4l2Z+amnyW1yg0g9CmVNbCOVaUlaIbSmzbxncEw3mOpGCWzfgnXlk3jLJFyXZe8f5hxIV+g59tTTicFwuOHgfHttjsWgwCj3lec6brU9aKDw4jeqGzHONtBw7jxEyhRVmFZQnGcbHsITzI8H+Z2gG7k5SGa3iHJnHBzVHM8TynKCsCz6GrNFpppDREd7aEK6tN2qFjSp6L3pYsNa5j4dqCr53pMIxzKqWIchOguJZc9GwEoWeRxYpRUvDhUcw0rXjlTJusrKlqzSD0CD0Lz7HYHiXsz3NCx0LuGAZbgZlYu7ra4NJKuNxqLmvDl5WXCqUEb+3NONcLWW2eNpifNJ5bp3CixlUr/UhNqpZvcxwJQHBx0KDhZuS1wrMlriOZZyV3Rglv7cwolBnDvLoSsHWcMC9M3TyrICuMc1hpumRlzfW1Nr+6M6VSiqxUeLZNWWq6bRfb1sRFRV7WNH2LvK5BCqy6plIWhRJ0QhvfaVAqCDybr222uXU459aoZDzP2RknbHR82r6La1k0PYfLKw2avs07+zMqVTNO9IK3SdJvfjFun37DNN+HUc6HhzFCsGSW3R6nlLVmoxNwrhcwSkqKSjFLSwTQcCVnuj4H05xJWlIoTVZrysrwTjmWIClrZkXFMCn49e6MtCgpiprDqKReRKGqNplGWlb4rkVeK2yrIrA9Gp5DjUKgkBZcXWuQFgohDZvr3/vVDlFWEWU1l1ZCzvZCAlsiLGM4LwwCNto+b+5OsYQkbXtLp+BYcqnwdjDLGEZGQ+JuaK3voVv/MmEJQa01SkNUGgfZ8Gx6oYslJZ5lOJ0OZgVH8yNmacVGx6Pj2kx8i4YjKRaUHYErcW0L0JR1Tct10FrgWIK/uDniKMoRGFU7rQ2hXVnXlAuW4cC1uLLS5Cg2QklSSJQyo6v2ondjS8WdccooKZnnij/6/nnOdMPl2X7tTJvAlRzNCywpOF6UaB+l0X+Kx4dHdgpCiFUArfXRl/d2Hi8+C/ui71jLuemqVswWpYJB08WzJe/tz0mrmrbvMM9M+v3m7pxhlKOBhmtzYRCahmVhmCsHDZfQM5M4amH8ssJQOszSkobn4tvQabpklaYdOHiWJMpKsyAXSHxHMk8rXlhv8uJGi4Npxq92piRFRVlrXtxoczQvuD2MSauKb5ztLpXivnamg2MJdsc5VVYS5TUvrj2eZaFsUUbSGoraNJijvDKRpzTTMi9ttIjzinlm2FBtKSmqmm9d6IKGH98aMo5zzvYaSAlHC7GereOYSmmKqjYLUlFGWipqDVF+wnTqMAgcDuY5eWkavFmVgtJoYbHWsOj6DtNUUKoaS0n2Zhnz1FBgrDc9XjvXoxM6bI9TlIJr6x7X1ltsDWOitCKpFKttz9BaxDn90F3ucKy3/Y+Vl4pK8eFRRK00FwdfPhV0XtVmzLRWtH2XKKixJdw6jheBjWBvmjOc58SFKSG2ApuG53Cu32BrFOMAnQVZYl4pyrpmnhZsjzOEgCRfBDuVQitoeJK2J6k1tAMX15Y0PYcLg8CIGdmSeVbTCSRneyHfutBdsAFX3Dg2DAPTpCQrK3Ym2dIpAHiOxcubHRpezM+3JthCEOUVs6w85Uh6gvhEpyBMSPmfAf8ORt9ACCEq4L/RWv+NL/KLhRB/DLwO/Exr/e/d9fjXgf8eEMC/pbV+44v8ns+CE7nApKypFaw0PTzbQiD44DDi/f05r1/uM01y3t6L2J8V2NIY/YZnYS3oJiw0aVnxgxvHhI7FJCoRQlOrmqKCYVwQ5YKe0iSFopdWrLRcXlpvktaKoqwpK0VSKt7Zn9Nvemx2fC71Q/7ig6PFMldNJ6xJiopmYCaOxmnJreOEm8cRZ7uGI+dct8EkroiLCikwy1+P4azWWh5qoQp2csNudnxuHEXY0hiKcVLQ9hwSWePagpbn4TkWWaX4+daY46ggLo36XNOV7GnF4SRnFhe8drHL0Swnryui0kxtGZqGmr1Zznob1ls+6y2P/XnOrWFCVRlNgNWWjbAke9OMWV4xaPrYAmoNrrCY5gXXN1sMmg7b4wzXkkR1hSMFaV4zSkp2JimrLY+GKzmYmY3ww3n+iYt9SWEoPODRaUK+CEqlzeeelKRljW8LhNBcWmmQlWa0VrMw6Nps0W+PEy72fY4is4S2O03J8opKK9JcUWpNXZtms+tI8spsfteLuQylNFfOtMz1WZjrVAEX+qbvtjtJ+YubI8ZJjm1JamXez8WVJn/5+hrvHcz5+ZYZ4AgW02t3l9jSomaaVPiOxWwh02o9I6y1XxV8Wqbw14C/BHxXa30TQAhxBfhbQoi/prX+48/zS4UQ3waaWuvfE0L8LSHEd7XWP148/Z8D/zKggP8O+Kuf53c8DGWtEHy81nu3XOD5nuE0uj1MUFoxinPe3Z8hhUlpXznTJikU07TAsyWD0EULwSwtWW8J9iaavDB6Am3fJXAkpYJKGcMktEYjqSqFJ833jdOcJK/oN10saeG7FgpBqTQWsDVKeO8w4ke3xoSepOXbvHauy5l+yKDhAIKkrLCk5ic3R6RnDdXERsfnu5d7/Gp7SlIYXeONzkdbvVtDM6663n50Sm0z1WQEdO4uRfmOhWNZFLViZ5JwcdDgTC9glpV4liQpzVTVr7Zn3B4mHM4y8rrG6wa4tku5MGQpwgjsSEGVm89KaEGtFY4UZGXNLK2pypRXz3UJnYKVhsthlCO0Ji8UXluwN0tBmAjeDxxeXm1ye5Rgx/DG9oyjqOCFtRaDpsvXmx2kFNw4jhBasdb2ubgog3RDI+TzMFr1Exid4sJMznzJ9A1ZWXOuF/Lu3oyirtkeG4K6g2lKYNustD36DYcoL/nGuS53hhFeXlPUijd35qy1PXxbUBQVUWEcimVL0rxCK4VtCWxp+nIdXzJd9FB8y2KtFTCKc7OBnmccRTllVXGh67M3ydidpMzzElcKDqc5kyTn966tgYDvXOxxoR/y/mGE0ppbw4RLA9NbcCyJa0vUosfUdG0C53RH4Unj0077XwX+ca318ckDWusbQoh/Bfj7wOdyCsBvAf9g8e8/AX4bOHEKPa31HQAhRPez/NBJYhbMVlveA0tHUV5x6zgG4MrqRyOF47jgw6OIpDAqa2mpGDQ9ZmnFOC6YpEZ4xLGNMT7XC7ClYLPrczDLKauaX+/OGDRcylqauugsJylL0NAJJFKKZbQrhOHXWWt7oAW3RwlJVvJ+XuMOjQZBt+HjuxZ1VZOVFj+7NSYtK7Qw/ZKWbyOAcZzTcm3+ya9t8H+/dfD/t/emMZZcaXrec2KPuHHXvDf3ylpIVpHFpTfOZkyPp2dasDwGJBkeATP6I1mGW+MNFmwY3mHAgH4YsLxBBuQGBMiW3e4xbGhsA8ZYGrVmpjXqcYPd7Cab7G6SVWRVZVZVrnePPeL4x4m8zNpY1Uxm3lriARJZdSsz76kvI+Kc853ve1+u7k240Q/JJFxeqbPcdHBMg6WGyzBMZ4fvoHZGw3I1dhAkjxTjopD84MaAIMlZaTl32ITmhapwilM1YS7WbSZxxrWDKVd2pjRcEwqVg76+P2EQZLQ8g1GQ0bRzbMNAEzm6AXlWoIuCJM8xNEHbNymk6gPRRE6e50gDvnd9n4ZjkWQ5WZqTFBJNz9keRYyjnLqj0/KUd7RnKV9ileJT7njP93xeXWsSlQ56u5OY/iRFIunUlGyDZWisNOUDrUUP0TXBhd7J5793xzG3hxGGLpgkGWFaMAlT6qUfSLtm0/KUZIWmCYIk5Vy3xg9uDAjjnIEA01RudoMgJS0kWaFW7oaQSFPD0nVWGiYHQYFhaLzc9hhGGVIW7Ewj0kwyTXLSoqBf2nj+L9+9QbtmcWV3QppJdK3A1GOGQUzHt7m82pxd+75tIIQgSDLe3hoyClMuLtXJCiXbrqrQdNxjlvJW/Ow8LOLm0QnhECnlrhDiOEm+FnC1/PMQePnIvx1dwj/yvjHNi1nHZ5Lf6Wl8SJBkswfiNM5nk8KtYYQuBJMoY63l0KlZXNufcqM/JSsPThdqNnvjiFujmDevD7i8qkpUr+xM2TyYEiYZe0VBq2bRdC2CpKCQOXGeM44lnqERaAJDk1im0gHamyY4uk6eS+ICirjA1AvSXBImylMXIdkdJyBUauBit85SR8lFJJlaWX/3o31uHAR4ls6l5SbvbY8xSgG0Q1ZbDqauVtlRpjwPdE2VVA6D9A6J60/i9jDkve0Rhqa+/0K3hijLPb93rQ9SMo0yNATb4xhTn2AINVFqGoSpJEpyhNBoOAaOoXOm4zFOUsZxStMSFKgJaxKrMlUpRCmiZ2JqAomFqStTnHGUkxYp0zgnK6UPwzTnIIC8EFiGYLFhqwkqSrg9jBhHKXkOKw2HtmcSZwUCwTBUq/yGa5IX6nD6sKLocEIoCsn2WKWTlhvOqRwoH2VvEvPDG31AVaaZmmDBs5iUhjzDIKVVU+KLwyDHNg3SouDFlRaygB/dHrE7VmJ2cZKpg/68QMYFmZWrcmvLxDN1dsYpDddC1wSpBM/UGMeSrYMpTcdm0TfZD3LCNGMQZHywM+FM20FogoanUzd1BnHG7iThh9eH/NzZCb5jsl9ahypRyIzdcYyuaXz/Wp+1jqdKfWsmdddk4QRMoY5rt/m087BJ4ZOWj4+2tLw/Q+BQDasBDI7821FR0/s6ngghvgZ8DWBjYwNQjUK6JsgL+cDux45nEcQ5QkCYZHywk7DcdPFtnau7E3IpubIz4fp+QI4yptGFYLXlUkjJdz/KyIuIMM159+aItmdxbsHl3VtD9qcxAo2llst628CzdTb3lQvVNMkxhGC946JJiWsrc5c4galMAFU2qCkjK0wNhAb9KENHYmgSUwfXMlhsufzZl5cQQuP6vjo/uHEwpR8kPN+rcWGxwaVln/W2d0c/glHaZU7inEkccHHZx9A0Wq7JatN55IqkrUFEXsAkSfmFI+mjWwN1WJtkknGccHMQEaQZPd/GNARnWh7dus31/pS6o1OzDSwNLi03EJrg+v4ETYMghYajM4lzdcYDZLkkSFSvQc02ibIM29BJCw3XAknBWtOmH6pcvmMI5dUMNF1VM//e7RGDSJ0bnO/67E9iRknG+7tjarbJJM4IkxzTUBU3ETCYpvSnCe0jqaB+kLA3Vpe+WVpmnib7k4SWZ7E3iRGapGabbCx4LLfU7zAqvSTiNGeaqEPvL57pUHd1zvU8bo4islw5rh0ECUWh0qm6ARJBlhdMo4RhCJaAIQLf0rkdp4zDRF2fZX+JY+j0aoIw1Ugl+JaKR7duc3ahxoJv86dX9nj31pSdccSb1wd86dzHooOaEDRd1QzqOzptzywPLpUw42mKDlZ8zMMmhc8JIUb3eV0Axykg/g7w14D/Dfgq8HeP/NuBEGIdNSHc772RUn4d+DrA66+/LoGZGmeU5dQfkIPMpSTK8llNtW3o7IyUsXiU5qrbNslZrDu4lipD7fkONUvnwz1VkSJQukmLvkVSQN22ONN2iVP1c5M0x3QNNMAyVCdzkYPh6MpvwNaZxhnTJEcXYOo6UhO4hk4ucyzDmJVnSqlW9A1Hib3ZhiDO1KHra2sN9kqjl9uDGM1QN+zllRaaZzGOUuypjiFCeg37Du2jOMt568aAq3tTer7DhV7tkTuc667Bha6PrnNHv8OZtsfeJKHpGAwjVVI4CjOVLkMQpkoOQ62uNZabDkGU4dgG4yAFTZDmAMr3F9Rh9iBMmMZK12dcCtipvg/1+zJ0vRR6K1jwXRZ8ySTOWGq4pTSJxYf7AQfTBNfU2Oi41BwLgUQXglGYM4xSDE3jvZ0xhq7x+fUmFxfUmiVMc45qpx7tRZhHl227pmr6L680ifOcW/2Aumuw5pls9gOu7E2hgGmqRBIzKXl/d0w7MBhMMzQNkKhFSZrPrDRdW6Uj01wjzwvyvKAwDUxNKK2qQUKYKKMjx1ITZ1pIHMPANnN8XafmWnxuo8Nay0WgKrQ0KbhxEKMJtVNfabp8sDNhHCbcHiWYuuCV9QZLDRffNtBLm9qnqYP5SeMTJwUp5Ym0Ekopvy+EiIQQ3wZ+AFwXQvzHUsq/gap2+t3yS/+Nh/2sQko+2BmX+eJPFh0bRxlppjSD0lwZqfiOwUd7U1xTJy8K2i2XMM0ZRTlxmuOZBtf7AVf2Jlw7mKBrgs+faXMwjdk9CLFNtdppeibnHJe1tseb1/tc3Q+U9rxrYtsa0zgnNzXVq6Br2IaBpKAo69rVOk1DCIFnGjRrOo4lqdsGv/5Sj91xwiBQEsj9acKtQchPbg35YEeJv9VM5R39vet9ikIqVdEwZXM/oFO3+KULC6y1XDxL59Yw4srOhO1hjBCw0nr01e7ZTo26o5rXju4u7FJvSdPg5ihAE4JhGHN1d8z5rs/mQPkfFEXBzWFAIVUjVNs1eXtryN5YCeTJQj2gmo460HxhpcE7W0P60wTIyXOdIMtJsgINyIuMAkHNFtR01WfScE2e73lYpkbNMgkSyWY/oCh0hNAwNVXlomvqQFggabmGqnKRkt2xch/ThNKWOkrdMXl+0Ucijy1d8bOQZMp/YzBVO8sgzbi6O0GgVHWf79V4a2vAR7tT0izH0CHNBdMkZW8UE2U55zo+5xZqJGnBjb5GlmtIAUWhtJXqjsHuOCHICnShGigbtip6sMpSUyFBUGDqyqvZtXVVTGHreIaOrQu++2Ef19K4lOUstxx6dbM8SFZ+CwI4CDKCWDW+CTQ8S/+ZSsgrTo65neIcLUMt+Rvl62+hKp4eicP8e5goZ7H7XVhBkrE/SXBMVd0gkVxcamEaGmleEKc5SVHw2nqbF5Z83t8e88OtITf6IS3Pple3eHtryDubI2xTo+FavLza4PJqg7e3hizWbXQdDKGas/7p1T5ZqTk/zQoMKclyKAxB3TGJkkw9VFElqUmeomsaOkrGuBASQzNouvDFjbaq788LLEPQcHV+fEu5iPWnCVmRc2mpDkLQrlmEqcrny0Ly4d4Uz1Y55f40oeOrRqw4K9hzTRYbSqJhvf3oNfWupd/X+WuaqBLMj3anSNTB+vY4QWwNWaiZtFyd71+bggDLUOm1pbrNWtvDM3SSVCIL1X2uSUGQSKIs5Yzjcq7jkecFkyglk8pcaBConVEqBYauzhx8WyfTeSUgAAAgAElEQVSTzOTKN2oOdUfnhpQ0bINzPU8VGgh14N/xdFVaW+5k1toOH+4FIOCdrRFLDYdr+1OeX6zfE4PT5NDMaBimTONM6SwlMSAIkhzX0rm6N+XD3Sl5UTCMcxZ9i4KCOJNIQy1uOqXFapjk5c/KCZKUQZARJXnZlMaRiUDHtkxlJmRq6DpkOYRpgaYVdGq22m1FOVuDiI2Oyx9/sEfN0NlH8PJqg7SQLLc8fFun7hr80U932OwH1B0TTRdoQhWIXNmRLDedU0/HVdzLE3+0f1jDbJvaA88SNvshcVogBFxeadxxOHhrEHJ7qKo0BmGCoWu4loFvGdhtjfW2UgOtWQaGoczM06wgKu0xoyTne9cOSHKpmrXSggXP4GCiM45SJnGGqWss+jZNz+JMp0YQp8SZ0qu/NVKNcLqyKGO5obpRERIKlSN+sx+wPYwpioJe3eLiUkOpjwqlkbTcdPnFC112JhF/+sEet8cxZ9oul5YahKnyW7ZMnYNpwu1hSCElzy/5/PIL3U+UYcjygpsD1cS02nI/sfqmV7fpBwn9IGVnFHJ7GFK3lSyybRrEeUiYFhRFwbmVGo6t03YtfnjjgDjL8SyBa1vYuqbkzQtJkqtu2LUFj81BNCsvNTWNc50apqGTZjnDKMO3NKQUREle7r5UWatvaTjljvD6foiuq51W3TFVVVLDIZeQFQUvrzZpuzYIye2Bkm1eb89fZuFQdNC1dPbGMVGaYRlKojtMM8ah6tB+Za1Jy1UmUUIIPtpTFV6aEFimxnNLHks1m7c3h7RrFitNwdZAde7nmTrQ90zlKGeVKrQHU9WtbOoapq7NvCh8S0cXEluHa/0QXWjc2J+iCY2hofH62RaNciy/eGGBaazKpX9wY8DBNOaV1SbnOh6FlOxOYixD/d4r5s8TPykYuuDSch1TFw88LDV1jThVtddHv2QUpQzDjFxKTE3DswyKQrLSUlaGmhBsdDz2pwkvLtexDQ3H0nmhVyfOcjQh+dZPtxkGCVEqKYqcy2sd/szlFVreLm/eGDIO1WFegeDiko8uNN69OSQvCtZaDpeWfD48mOKZOm3XpuEZJOUEluQFm8OQMCmYxCmTKMPSBf0wVXpGIuVz621Wmi7nuh5hmtOp2eQFNB0LUxdcXGrx3GJNnYvsHlZUwfmuql4ZBimWcX9byYNpMitZdS39EyuUbEPn+V6dzf2AN64dUEjwLI0vbLR4Za1Jf5rSdi1uDUPSosCWOpuDgLc3R0gpafsWXd+eGatM4oQgVSvYpabD+V6Nd7eGmLqGa+uc79bQS3P6JCsYFcrRa8G3Wai5ZEXGNFEqsZO4oO1Z+LbSYHppSWlG+bbBuV6NaaT6J3Rd8CuXekgp0TSNoigeC1N5y1CLk0mcYZQ590JKLi753BxGTKIJu5OI5YbDl59fYK3tEWUF/9ebm4RpxiTOObvg0vMdPtoL2Zsm+JZOlGastz2CJEcWkkGUoQmVsoySjIMgQhNq12mZSn1W1wSOobHcUOXY+1Nl2Vm3BJZpstpy8WyDQgo+3J1yvldjteXQqdlc2ZkwDA/QhCDIVEnw3iTFMTT0UucL1GIkygpqln4sSZaKT8cTPynAww+lznY8xnGGd9dFpgvBOEqJM+VpsNx0EAJ2RqpEbrWlJLdNTWAZOpdXmzimRpJJTF3wk9tDPMtgZxTPDkCnYcLVPUmaCxqORZQq05mao3Ky5xZt2r6hrCKnKa6lEScFYVltc3G1h176Cry3PcE2DHQtY7VR5yc7U/phytWdCV842+bllRaepeE7Bo6psdpymaw0aHsRyy2H1abD3jTlzRsDfvm5rtK30XVMTRnO741j9ibJTL/oblxLn02i7iPke11L57UzLb5/o0+SQsPTWWt7XNsP+NK5Fv0w4eqOQadm41oakzBlFKbYlsaS7/DqWoM3rg1UR7RlKaeuSQoIVhs22wOL7UnEzjjCMgQtxyIrCgZhghCSM22PhmPxwmKNcZgyjUN2J6pSaRgmLDVdnuvW+I1XVwmTnLe2hryzNcQxdDYWasqTwTWRUnJ5pcE0ye6bzoiznJuDCFMX6lD1hB5cQaLKNRuOSbtm0a5ZWKOInZGSw94exUzjjJvDkA+2J4RpBtTZWBB8uDdFNzRWmg5RVhAlBW98dIBn6PimTpypQ+YwzalZJroBvmuqswRD58c3h+QS4lzJmddcE98xQELXtxBCQ+gaSZ7iWRoLvs3agkfLs1hqWBSImWzGSyvqqN5dq/PhntrlLtZs4lSyN4kQQmOl5ZLmSjTyg7LPoeWZnOmcvFxIxZ08FZPCw9A0cd9u1JqtTHOyvCDJJJsHAY6hz4xR9iZKAbMA2p56AIWJqgjaGiQ0XYsXl+vEaY6ugW8ZpHlBmGTsTGI6NbUyNUo9o+sHAQ1X51y7Rpqq3gFdEzQc1WORFZI//PE2Ly43lfl8KTr22nqLaZQhdia4loZhCCTKyW295RFnBT/aGinN/YUaP3++Q9uzeGtzwKSUW9idxGy0PZbrDghKKWUlLS4lM0noo9Qdk4tLKp/+qNUgK02XX7nY48c3xyw1LMI44yDIyArJ5ZU6rqFE2M51PFxT59YooB9kSCl5fydgse6QZAU9z2KS5MRpRj8Ax3LwHAM3NBjHGQeTlCxTHtiubZBnBYaus962MXQNTdMwNJhGGVMyGq6JLgSepRqnRmFaVroIVlouZ7veTK5DCPGJ1Vi743gW14Zrnpguz1Y/VEZFYUbdUam4pYZD0zX506v7TOMM29BIM5Uu+nB3SrfmsD9VNrGTKEcIQcMx8W2TgyBhHMYkUgk9RplkY6FGx0sZx8p5MEoLNgcB6y2Ha/shjiHIpFQpKF0nynOmqcS3YaVpk+cFjqGx0vJoexZnFzzOLtQYBAlJrnZoeaHSo7qmihHCJKdXtxmGKW65qAqTnFvDSLm5ZepavJ/nScXJ80xMCocMgoRbwwjfNmYrkPWOxz/5YA9D0ziYJtimQNNURUatTKks1CxuHASMw4y6o3N7qETYlC4SdOs2NUt1KDddk3e2hniWTs3SudDzSbKCH98acTCNubKj8VzX58sXu+SFpOtbfLgXqC7kUgtpGKkyTNsQDMOM7149wDJ0luourqGz0fVYbDg8v1hDoBFnBeMoZRxlLDUcHFNVi5zv1hgE6WyH9N7OBCHguZ6PoasUgCbU4e6DpAQeNhkkWcH+NMazVCnt9YOA/jSlW1dGKbvTBCHhYJLgWDovrjSJ0gzPMnh/e0LbcxhHAVFeMBlHLNQs1dTm6DRrFlf3pqRFgS7UA3FnoB5UQZLT8kwWGx6+nRJlkp5vURSw0fHY0iL605SlhuTmKJ7tes52Pd7bmZQOYxHnuj6vrTfvOFvZHkUMgpTFun1Hj8IhNcugP03RNLBPsHTSKR/SpqF6cJKs4O2tIbujiEJKkkzimEIVOpTyH4Mg4UbpFNh0TdqewUJNdZZHaYaBWrzsjGPSQrLVD7jQ9RmWjoGGplKsQSqpeyauodHxTSxNYxSmjELVMPjSUoPPn2mw2gjph6r5sShgEKZsXdnl0nKDlaZLlBa8e1MVaNQsHd82qDuq89o2VQFFXmpoeZaOoWustV0mkdIDqzh9nqlJYW+SkOXKInGxkc8cstZbKr20UkpCXFqqMwxTru0H/PT2mPW2MpsXCLbHEctNFzPQiJOMUZQRJQUdT+MvfnGdgyBhf5IwTXLqtkndVWmQzX5AnCufhTNdF0NXB63jKOGFJdVMtT9NWG44rLc9ojTng70Jcaq6nHMp6fg2F5d8Lq80qdkmRSFwDEHN0lioqXxszdZnu6K2Z3FpuY6uMZO3kFKVY8ZlN/RS/XhduZv9gGmcI0SCt1xXZji2wa1ByELNZqlh8+HeFNdSh5TDMCHNJZ5lcq7n49kaYZKx2Y8403FYaXp4js7NfohE0PIsXlj01ZmHgLprk0UJjoAFz+aV9RbrHZuPdgP2SnntQZDy2lqDosj5aLdgHOfoQomzXdsPWW06bI8ifMdkwbc4uknKCzkzZ9oeR/edFNo1C8/W0YX4xIP647LedmnXLBxDlSrfGgZc3w9IcpX6Obvg8cKiX6bH0lIuIkNKwfOLNTq+xVY/RNdBzwS//MICH+2FNKflfRCmeJbaeeW5JEhSJpHaCavdr5IXeXG5SZrD7eGUFNWjcHbB4+Jyg5ptcmsY0nAMsgJGYYIuVOn13jgmyQuyXPLBtQndus1z3Rrdhk3bs5QmlanzylqTpmvOKgc7NevEtaMqHswzNSm0PLO0LtRnlUpBnHO+VyNIlINUlOY4ps4gTJWCZKJSOw3X4IPdMQ3H4NYw5nNnWvSWfK7sTVXONlXqmr26MzO12ZtG+K5Bt2ZxpuPRbThc7NX4wpkFNg+mBIlqYusPI1ZbLucXaniOwZmWxyjOiLKc0MtYbngsNiyWmy5rZcPYzjjiIBDIQp0/ZLlkteXSPnIwujuJZ6mw5aajqlcmER/tqwnBK9Ndq61P7x1saBqgusQF6kHmmjovLdXZncSlJHmd3XFCUUgWmw5xecg4jhKiNGe55bLUdDA0jZWmiy7kLG/+0orPFzYWWG7a/H9XD5QzlyEI01wpe2Y5Sa4ezpkscE29NCaKOJhmjJOccwsuo1DVxedFQZCqSXGrFJFTDzl/1jzlO8pa85PSQocLipNECIF/ZAfXcJSzm9B0XlttcL7nlw18GosNh89r6iyh7ph06zYrLRfb0Pjf39jEsXSGQcoLi3U0XbDWdPn9d29jGirNlqQZQawEB21Dp5AxaaphCA1NCC70PII0o+k6FLLglbUGTc/i2n5ArTxY9mwdu9B5brHG9jBW8htRhlnKhSSZUmE9LFhwLZ2zCz+7LezTzrztOp+pSaHr2yzUrDsOBhcbNllRME0yBtOE3XHMlzZaZVexhjQAJO2aSWNkMJimKmVQSM50avzqxUVMfY+WazKNc871VF7/5jDE0HSaro5paCw3PUDSq7u8ut5gtWXz5maf799QPQ2LdRvHEjRci3e3R/R8m+eXfFq2xXrHVRo2ec5Sw+HdmyN2RjGTJGO57tDyVJpgo+PSPDIpHC0h9UoRPbVLyOlP1SrxuGek622XRindbegahq7hdQyu7U/RNY1cSmxT1agXUmLogm5dmRPd7EdYhkbPt3EsA9vQeGmlQcs1afk224OITt3i5893yAvJb7xqs9FxeePaAXvjhE7Npudb7I1jPtidsN5yWWm61CydzUFIP0jwbZOskJi6zijIGIcpyw11lhMmGW9vDrk9iHhuMeLltSZrLZfz3do9ks6PA+2axVcvL5HmOQ3XYmsQcjBJMA3BxcU6C76tmvGEQErJqBS8a3kWNwcBH+1NuDmIVLrMUNVwSVawM05wbQPb1CkKiSbAs9VK3tA1XlxulKlRgyhVO8GvXl7ixkHIcsshLS1Mm65FISVf2GizN0kIYiUbcqHr89bmgBsHAUGcsTuO6NXnX+pbcX+eqUkBuKdSxDFV3j8vCn58S8n5dn2LCz2fr1zsKblnTVVSdH2bf/L+Hp5lYJnqgfHyWhNdF7x5rc84SvFMnfM9n36YcGVbmcX0fBuJJIgKCiTb45hxmDIMcsJU1X1bhsrrh0lGnoMuNK7sjNG0kA8PpnzpbIfdsbL+3JvE1GyDZcfhxaU6mZQ0HPOOCQHUJGjqGoYm1GqukDjluC+t+DQc89jbdE0T9y3bzMqcjCydtyxdn1U5GZrgJ7fGGIZGIeErLy6iC+W6pglBr2HzYt5AFuoc6I9+uoNj6Gi64PWNDp6t8/bmCMfQKSi4PQyQEiZJQcMzCZOC1YbNh7s6Ldek7ZncKntRDF1Qdw1GUcZiw2V/moCQM0FBUxcs1h2u7k3ZHcdcWqrTfYwaqlxLx0XtUsIkLx/8CUmW06s7rDRVc9rNYUgQ5+xNkpkQYtd3yEtFSF3TuLjc4PYgRNc0rmcFDdek5qjdYy7B8lT10iBMWGq5NByTXKYs1R1+uj1RyroSlpoOvYbNYJqy3HRouhY1y2ASq7Mjy9C4uOSjCcFWP2QUZry6zgOtcSvmyzM3KTyItbbHzWFUyl2UN46u4aC8cAWqG/kLGy1MXXCuq0o4dU2wULMwDZ1bo5A/ePc2Ky2PpmtSdw2yomB7FCnXtFFMzTKYxqoaRxYFi75Flhfomvr5DVfn8kqdcZxjarA7UbIG+5OYJFMPTd82ON/1aNeU8NgwSEnyQq3y7jofOFp1pZX6UHkhT3wVvN522Z8k6JqSF7F0jbNdD1PXCJKMlmtwaclnuelyaVnpDBWFJEpzbg5C4vIAO0hyov0AzzKo2QY/2R7jGCafP9NmdxLy09sTkiwnL5uqNCHQNIGtGfzSc13Odmo0XYMfbQ0Zhik128QzTX7hvMfmQDm1DcKUW6OIQZAQpwXTKOOdLSW7leQ5X7m0dKKx+rQs+CZXdpTk+82BEmREqrOzm4OQjq/STRsdF4Hk9ihmqWGXdpmqr+fllSY3+lNqto4mGliaYH+aUIiCaajsNqNU+WePkFxqqFTjOzeHHEwTDJ2Ze9raqjqTS3OlY5nkBWZelmTbJo6pdo6+o7M1CHBNnaZXid49blSTQolnGXz+TJtReKeM9ME0YRRmHAQx++MEIdQhm8qlq/LEW8OIW8NQ2WjqGme7Got1h5uDiDQrWPRtxlFG0zVYabosNW02DyIuLjcYRAk7Q9UvsNRweXmlxYWej5SSzX7Id67soQnBWlutAJNMcq7r8UJZKjqNM64fBEiUW9bKQ84HhFCrZfjYae6zniCiNGd3rHo3lLOZPktl5YVU1py6zsaCdYfEuaYJdicx+5OEvYnqYLZNjU7NxrN0XFNH1+DKzhgE7IxD3r89ISvUQbwuBHqpV2RqgiSThFlOt27zZ15e5vYwIsmV4GHLs9go89nX9qf4tklaFNQdA9PQcCyNKCloOo/vgWfdNlnvuOyNddJCVSkdHporTxF1HQ6DlDSHjm+zN4npT1POLLilQrBBp2Yq3+2xcqpzLBOQbBOyO02Vz7mlc36hRj9ISfKc/UlMv6xsC1KlKbY1CAiTgvWOQ9OxlCS5iHlxuY6ha1xebdL1ba4fBBSFMo46p3mVGupjRjUpHKFZmpQcxStLGaVUu4Ki9CTOi4Jr+yFXd6d4ls5GxwMpyzQNmIbOz51fQKIevLcHEdNY4popF3o+57oawyAlztp8L+sTZQWG9vGWWgjBmY6HbS7y7taI3XHMSysNenX7jptICFXPfZhDb3nWI2nzHHWaO9et3XGgeVw2+yGjsnqr6RrkRcaZBfcOpVa41ywjywt2ykl2GCYseDbjJONXLvawDLXD+NHmiCjLabkWay2PSaSkM+JcNTsleUHdNhiEKW9tDmm5BkmW87kz7Qf2HnRqFkGSY5eKtJom+MqlXmnY9PimOAxd4/lFn/V2gW2oFF0h5ezsZrmh5LSLtmSp4fDt93cJE2VytNH18G2DnVHE9ihGCEndtRjHOUtNG9fUGQYxu9sREouGq/wN6q7J+9tj1tou/SBho6MUgqVUixKALFOyIffj0M50u6zwOgkqv4TjUU0KD+GwgWul6TAMU4Ik50zHI0xV6eMkVnLEr6436XgWTdckLyTv76gH7lLDwbMNtkcx26Ng9hCvOyZ1R8kG3DgIKWRBEGf8w3e3ubRc58UypdKwDQ6mCRJJmOb3rKo8S9WhR6kSihvH6SNNCtM44/C+PRRZ+6ywDVX+2Q9ibFP5F7ywWJ/tFp7r+Uzi7A6/B1BVVI6h063b6jA8SLnQq7EzinhxuVEaxxtMYgPfNbm0VGel6eLZOllW8NbWCEMX/OT2iLpjoQt4b2fCettjtRXf0Z18exixN4lpeSbrbY+XVu4ci2MaOObjf3vYhn5HJZSGuKMLOMsLkrxgsWGzsVCjVfaBHMqeD0oZk91xTNuzWajZ2IbGctPm+v6U5xZ9NAHv70x4b3vCUsPmg50JH+0HNFxVVffBzpSub1OzDVqexUrTpetb9IOUmq3fsxPtlX0VhqZVu4THkMf/qn8M2BlH7E0S9icx62131rBkGRqrTYcCiJKCgUhnjWNrpYx3zTaQUvL59RZ128Q2tDse7stNhxdX6twcKKmCJA8ZRSnP9fyZDIFj6kqKI7+36xhgre2SS/WEb7mPlu5ouiajSHUStz9jfZ/1tjIleqloKB0m17yjEsq19PtOXLahq8al2ynnF2rcGkXsT5QbmmVMudBVOjq9us16253Fem8S0/MdtkcJ7+9MuG1E/Py5DtM4YxKlaBLljVG/My0oJfSnKWst+VRq7BSFnElG1Gx1ViVRZzxb/VCpkvo2t0cRDddkHKeEcUacKQG+L260Zzay4zAjSNSZ1ihKOdupAZJWKX8RJDmrLZ9X15uz93+Q4qkQgoVHdPqrOH2qSeERiFK1ih+FGVMvZ3+q5C8uLtW5caCM7z/YmbDcdMhzOesbWPAtbEPjyq7qSXBMbdbNeYgQSv/fEILNg5Aoy3ne9xlHGZ2ahWsZbCy4ZLl8YPrDMrR75J0fhqGrjueTQJTiZuNSCqLuPPpl1qlZXF5tcuMg4MXlOuMwxTYNojRH08Q9de3vb4+Vz3Cez9IYXd8hLyS2aZAVkndujzjTvVNDp+tb7E5i2p71VE4IoCrA0kx5L2z2AyaRcmXbGcVl6WrM+W4N29S4sjNFtzXVd2AZ3OgHPL+0yL/w2ir7k5hrBwFRltN0DV5ebbLZD2fXT5ZLbFPwwmLVc3AanHQfw6lPCqWV5l8t//rfSSm/cde//yEq3SyB/1xK+a3THeG9rLYcpJQIQemEpsJmGRotT1k5Hto4OpbGMFAPw0M3tyQrMDSNrn9/ga/nej5Xdif83PkO26OIXt2apXNU81eTQspZTn4YpkgpHwsFT1CHx4MgwbOM2Q5Ajbtxx7gflaZr0lxTK85heK8l5lGGoZL36AcxXzjTJi8E622XM22PWyMlv7FxH7+IxYYzy28/rViGxkrLYfMgoOsrqYs4y5kmGZpQ1zUoFWFVNyFYbzv0pxnduo1jqgKB5aZLzTb43Hpr1nX8Svn7+eGNAQs1i1rZ51Dx5DOPncI/kFJ+XQhhAn8KfOM+X/PrUsrslMf1QDzL4IWlunLcktxR9rng27iWzsUlHyEEjqmzZ8UEcc5iw8bSNeqOQZIXSlKhUJPL9f2AzUHIYsPmQtdnoWaTZpILPZ/nF/07NId0TaCXx7LDMOX6fgCoh/E8t+F7E9UzMY2Uvr8Q8NJKY5YqOjruT8v9Dv8PYyiE4EzbZeRmnOk46LrgfK/G2QWPjm/z6y/2eHW1QVoUdJ6BdEWU5tw4CNDLHZWuCbq+TcezuDWKmMZK5rpdyo8cToqmrvHCYp00L3h1vUlRqMPq26MIQ1PaSg/K/YdpzjhW8uufZsclS+fB40itVHy2nPqkIKX8qPxjVn7cTQH8gRDiNvCvSykPTmtsD0MIoUxBxkpg7XA1f7ctY9e34YgS9blujaKQXN2bECYFLc9ksx+yU6ptNh2TxYaSoTA08Ym2hFJ+fK5wH2HTU2VnFCvRu3Eyk99Q4zu5G3wYpNzoB5i6xnO9Ghd6PkGaq5THQcA4yrg5iKjZqst67a6dWVFIDoJk5n39NHEwTYhSdbY0jtLZTlLTlMQ3qLLmoqySO4plaLOFiKYJdoYxB6UHuGM8uJ+g6ZrULAPT+OTfeZqrwgzf/ng3meUFV3anpHnBett95J1vVV10sszzTOF3gP/zPq//ppTyQAjxl4D/BPh37v6CMgX1NYCNjY0THeTd3ByEDIIUIeCFJf+RNXCSvCBM1A0bpTm+o5Qqa44xS688SgVQq5QiLkpd+3nScJVa6AtLPr6jmstOuiluFKVIqdRZDw/sG/rHB/8Amqa6qO/H9jhib6weds8fCu09JdQdVamma+KB/tGP+v89ulP9pAf+uYUaoyi9rzT9Ua4fBARxjqbBS8vK/TAqRRkBRmH22KRDn3VObFIQQiwD37zr5dtSyt8SQvwC8BvAX7j7+47sDP4+8Ffu97OllF8Hvg7w+uuvz3m9/Gg4pk7LMwlKJ7G6bfBcz0cIHihb/SAel8qN9bbHSlN+ok3nZ82CbxGmuZL7vuvBt9J0qDsGtnFvGeSzQN0xubzSmKXWjkOnpook9IfsXB9USfYo1CydRqmntDDnBc7TxHEPosXRdMRpIIRYA34X+HP3Sw0JIRpSypEQ4qvAvySl/Nce8vN2gWufYihdYO9TfN9nybzHcPf7fxH4/jG+/zSZ13v/LO/7s8bzs3rfz5LH6Xd8NJ7zvneO8qSO5ayUsnf3i/OYFP4H4NeArfKlfx64BHxJSvl3hBBvACEQAX9FSrl1/5907HG8IaV8/SR+9pMyhuO+/zzHP6/3rt738Xjved87R3naxjKPg+a/dp+Xf1B+8LgEt6KiouJZ5NlLvFZUVFRUPJBneVL4+rwHwPzHcNz3n+f45/Xe1fs+Hu8973vnKE/VWE79TKGioqKi4vHlWd4pVFRUVFTcRTUpVFRUVFTMqCaFioqKiooZ1aRQUVFRUTHjmZgUhBC/Wn5uCSH+phDi94UQ/70QYuUUx/CKEOL3hBD/WAjxh+Xn3xNCvHaKY/jr5efPCSH+WAjxR0KIPxFCfPkRvvdXy8+nHsN5xe448Trm+/5q+flUYz3Pa/RhsX4c7uHy/ed+Hx8Zy8lcn0q69un+AL5Vfv4G8FuAA3wV+H9PcQzfBlbuem0V+PYc4vAPgOfLP3eBP3mcYziv2B0nXp/R+55qrOd5jT4s1o/DPTzvGP2sMfu0H8/ETgEQQggN9cv8ppQyklL+AerCOtVx3Ofvpykk3xFC/BrQkVJ+ACCl3EMZGj2MecdwHrE7TryOwzxjPa9r9GGxnvf1d5R538eHnMj1+SzZcf4joBBCtKSUAyFEHbjXkuvk+B3gbwkhWnycttsHPlHw72/wo5EAAAUFSURBVDPm7wNfBv7vu+Lwo0f8/nnFcF6xO268jsM8Yj3Pa/RRYj3vexgej/v4kBO5PqvmtYqKioqKGc9K+ui+CCH+5cdgDP/hYzCG//YY3zu3GM4rdseJ1zHfdy6xnuc1+rBYPw73MDwe9/Ehx70+n6X00f34rLTuHwkhxJeAXwJawADlUf13TnkMLwO5lPInR17+X4/xI08lhvOK3QnE6ziceKzneY1+ylif6j0Mj8d9fGQsn/n1+Uynj4QQtpQyPqX3+q8BG/gDYAg0UNUTmZTy3z6lMfxNYAlIUVUKf1VKuSuE+JaU8tc+5c888RjOK3YnEa9jjudEYz3Pa/TTxvo07+Hy/eZ+Hx8Zy8lcn6ddRjWPD+C3gTeA7wD/AR9Pht86xTH88QNe/6N5jAF4DfhD4PVHicM8Yziv2B0nXsd837nEep7X6MNi/Tjcw/OO0c8as0/78aykj/4t4BellJkQ4neA3xNC/GVOt4zsDaFc5/4hMEKtMH4dePMUx6ALISwpZSKlfEsI8S8C/zPw8iN87zxjOK/YHSdex2FesZ7nNfqwWD8O9zA8HvfxISdyfT4T6SMhxHeklL905O+/APyXwKKU8tIpjuMLwC+icpFD4DtSylO7mIQQPw98JKXcOfKaDvxFKeU3H/K9c43hPGJ3nHgd833nFut5XaMPi/W8r7+7xjrX+/jIOE7k+nxWJoV/FdX5eP3Ia2vAfyql/J35jezJoYrh6VHF+l6qmJwez8SkcDdCiG9IKf/SvMfxJFPF8PSoYn0vVUxOjme1T+FURbSeUqoYnh5VrO+liskJ8axOCs/e9uizp4rh6VHF+l6qmJwQz+qkUFFRUVFxH57VSWEeioZPG1UMT48q1vdSxeSEeFYPmpeklNvzHseTTBXD06OK9b1UMTk5nslJoaKioqLi/jyr6aOKioqKivtQTQoVFRUVFTOqSeGEEUL8BSGEFEK8OO+xPOkIIXIhxA+EED8UQnxfCPHPzHtMTzJCiGUhxDeFEFeEEN8TQvw/QoiL8x7Xk8iRa/Od8vr8d4WyD33iqM4UThghxO+ijL2/JaX8z+Y9nicZIcRESumXf/7ngP9ISvnPznlYTyRCCAH8U+B/lFL+7fK1zwENKeW35zq4J5C7rs1F4BvAnzyJ9/wTOZM9KQghfOCXgX8F+K05D+dpowH05z2IJ5ivAOnhhAAgpfxhNSEcn1Kg7mvAv1lOvk8Uz4p09rz488DvSynfE0LsCyG+JKX83rwH9QTjCiF+ADgomYNTN7p5ingFqK7FE0JKebVULF0EnqjS2WqncLL8NnAoYfvN8u8Vn55QSvl5KeWLwJ8F/qcncSVWUfE4U+0UTgghRAe1kn1VCCEBHZBCiH9PVgc5x0ZK+R0hRBfoATsP+/qKe3gH+M15D+JpRQhxAch5Aq/Naqdwcvwm8PeklGellOeklGeAD4Evz3lcTwVlNZcO7M97LE8o3wJsIcTXDl8QQrwmhKiuz2MihOgBfxv4W0/iArDaKZwcvw38F3e99n+Ur//x6Q/nqeDwTAGU9s1fllLm8xzQk4qUUpb2jf+NEOLfByLgI+Cvz3VgTy6H16YJZMDfA/6r+Q7p01GVpFZUVFRUzKjSRxUVFRUVM6pJoaKioqJiRjUpVFRUVFTMqCaFioqKiooZ1aRQUVFRUTGjmhQqKioqKmZUk0JFRUVFxYxqUqioqKiomPH/A2dQQztxLfz1AAAAAElFTkSuQmCC\n",
+            "image/png": "iVBORw0KGgoAAAANSUhEUgAAAYUAAAERCAYAAACU1LsdAAAABHNCSVQICAgIfAhkiAAAAAlwSFlzAAALEgAACxIB0t1+/AAAADh0RVh0U29mdHdhcmUAbWF0cGxvdGxpYiB2ZXJzaW9uMy4yLjIsIGh0dHA6Ly9tYXRwbG90bGliLm9yZy+WH4yJAAAgAElEQVR4nOy9169leZ7l9fltv/fx5/qIG5Hh0lSW7ersrvYaZlrACKSRQIPo+QN6hBBCmIdBPDASGgnzMAIhQP0w4gE0gARPIJBmoMZ0d9HVlWW70kRmRtww159zj9l+75/h4XfiZkRmpIk0lVXVd73EjWP33Xfvn1nftdZXGGO4wAUucIELXADA+aIP4AIXuMAFLvDzg4tJ4QIXuMAFLnCOi0nhAhe4wAUucI6LSeECF7jABS5wjotJ4QIXuMAFLnCOi0nhAhe4wAUucI4vZFIQQnxLCPGnQog/FkL8/fc893eFED8SQvwTIcS//0Uc3wUucIEL/GWF9wV97z3grxpjKiHE/ySE+Kox5iePPf8fGGP+8cf5oPX1dXPt2rXP5SD/smFvb4+f1bk0BgwGqQyuI3Ad8aGvl9pQ1BKlDXHgEvnuz+Q4Pw1+lufzw2AMiA8/vQAobUCA+9iLa6mRSqMNJKH7xHOfFsoYWqkRQhB6H70+fZbzqbT1X33UdfVeNFKjjcF3nfe91xhDowyuEHjuk+dIa4MQ/EJcl4/w6quvTowxG+99/AuZFIwxR4/9twXUe17ynwshZsB/aIz54Yd91rVr1/je9773WR/iX0q88sorn/u5VNrw53tnKG1Q2jBKAoSAL1/qIz5kwLk3zfnOOxNOlg2XhhG/98IGm/3oEx3DLG84SWsGsc/24JN9xsfBz+J8fhiMMbxzknF3UpCELt+4MqQTPv2WP01rjhYVANfWE3qRD8BrB0tuH6cg4IXNHi9f6n/k91atYlY09CP/A78PYG+Sk1YSgBsbnQ99LXz887koWu6fFQBcHsWMO8H7XvNwVpDXip1hRH/1u5aN4u2TDIBO6HJjo3v+eqU0/8dPDpkXLdfWOrxybXR+vLePU+pWIwS8vNPHecaJ6IuCEOLe0x7/onYKAAghvgZsGGNee+zh/9oY83eFEM8D/wD43ae87w+BPwS4evXqz+RYPy2u/Z3/80Of3/vP/pWf0ZE8G/RqxfUsF3pWSw7mJZHncmUcPzHYP5wVHM4rqlbSCV1GSUDoORgDR8sSgK1e9L7vuzyM2epHVK1mexDxaXz4x2lFKw2nac1GL3zm1eQvCpQ2TIuGrJbUUjHJ6icG3tO0ZpLVDBP/iXOgHzu5SehijGGzFxH5H49tvn9WULeaadbw5Ut9ylYhEMTBk6voURKQ1ZLId4k/wxW2fiylQT8lseFwUfLGYcooCThZ1ueTQug5JKFL2SjKVvHawZLLo5hB7HO4rJjlLcuyZRrW1K3Cdx0Cz2F3FDPNGgaJ/wszIXwYvrBJQQgxBv4b4N94/HFjzNnq37c+aOVojPkj4I8AXnnllYucjs8JeS25O8kRAm5udD/21niS1hS14t60oGgktza7eK4dUELPBQyLUnJpFLM7julHPmdFwyRtAPAch41eCNjV7jRv0NrwjSsjvnJ5gAHWO+ET31m1itvHKa4Q3NrqEnouVWsHwl7kM4j989cOYp9J2tCNvF+6CUFrw6Jszym2K6OERdHSi/zzwe8R9qYZr96bo7TmX//mZbYHEa4jzs9V0UjSUnJ9vUvsO1xb63ysY0gryemypp94vHOSMSsbIs/j+kaHbughlQZgkPgMksFTP2Oa1VRSs9ENCT4GtfQ4Rp0AbQwGWHvPLqGRmpNlTaMUp2nN1iDk7iQn9BwuDWNubnSppeLbr59Stop5WfNbNzdIAo+r44R50XBlHLM/r3Ccihe2eiSBRxVqlmVL5Lm4jkBpQ+A5SKU5yxviwEUqw/68JAlcrq93PnRn/DRobVhWLZH/+dKnX8ikIITwgP8RSw8dvee5vjFmKYRY/6KO7wIWeS0t9284X9F9HPRjnwdnBbVUVFJztqISikax3g24tdlldxwTed75TfT4jf/4z5Os4XBesjct2OiFbPZDrq11eDArkNpweRhxmjbsTXKOlxWe6zCIfXbHCQ9nBWWjmRct3Z3++QSwM4jZ6IbnE9UvE/bnJWd5w0lacXWc8Nxah9++tUbR6CcmRgCpDE2rSQKXw0XNr1wdPfG85zgIYXn5QRLgOIJZ3nBWNKx1AobJ+2kZYwyugG7sMctbpDScFQ3X1zs0UpNjFxoA19efThmVjeJgbqkspQxX15JnPg9r3fCpj7uOwHcddkcJg9hHa8gqSYa9bruhhysEerUXFdhrZtwJ+NVrIxwB06whrSRas6JBFfszu8utGkWjNLOi5blxgjKGZSkRAnzX4TStqKVmlASM3jNhlY1if14Qei67o/h9k8b+vGRetAgBL2738D+n6/eLGnT/JvBrwH+x+sX/I+BvGWP+HeC/FEJ8BauM+jtf0PFdABgmAWktEcDwPQPKh2HcCfj6lSH3pjlCCHxH8PZJRl5LllV7Pih3I/+cUuhHPjc37Uo0Cd69LB/dF9rYQl5WSf7szoSfHqSMk4CTZUTZaJZVQ9Eoxh0XR1i++v60oBv69GKP967JDHYl/Ph3/TJAaUNRK7JKkdeKo2XF4bxkVrTsjmK+tjs8f+03r44oG0WrzFN3AULYBUHVSrqRff67e1P25yWXBzH/0ld2nvIeQTfycR0HYwz9yGdZtSit6YYu87LlEaNTNIpO6PFwVpDVkp1+zGBFZT36bt/7bHdyriO4tdllf17QSn1O97iOYJJW/PhhxagT8PXdActKsjOIeHBWcJY3dEOPy6OYnWGEu6zPd2Ot0jgOaA0aOF5WzAtJ0SiSwOHBWcm4E/DyTp9laRdXs6J536RwmtaUjaZsNKNOQPc9E+YjKsyYp9NinxW+qELzPwT+4Xse/s7qub/9sz+iCzwNgedw87Fi27OgH/u8uG2LkkKA0iXLskWtdh6jTvjEynVRtNRSsdYNMcYghGCSWRpqoxeyvqKTFkXDm7OKe2c5Wd0iHI3juEht+MrlAYPYUkKvPVxQtYokcLm21kEZg7OaGlqluX2cojVs9kO2PmHB+ucRl4YxQoDj2L9fJ/A4TWuUhuNlff46rQ2h7/JXv7R1/lgtFVIaskYyiH3q1tI8ke+xKFuMMdw9yXn9eMnrBylXxwlfuvR++ufaOKGSmsDr8sbREiFsneL+WcFz44SitrqSUeJTS8UsbwE4zSoGiU/gOdza7NIoTe8jis+fBL4ryCp7DJ4reH6ri9Kan+wvOV7UzIuWr18Z8qWdPj89WPD6QUrRSDZ6IdO85vnNHlfGdvfSKo2A851QP/JIq5aq1YwSn2le00jNvGwZdwNe2O4hlaEbvft7HS5KilqRhHaB5HuC6CmU2aVhTODVJL63omE/H/xyLZMu8HOFRzTQaVpTtgqEoawldyaKYeITeg5Fo2haxT96/RgDJIHDpUHC5VXxznedJ5QgniPoRZYrHyUejnBwgUujhBe3e9yd5Eyygqxq8V0Xz3W4M8nQGq6uWcqgVZqyUUhtqNpfjlvAGEPRKELPoRt69EIPg6FdTbRp1XJtRcO8fZzy1knGqBPwzasjAs/heFlxsqx5cFZwaRQzL1pubnQsF67tAIeBcccncG3x+f9545jtQfzEirdVmrdPM5Q2bPRCpIJWGd44Srk0sJTI4wsN1xiS0KWoFf3HFglKG2Z5g1LmfSvqTwshxPl3dkOPyHcxxqEfeRwJ6IYep2nFP7t9wsm8ZtTzuX9WkNUts8Iey8uXBhhjuHOaM81rOoFHL/KJNzt848qIaVYTeA7uRFC2mthzmaQ1V0cxh8sKqQyLoiavJd+7t0Bpw/X1hC9fHuAK8UTBumgkB/OKOHC5PIw/03PxNPxy3BEX+LnCI5qolRrfc8hrSSfwmGQ1ZWtphFlhedm0avnJwzl3pwUCiH2XRSl57WBB4Lns9EM2+hFnWY0jBP3I56XtATc2urgOHC8a3jpOkVozSDyMgXi1O9DAomyZZg2Ba3ceNzY7bHaD1erZcGn4wbuEWioC13nmguAXgf15ySxv8T1BIzX3pwUHC0tbeI4d8B7OChwBB4uKvFYsyoyr45hLw4SsapkXNcuypRd7ZLVkrePjOrDRi/CE4E/vTtHA7ijiaFExyxu+/eYxv/v8BidpTTf0GMQ+Ullq43hZUkvF7ihmktWsdwOKWmGMoVUGz7GDXy/08B3B6LEaxf68pG41y1LSj/3PXBBwY71DozS+46C09cqs90JC32GtE/Lq3ozXDlKWZcOg8FnrhjSt5ixr2Pcrrq93yGrJd/emzPKW3XHMOAnYm2S8uN3jxkYXqfRq8dPl4azk7ZOc+17BIA746cEZp8uabuRRNophEiC1eWqd4HhRsSxbykYxSvzPnfK8mBR+TvBhktWfV7nqe6G1QWrN3UnONGuoWkv99EKXwBNkVUvTak7bilubHVqlqRpFJ/LY6AUobRgnPn+xvyBvFWuJT8cfEQYeP7g/5+1JRuAIrowTfNfhcF7yxvGSWd6wM4zohh63NnsgBJ3A4+2TjDiwcte8sVTS9/fmDBKPolE4QlDW71pkqlZRryiAB2cli7KlG3lcX/94qpsvElVrf4+qUeR1y940wxhopcHzDW+fZjgC9ucVlwYh92c5jVRwG17Y6nH/rOB4UTNOfNKyRRvDf/X/HrLZCelGHi/vDPj+vRmBa1e+xkDRao4WFUfLCoxgWUo2uyH92ONkWZFWkiRw2eqHPL/Z4zSr6Ufe+QQWeA7bg+ic1nKcit2R3c2EnkPdagLP4Vnng7JR7E1zXEdYFZuBYeI/Mblbn57gzeMUpQ3DxOd0WdtdRKCIA8dKVAOPUSfAcwRnRUNaS6TW3NpMeDiv7A4n8lHScHeSUdSaHz6Y8xs311DKkNWKXuiS1S2ny5o3jlKGiRVdKKW5utbhK5f7bPbjD6RqZ2XLvWnBqOPzsvfRPpFPi4tJ4QKfCZZVy/2pNQxVjdXF10py/8wahEZxYIu+EZykJd/fmyGN4coo5uWdPjfWO4w6AVmpOF7WHO4v0BryVrFuYFbWLIoWV8BZUTGMQvbOCg7mJUeLimneMogCnt/qYzCklSQOXBZly5cv9UkClx89WNjdBNCPPY6WFdO84WRZMUwC3j6xA+la1+rnwe56fhFwaRhzmta8fZrxznFKWknWOiE3N2JOs5bDWcmibAh9l0G8DgaOFzV7k4KzrMF1HEszlQ2TrCLwXWZZQ+A4TLKGnWFM7LscLkp6sc9GL0IbjTGC1/aX9BOfG+sdaqXZGcQsy5Z705J52XJjo8sg8elFHm+dZNyd5MS+a01l5t2C9uOqs6vjhLxRxL77zDu1edkglSGrpDUpRpYyfGR2PFlWHC9rWqXxHIEQgmlWc29leFvrBnzzuTHLomVvWrA7jrkzSTnNaopGMStbslpiELjCXsO/fmPEd96Z8fpyQdYofvJwjuc47AxjKmWltX/y1oSjRcXBvGR3GOG5Hkng8a3r63QeqzEUjeRoUZHVklHiYzSsdwMGn8OO6Wm4mBQu8JlguVKVGGNNYRoYxQFx4BF4DvemObXSVI2kagzT2mrFX9zq4wiBVFA2miiwq8f9ecVaJ+C59Q5b3YC3T1KmWcm8UGz3I06WKRhD3SgcAaHr0irFvbN8pYU3TLOaTuTRjzwC3+W3bq2xNyk4XBRUrS1i1lLx6r0Zz40TpNK4joNUhp1BxDSvnyq7BKt3dwQ/M1lrWrUrdVXwPorhkTt8oxvy+kFKWkqyWvKlnT6B61LLmtB3UIUdeCdZTeI7IGyNZla03NzqEvuC793LKOqWRmoGic+irLm50aWoJeOOjzKGtGpZ74ZEnsOylhwvKzZ7EWdZQyPN+cDVSIU2hnB1vI3SNFKvqLyK59YSBolPFHRplaEbelStOqcA36u++bgYxD6zvMVzBZ5rC7JqpdZ55BvYn68czYOIzX6I73rsjgxSG7QxZFVL1ig8V7A3yckrTVZbb8N6L2BRSFwB/ThAanjnpODSICKvW/JaMitaholP4Aq+vNMnrVq2BgFnRUsjJaHvsDOMeHGnRxy45LWkVVY2fDC3irHDRcXNjQ6zsqGRmsh3qaWiqG1N7ixvUMb+3YtGnb//09KdF5PCBZ5AXkvSSjLq+E9VOCzKloezgti3vL3jiPP3FI2Vrx4vbWH5pZ2udX26Dq02LPKWtW7AWjfkYF4hhGGaVxwt7c04agO+cnnAX3lxy/oMpgUPzwp+eH/Ow1nB/bOSqtU4aKQBF1t01hi2hwFH84qHs0OM0fyVFzfxXYdF3vJ//cURNze6DGKPNw5T9heF3XU4gl7s85VLA767d0bgOjy3lqw04OJ9lMPj5+D+tMBxns3U90nRKs29aWEpm0ad01nGGGqpuTfNaaRZFYWtG3cY+/Rjn7yWLAob67Eo7U7reFGz1vUZJz6uK9jsRXQDj2HiobRhWSlOlyVvndgB+nBeM0oCnt/uUra2JpAELoHnUEnFW5MCbTS10qx1QtY6IZu9kHE3YF40/ORgya8+NyIOXAaJx4OZ5so4OZdVhp5L6Nlr786p9TBcHdsJ44NQtYqjRUWwMp09jiTwzuM4ZnlDqzTr3ZCsluxNct46Srl/VrI7jljrhqx3QyZZgyOsnHSW1/iulc/uzyvy2lJdm72Qy8OEq2sxm/2Ig3lO1Ri748wq9uclaMOkaHj7JOfSMObyMOH2qrB/tGgo65aNbohYOSB8YXcGdyfFKgtKkTeKd04yTrOaVmt2BiHGCKZ5zR/fPmVZ2b/vI0Ve3VovDkDd159aTXcxKXxG+KgYi18U3J3k52a1W5vv5zhneWNpndoOPp3Q43BRIpWlbIq6ZX9eILVdlY47Ea3SK37WGtV+59Y686Lh1Xsz3jhK7cp8GDFKfKTWXB3HHC9LDpcVR4uKRmmmWc00rfE8wZ2pZHcYs6wlnisoW7VapWoqpUgCj7dOUtZ7EUZbPv3OJGNetAwiOxBO8prdYXJOLZSNQrqGVtvV7J+8PWVWtPzOrfX3ZSw9opS0toPT5z0pPD4taa1ZVi290LNKq7TmzaOUK+OEKHCYFQ3jbojvCpZFy0lW00rNdj8iqyVpLVHLim7kMU4CBknAWVYzcx2WVctz45j7k5S8bZnnCmms+awX+SzLmqKRrPcjXCHYXetw/6wk8l1eO8rY7oc8nM7ZHcdMi4itTsiylLzdpnRDh6/tjrg8TM6NX+/d8dTSSmCzSnJ3mvGS3//Ac3ua1ue5SY9MZ0/DqBOgtXUSv3GUorRGA9c2EivZDV3eOEoJXIe9qfW23DnN2OxHbA9CPGEH71YZro4Tnt/u0g08Qt/j5nrC7eOM79+bcWeaUdYajWGeNyDs32Je1EwzwQ/uz5gXDZOsYVq0hJ7gjZOM/VlBowxHy5rQE/RjW1urpLbfbeyu1HccosDlYF4Qeh7Luj2fFB53LCj96f0LF5PCBZ6AI4TV9H/ADnTUsXx7sFIVSWWIA4+yaaikHSBPspqNToQQlkJIAo/Nng2+2+xGxIHHjx/M+enhkodnJcuqYe/M56+9tMHd05xZ3vLawZLjRcVpaqkPz7EuU6kdkkAQ+y5FKykqSeg5ZI0krxSNVPRDn7O85bm1Du+cZjyclezPS/qRx8Rz+JXnRvzLV3ZsjEIv4MUtK2VN6xYXh7O85i/2lxgD37kz5W984/IT52C9G1JLy0e/Nzri84DnWr9IWrWcpDX3JgXDxGdeNrx1mnKaVfiuw7WNhCujhLsTW0T+s7sTikZxa6PLl3Z6KG1olaZVhmHs0SpL6GsE+/OS0Hc4WVoD1VlaI41dz/quwBHwk4MlrhDU0rDRjVDKcH9aULdWYx/7LqIb0CjD6bLixa0Oae2xN7UxEhu9iMujhFubXarWFvQfxzD2yaqW07QiDkIezsqnLkzA0kvzorV+jMcml1ZppDLUq+vOdwUnacXtk5T5atcQeA67w4SdYcw0q/jRgxknyxplNHmpeOc0Z543aN3n/llG4vtcGke8uNNnsqz40+MJdavZ6oc4Au5NbV1GG9johnQCl7SS7A4ivnl1xJ+8PaXju0yUpTqF0UxTxagjmBYNdyc5juPQSMNGP+JoUZJVLceLimsbCQ9nJSC4vhFzeRjTSMNLOz16sa03DBKfs/DdHdGnvt4+9Sdc4JcKNzY65LV8XyTCIwxin8HlAUeL6lw1cmOjwzgJWO8F/NndKS9u9a1xzHeYFy2XhhHTrCHyXHxPcLQs+d69M946TqlbidKCfujxwwdLbmxIFoWkaq1uPfAEvuNwVrZobWhX8kGlDR3f5WBe0wkcekJQS812P2QY+1YSqO0kl/gukWtprl5oV7nXNjqME98qkKQ6v5nCwGGYBChjyCtJ7D854Fgax0YvfJ4GovciDlw8V5yf80ZpQFBUGqUhClwizw7MceDxF/tzjtOaRhqurwte2O7jug5vHC65udEhCTw2ejFp1bAsG5QRNK1mVtRkrUSuIhz6sUPou/iOsLUfA4tKstkLKZoWJRVg6IU+v//SJmWj+OnhksBzqRrrnVDa0l4/2V8wL2w9Yr0Xvo+acxzB7ighqxVKG3z3g7nx9W5IN/TwHHFe13mU1bU/LxkmPolvz9kktdlZ07xBCHhlZ8QgtoXbV/fO+N7eDK0Nz292aHzNOPExwO3jJVmtiTzN1fWYyHNY1C2vH6TMywYH2OpHnGYlke9xaRDxa9fWGHc80kajtebbb5yiAN9z2BrErHUNZavoRoq61VwdxVwZJ6S1ZKMbntOcea3Z7If2GvQ8PFdwMKv56u6QbuhZmbDzrp/haUmwnxQXk8IFnsBHhW0tipZJXp+Hmj2C6wg2uiFfvzyklTP2ZyWTrEE4gu/cafFdh3ESUEvNG3em/OD+nLxWXN/o2Dx6Y2gayU/3F4CgaiSb/Yh5LimkYqvj00QuZa0QjkOjbcGQlVNZGqt7v32cc5I2GODK2Aaw7Y4Sdvohs0rSSM00tdyss5IsGuyAvyhsLHfRKL55dchZ3nBl9G7uziOtOMC8aNnq/2yz87Wxkt9Gam5udPAdh6/sDtifFbiOIF8VopPA4zi1SpnYdxEYXt07I60kvdUu6vWjFN9ZcrosOVpWaGO4sdFjEAc2XkKAcUBpYQ2Crgs0OEbjuy4/erhgreMjjQHh0Iut1DSrJWWr8Byr6DlNa3wPpLa1iJ8eLLgytsXTK6PkfdlHziqGomzVR7qZ33udFo2tgUhlbMFa28l0mAS8c5KSNy1ZrThalCu/jMef35tyuCxQCnaHEb95a41WGh7McrugCK0r3MEhqyWecChbzWla4zqCqlW4jsP6KGTYCThYVLw9kWz1ImqpERhO0pr9ecVGL2Cjawf8ZdXgCMH19S6XhhF5K5llLQ9nJdfGMaM446cHObvjDlnV0ip7vA9nBdv9aHUdGm6sd59QLn0WuJgULvBM2J+XK97SKnSCVfbLndMcx7GmoOc3u2z3I370cI6LIHJdhl2fo3mFAI7ShiSwF3iycPjK5T6V1OyfFewvK3zhsN4PeTAtaDUcLUqO5iVp1aCNVamEnofBUgHSGEKtyWu70nWErSOMuiGbvYiXLsVcGcU0UvPaYYpGc7KwRjoBjDt21bksW94+zkjLlndOcwzinLcF6IQ2QkMbq1DZm+SMOsEH7qo+a0yzBs9x8AKHRml2RzH92MMV8JP9BVndsihtMf/rlwdM0hpjDMtaMuwELCpJWjYsqhYpNVLDnUmKIyBwPXphCY7dWU2Eg4PGdQ0CQ1E39ncXLpUUnGbWeHVlrUPRSq6udXh174zbxznLpuXmepfNfsBp1tJKRTuKOZjVBL6gH9soiFaapxaUA8955mRUsKvlslG8sNkl9B36sVXoSG1d057joJTkpwdLvnl1zGuHC+vjEA7CNTiuwzvHOd3YY1PFGKMYJiGzrOVgUZDWDevdkEYqPNehaCS90MMRhnEnoJGGZWkl0kprThc1QrDyNhjunxW8sNnlaFkwzVpubMS8en/OH78zRSlDL/Z4frPHyTJhUSmqVlO1isHK/V82mm5gw1rmpU0VbqTh1lb3iWswry2l+kmVcReTwgWeCZ3QZVlKktBjvWcLsPtzmxCplOFHDxZMC+spWEsCtgcRm4OINw9TskayKFs2uz6L0t6si6LhzqQg8BzuTkvyWtJoTVZLLg0j0lXNoG0VlTRIaSiahlECvdgjcAT9JOSdkyWB66K0jeV23YaTRYkDtEoxjgPGvYDdUcz9aU5atvQiD891uLHZ4Syr2e6F3DkrWJQNk7zl5Z0envPujRX5Ll/a6WEMvH60tAmbtWRw+enxz5/9ufc4W1Egke+eUwdHy4qikexNc76+O2SjG9KLfW5t9s5rOkLARjcg8e1Kd1m0zPIWow2nRYsrWs7yhrxuKRrbac1zwXU8eonHLGvOdx6u0PQjFxfD0byklpof6TPySlNK+96qVWAEV0cRp2mL7zjURjGKIw4XFTfWe8AjGuzToVV28Dxe2j4ZnivY7EdEvnsuKd7qhUzSmnnZUtSKN49SXrk2ZL0fsZU1ZHXDw1mB1gnd0GMmGvpRSNXalN9maSMxDhYledXiCIEnBFnVYBDsnWZcWe+AMXRDl4dnFYuiRhnbXTBwHaTR1iVdtSSBde53woBZ3jAvGvpxwEYvYlC2VFLiew5lI7k8ipFaM81blpUi8K1pcJQEBJ5DI989h4eLkkna4LmCF7Z6n8jXcDEpXOBjw+r47Urv6vhdWmW9G9BITdlIDhYly6Lh9aOU59YSktzl/rzkneOcqpHsh+W50qhRiknWIpbVKudGYrTAKIXWHkdpxUY35PpanwdnOaXSzPMG37NFZ20MSjtkVbPayks8x4bBOdhawVnW8NrBkh/dX/DSTo+rawnzsqFZFcg7gUvVaB7OK9C2wK4RtFIxyRp+9/kn5Y5CiPNBuajV+xrHfJ4YxD7Jdg9HvNu+9HBR8fZJyu2jlEujhMNFSdUqvnVjjZ1+xHfuTMhrTas0l/ox75ympFWD0hplNLUyOMbQGsN8KYlagisAACAASURBVDHYNogulkLa7Fr1TisNaqVK64ahVZs1GiPEytQleWG7y84w5C8OFrSrOs16NyD2K44XDQiIA4eNTsjxsiLxHRal3f09klGepvaztlaD+kfhUWbTaVrRizz+7O4Za52QB2cF37qxRhK4VvGT1by0M+CsaDmYl+SNZBz77PRCpr2QaVEzm9loja/tDvnq5QGTrMZUimXZMi9rAtfBIIgDh2olaU5rCQYezkt216wBsxd57E0LzoqGslVEjoPnuzbdFIkvHALf4ddvrPGlrQHffvOEjV7Edj/ia5f6GAM/erDAc+1kBvbei3yX01WcyM4g4vIwJvDdJ3pGVKsQQ6msqMB1nv36/CKb7Px94BXg+8aYf/exx78C/PdYJd6/ZYz58Rd0iBd4D06z+jzRclm9W4wOPZdrawk/PVjwzklGKa3K4vZxxsmypBeF1EohHOhF/jkvP4h9Lg8i7k7LlSxUEwUu60nMomjJM8kkrdmb5lwbdxjHPgJBVisE1gXrOGC0wTUwrSRKgTYa34OztEG2iv25Lc4WjQIBp8uG47RkXtQrg5PD/qygbg3rXY9O6FHUPrHvsj+vuDx6f57/9bUOZas+045hH4WjRUWrbOc5F8tn//jBnP1ZSd4qHpzlPJwKXtju8nBW2GiGXPL/3Z3gGGu0Wu+HLCu7Wp4VdsWL61LVLY+82w4QelZp1mqDVHbwV8oQ+FYCPM1bamlY6wS4K1lw0Wi8yOXqWofjtKGWioeLioNZiefaWsGtzR6LoiHyXe5Oc7JGMu6EDBPfdt9btQTVpuLyMP5Ig+AjWarnOEzzhmneWElnK4l8h7sT61I2q0Tc0LXelqN5yQ8ezihbTaM0Ra1W0tAKeX9CJwxY74ZobaiVJq8VlVDgODZyG00pDVLagSqtJG8eLdnohmx0A3YGMWdZjRAOUmsiX5DWNhjvUdBgVtq2pf/iy5vcPyu5PIp5fqvLH781oRO6aK25Oy3IG8Ww45OWitCDd04zro27+J7zvoC8nUHEsahIAu99k6rW5vya/bAOcV9Uk51vAl1jzO8KIf47IcSvGWP+fPX0fwr8ATaa/L8F/sYXcYwXeD8eSf+EePdnu3U1HC4qq5cfJZYvThQ/3F8Qew6xr3l5p8c3rowo65b/7QcHnBWS9Z7P9fUe09za+oWwA3ziu0x1TaM0ZWtoWsWeFlwdR4Sey/22IFiZ5pzQxhRUUq8GOEMnchHASVZzsjRUShN6Lv3YZVHUZJWNQUh8wbJsqXqKXuShTMtaL+bl7R4/2V+ubiq74korSTf0zrluxxEf2VP4s8SyajlNawyGspHc2Ojy1knKtKjJaoljrCO8UYrXD1N8VxD5PmdFTdsqylaT1pLTrLIx2NrgOaCMZhA51C0oB6SG2IPQd2iVoWwlwhirPjLgGUPgugxjj61BwlbPZ39Rsmwk06wmdB2WlaK7yjw6WNiV7aJq2ehG/MqVAa8fpVRSszepmRUtvufgOw7avKssa6SleJ5mECwayfHC7gy2+iFHi4rnt7tkq2iT02XNWjfg/qzgZFmTNy0G2DvLcTAcLiuMhvvTip1BRC9w2RpEnCwrQFBJQ1ZXjJIQpTWtUlStwhMw6ng0GCopcBwIfRvzHvkOs9ym+h4tK76006cb+fi+YlG0eELw3Chm1An50k6HsjGkteKf3j6hVYZ4JfCo5ZKjZYVSZqX6gtB3kdJOzpPU1owOlyX9xIooamkXWaFnP+O5D+iQd3ean+9uP0jqC1/cTuE3gH+0+vkfA78JPJoURsaYBwBCiOFT3nuBLwhr3ZDQd/EcQeS7581HTrOaspY8nJW2Ycs4RhqP6+MuSejyq9dGfOvaGN9zKWrJrf0lWlv+eVk0bPUC5qWNDmiURmqNQeMKgdTW7TzLa1op2RklbPUjzvIG37HcdS+yscWOI2iVYRT5COMglZW2Og40UvJwViGVplqpU1qliAOPF7a6fO3ykKJVdAKPl3d69BOfRmqur3W4O8nPw9le3O490zlrVsqqT2tws2mtcDS3zV00GVWjaKVtkDNMbLzznZN0ReVppJZ0fZeNXsjxwrpjW2nohz4GzTRvwAikNASOoFoZnxoJrdb4wnoaNvsh2kiEK2iNXWHWreZ4WVI01hBYVDYJ9/I44Xnf4/p6YiWnQtBIw3PjDr91a40Hs8IOctrw1ctDpDbsDGIcR+Bgexs0Up+n22ptv+vx83f7OGNv1b3t97+0xfNb9m9SxrYA/OJWH88VmAdzPOGwPwdhIG8krTZ4joPrC/xV2F4n8vntm+uUreTVu2c8XJYIBGd5xa31hF7oUycaYwxGazB28eIJQeh7rHV8fBfSWnM0L2mUYa1b89JOl3khuaMyHMexYYuxR1FbR34tJVklqaTiYK5olOKl7T6h55KVLc9vDlhUDVJB6AmWwqCMYlHasEnfcfBc8B2XRmme3+p9qOjhPDSxVR/4GvjiJoUhcGf18wL48mPPPb5X/PnPLP5Lhm7orYq5LfPC5h1llcRzBKPE5/60YJrbyIAbm12ur8f8ytUxniO4c5rZlVvdMitbtrshx2nFm8dLlrXGFwZjNEobhOMCLcKBVkIQCFzPIataIt+jE9laQCE1PQfWewGX3YRl1VC1hkYbBrFHFDjkVUsnDHAdwDgIFDvDhPWOjzaCXhxwfaPDw7MKhOG7e3P6sc+4GxD47rlL9FndosbA7eMUYz46tuFpmOU2Xny9Z2WmL2z17MAEHM5LBrHHi9t9PEfQCV3SWpLEPpHjcLQsSUIfBGz2IhzH4WhhlVmOEHiOi9aGShl8Yc9BKWuQ7950WgiklnSCDgZt6y9S4biCvG45WFasrZriDJOAyHcZJx7DJOTemc2XetTp7Pde3KBsFK8dLEkryc3NDlfGCbO8ZhDbYehwUVI2iq1eRC/yzg2CvfdILotannPsZSvPG9bEq97Hj5o0/d4LG0zzhoN5yaJoOFpUlK3i5Us+/dDj2nqXb98+sU2AMFwZJZykDQ8XFQYb1/Kok5zvOBzMS2pjf6e1vjXvSaMoG40TemA0ldQYrbhzkhG6Duu9gFHHNo5aVi23j1MaZXhxq4fRmnE3YG+SM+7YfhWnaQnY/C+EjewIV/HtA2V7TORNa/s9L0oaqYgjF9+xPaB//fr4A6khe76bD8zzeoQvalJYAI8yYPvA/LHnHr/znipNEEL8IfCHAFevXv08ju8CH4K91Ta0ahWjjs9XdwcoZfjpgc2Ff/s0Zxh7dCMfIaw6QjnCZvhXLXtTG89wuopXXpT2Js+VpTTuz3JcYdtqKmXpKk9YXlghaKS0Chdpi6WOcOhFPq2ykQyNNPRjH411HHsOuELQjzzWej4uAb7nkrcto05A7LmcLCveOklxHYMyghe3epDB5WHMtbUO87J5ZumpNubd1pOtZMDHf79UmgergbVoJC/t9Ak8h41eyLffOGFetKx1Q3ZHMRu9kGzVOnKaNYw7gTW7OYJ3TjMqDaMkZFE2uMJllPjnoYVKaTqhz0Y/pJY2S8n3oKgUdWtopVU37Qz81arWMMsqqgYcAWUt2ezHJAHcOyttYxnPwRcOi6phnNjC6w/vz8gbG1gYui7z3GZo3Z0W3JkUvLTdZ1G2KG3Ym0xt4XUQ2ejrx3C0qIg8h9BzeWG790QPBmMMdyb22uxFHkVjnfc3NjrcPbUxGh1lFwvr3ZC8aekELj+4PyUrFVdGMbUyDCKPVtuJpWwUlwchtVQcLEqMgiix/Sm0gcO5JJMNR2mFKwQGgzYQGs0705SzImAQBcyKdkVDtoSey8mixPddAtfu5Hwh8AOXVsPXr/RJfJ95XqMNHNSS3WHE3jTnLKsZJnbHjjDsjhOWdXveLOjxDoPvRT/yP5YD/1NPCkKI3wH+wBjzbz/D274D/G3gfwV+H/gfHnvuTAixi50Qlk97szHmj4A/AnjllVc+v2alF3gq2pWMMA5cbm50z52p1iiUWhey67KsrGntJK25tpYQeg5pWbM/s27o0BW4roPWmkYZtNbUEgIPHNdyn1pLNFbt0+8E5GVLJq1hKA4cesKjG1pT27xsCTwXz7GUU121zHODNpr1bkRaS/JaUSvbrL6VhthTtFpz+7jkOK2YZjYT6fZJyq0NS2XEgUscfHjHq0ZqTtKK2HfPm8a7jmDUsc3hnzV+wF3l98/ylqLxeXG7hxCCZSUJfZdG1dStZqMXWp/IJCP2Pf76V7fZHcUYA//gT+4ySWsuDxMiX3Cpn6xqEHan1iqN0ppCSrJ6tTrFUiMTaia6oVUwzWtqZWmwVkJlHrVYBRzDsmqYFIZh6LI/c1nvBYw7AVdGCeNOsIoFUbbO4bn0IjsoV63GaFYUocZzV2awlZM5q+X7JoWikfiey7X1DlfHCZ5rV/CPYqYftfp86ySlXLmpv747YNwJmK4ktwezkrdOMoZxwCStOJw1ZKvGUM+NknNH+/VxzGvHGXdOc0pp6UwlBDu9BKntjk0IQas0WoPj2j7iketQSU2rNXVjaFptTX7GoFf1kknestUXZK3G9wS9jk/geWx0Q7Z6MduDkJ/sSyZpg2OsdFcZgza2lvH13QHrvZDn1jpEvss0b+hF3lOb9DwrPtGkIIT4FeBvAX8TuAv878/yfmPM94UQlRDinwM/BO4LIf5jY8zfA/4T4H9ZvfRZJppfWnxU2N7PugnP1XHCNGsYJj7LUpLWNrrg0ap1qx9xd5JTNoqyVlweRrx5nPLdO1MOFxVrvcDyplVDq23cbywN2hHkRYMRBiFchklIP/KZZC2ua3nWRmrqlfoD4RFFLgfzknnWEAQuoyTg8iimNauOVbLFdRy0trxy0So2OgFHy/rc+GajIdyVictFOIJB7NMN/fOsnI/C4aJkWUpmtHTCd5Ufu09RLn0cCCHY6od2QvJdjpYVApv59NzYdkobxFaimNeS42XNZi/kpe0B24OIHz+cs923k0PoO9zY6PHGwYJGaltXaa2fwO7kDO6qqUE/DnCFOOfznVWvg6xqaeTq/1jJqufb6G2pDI7WlFLQC13++ld38F2HtW5AKzWdyMNBcLSo+caVIdfWEnpxQKM0oe8QeS7b/YhwZYQ8y60nYqv//ol0ZxBztKzoBI8Ks4pp1gDWZT6IffJGcmkQc/s4I/QF92cFWhnunRVEvlUPpVXLPG/BWJms53q2+DwvKRtN6AkeTHPrYnYdPMeh1TbYcVG2pLWtT3RDS8MFrkPVtjiuwyC2/gGb6Gt3jIHnEriCcScgb/RKhafpRh7KGEadkF7gkoQenmt3G9v9mF7k89J2j+NFxSRrySrFpWHM9jDi67ujc6qo/xkaKD/2pCCEeAGrCvoDYIIduIUx5l/4JF/8uAx1hb+3evzHwG9/ks+8wM8GSeCRjD1apXnjMAWsPvrWplWJrHdDDuaWHw49gSsEr+7NuHOaM+p4XF/rMk58fvxwwZvHKYHvsDsO6YQebx4smZQNw8jDcSz37ToNUtk8nGHkkdbSaueVdebWUmMQ1K3tmGWEYBR6BA4cp9ZX0EqFVILYd7i12WPQCej6Hje3uvzGzXX2Jhm+67IoGsbdgKvjhPVu+LEVRv5jyqzPqhHKc2sdTlMrp52kduDb6IV8dXfIqBOQ14q8abl/lnO8qJgVDS9sd/Ec0EqvdO4RL13qMkkb5lVL1ShqKekELr7jU7WSRWk9GWuJb+Oj04rGKLR5jMu19VWMgJ4v6MURceAg0MzzFu267I46/MatDX7zxjoH84LXDlOySnJlzRrChh3rMN4dJedxKi9t93njaMmf753x8qU+G73ofVHYj+NR3eARAtch9AXTrGXcic/lw2WjLB31qBHQ8ZKyVQxin7VOwKyorTfGKG6sRaz3Y6pW80/fPLUtSSOPrGopWk3TSpLQwXUEridYFA1hYJ3MjdS4rmC945E2diEwiH1e3umDsLudvJKkte2f/fx2j3luey4oraildUNXrSarWjqhImsU37oesNEL+d2ddU6WNZ3Q58WtHrFv+0wczCue31KfuOfEh+FZPvEN4J8D/6ox5m0AIcS/95kf0QV+YeCuTFSTrCarBbujmMh3yRtL5Whj8D2Xu9OMrJYIx6Zr/s7zG+zPSv7Z7Ql1q6ikohcFoCWVAmEcGm1YD1x812GSN9StxHdtBo8tQhqktPp5g1ndLA7z0jp1N3oRw8Rnd9RhktU0sqE2didwdZxwfcPGPnuOw5tHS6tC2u4yjHyS0HtmuenOIKITusxyW9B8RMV8GiSBx3NrlhtfllaP7zqCwHO4PLKd1mqpGMQBjmsdrm8dZ/zk4ZKTtEJpY38XP+C7x2e8frBEacNWP1zFMlivQhLaxkfSwHFao1pFszIteI5tZakVqKq1KhDhME48jIBpLokDj0HiszuMEcJwtCyR2lg12EpivN4NeOMopWokf3b3jL/20iazouUsr3kws9Hrrx+mjDvhM02qQggC1yH2HZaVZGf1vY/ivg0GqRSuIzDGFtGXVUvoeRRNyf6i5NIgJgl87k2XIKyY4uZGl/tnDu2yBDStsfUtp4X1rkcc+nQCl3uTnEJpjjLri/BdgdIwK1qMhsC36qubGwmR77HVtXHckS84TjVJ4LDe9ZFGcLy0dN161xamlbE7kHnRrvpG2IZAbx6ldCOPe9OcL1/67N30z3Ll/2vAvwl8WwjxfwP/MxfqoL/UsKmWMYvS2vYPFxVXRjF3Tm1bS3elinFb2F45MH/3+Q08V/Da4ZJBx6eTe9RKc5a1GGN5a4TA9wTjXshkWdPx7eRQrxzL/dgnrSTSEbhoxknAdj+kEwfcPsooGskgUVwa9BDCoagli0JgtOHyKCYOH/UJbrg6TjhaVKx1QxwhiPruh04IxhiO04qzrGFnEDHqWIpDCAFGkFYKsB27PiskgcfNzQ5Sm/NCYei57I4Sykbx/FZ3NfgZ3jpOOU6tX2C+qhtUdQuOHRE1hlHHJ1+ZmC4PPe6dZWS1puu6SK3xfZfEVzjGxXUFaysTW2sMrVJEnmBaNngIlDS4vmAYB3zj6pBhEnDntGBnGPFrz43R2M5go07A3jTn7mmN49T8k9uGRsJax0dpTei79GP/Ew0otlvauw11QsdddV9rOF5UeC7sDmNapdkZxmS1ZF40q0K0SxJaSSfGTmBB7PKNKwN2xwl3TnOOF+X/z96bhViW5/l9n//Zl3vPXWPNzMi9qrOqepma7lnUM2MjxiOErAcb7Af7xcYwxiCDjbziF70IWR5kgzEYhBHCWKMHGywEftBIzEizSD2a7p6u7q41Kyu32CPufs9+zv/vh/+NW7lXdlVWLl3xhSAy7xJx4txz/svv9104mue4lonvGPQbLr6rqaiTrKSe6R2UKSAvFY4peX9vpnM3lMKxDbaHKdfORChge5hSSi2YO9P28WybopZ0QpcLHZ+rqw32JilrkcfxvGCl6TJKCtZbAZFv4dsmUj2cRzFehCk1PYuN1pN7YE/CU08KSql/BPwjIUSIFpT9F8CqEOJ/B/5fpdTvfe6jOMUri8AxsU2BlArP1vXWpmchpeJcN9Ch5kpyvhsQuJamB2aaZ32+GyJLvX0+nOZ0fJeDeU7k2qy1XMZxiUKw1QvZm6bYpiApFK1AW2FXizpxXEjioqbfrFBK0Q1smo5FXtY4C2Vu07Nohw5vbEQ0PZOylORlzU+3x0Shdg7d6gUIBO/cHXM0y7nQD+5rpINeAb6/O2OclAzigre3OstJxLWNZd6w94xttQNH/46kqCgrtaS3bvUCJmnJ6+sR37815PrBnGlaEVqCOC2RwK1BwuvrTc51AiZpwTDRIT1ZIUmVxHMcRJwyyys802CUa0pxN7T132QIAlNwdbVJVpTUSk8uWVlT1BLLgq+f1ZGT26OUy6sNGm6DK2sN7gxivn9rSMOzCG2TvK4pC8m7O1Ns0yQrPX7jtT6Bo3dnT1LaPg5n2j43Do9QwJ1hwtW1Jg3X4lI/4O4w4d3dGWUteW2tSSe0WW+7fLiruLza4Btndc9mZ5Jx+3iO75gErsEPbo8oJfRDh2vrTe6OYqRUWJbB3WHKKNUuwLYw2OwEWIYiLyRZVWOZimmuXUxLpcjTgnbocneUkJYVSV5jmlp7AArfNhAIXlvzWG16KOD9vRmDme7bvbHRYi361Gq813QYzgs2H9iNHs40+SAvC1Ya7vMzxFNKxcDvAr8rhOigm83/LXA6KXwFEOfaeM00BJf6DQ5nmQ7AUZoPX1Q1d4cpu+OUYVIsrCJSNts+Ld/i48OYvXHGa6sNvTLzDKSwcDqCUVrSCV0CxyS0TeqsYl6WRB2P9ajN3iTn7nBOUWnLhVqBa1lkVUVWSm3C1/AIHJ3JfP0ooZRyyYJ5fSOiknDzKOHj4zllrbTDqm3iBZoVsj1K2BtrPvvhNF/Wv09gGmK5mjUXPkgn8GyT19aaz0Ss9iikRc2NQy3aWqtcViOt8F5t6t91qR/ye1JhCrAdC6/WjKi2sukEDhdXG3ywO2EYFxSlwrVgklY6v6CWGIYgl1oZbtumVk9XIJCsNhzePt/iV6+scDjNGacF//ef3SU2KqoKvndzSDdw8RwDf2zyW2+sU0vF9z4ZMIgLdkYJSkmO5rpJ2/YtzndCLCEYJxUN136kLcMwKXAtTTl+HExDK9ql1F5QF/ohB9OMu8Nk4RiqE//0d4OdYUZc1GwPU4q6JikqfEdrVnqhy9Es4/YwBaEYNj02uwFb/QZIuHk8xzQMirJikuY0XJueq1fmZVVxHBdIWZNXglFV0HBMBIYufQoIHU0LlcB60+NglnHjaMY0q7i00mQtcrVfkm1i2YLdYcLtQULk2fzypS5SaZsWgKN5QeOe8xJ5NkdlTuCaX6iv9YW6FEqpEZoa+ne/yM85xauDSVoipb5h47wir3TYvYkWdxmGwLEEmy2fQZxTuTpUXkrFwSTn1nFMUUviUt9A81yL1XoNj6zSwTGhY+oVaiHwHC3K8UMLSUbg2tiWwLctlJL4jsEwKalqiRA6jL7fcDEMxTSrkLWi7dv82pUVbMugEzjsjFPe3uqwM0qZ5yVHc+2eudH2lgyWoq7pNRzcB5hHLd/m7fNtRkm5zC64F5/H8vlpcRI+D7pkkhbaGTR0LQJHM6j+yjfW+OHtMYeznDir6AQu602fftOj6dsMZjlxofMOpKYfYZmCKHDwTJN5UWGKmmrBDLINg2IR4lPUujzyG6+vsj9J+OnOlB/eHmJgYKAtxata75IqqRjEOYFt8d5kxjAuiQJLJ5Y1XALX5Op6pEVbD/xtJ9DZx3oAvLr2eFsGEGy0POJcM5ZuHM3ZHqZUUieRXegFWIs4y7VIR7QOF6UmpcRCQ6Ancsu1mKYFrm1Q1YqV0KXtOxRVxd44Z6sXLMOA9qfafLDhWVxZDTmeZVw/jpnEJYahfaJWFwJI2zRYb/naawuBabIgNpRYpmCSavX90bTgOxe7tAKH41nO7jRjltWstVwOZznrkbe0Annw2lxvefQbjl64PCJb/Glx6pJ6ip8JncBhllWYBjQ9C98xOZzmuLZYDogXeiG3Bgm/sNWhGzr86O4IQwh6TXtRjoFvnG3R9GyuH8woS8VGx6XlWwuKorUwKZsQ2i6BY7E3yQhcE9A0zbWmTqn6+GjGwTilUlBLSVVDwzd4fT3iG7Xmkl9dbWAaJqtNl7SoFzJ/xRsbDd7bmwHaHdQ1dcN0qxs80Ygt8h0i/9klXT0tGq7FZtujrBUrTXcpItyfpIyTEs82ubgS8ltv+vz+Bwcopc3fLvRDvnulT1pUHMxyFrk41JUkqhSBY+DZBqYpuH2U4liKYaJpnSuRS1ZUTLOKtNJ0UQNYaXhsdQKGcUHoGHznYg9hQJbXdEP9WdYKzvdDuqHND+6MiLOSzmaTbuCyGrm8udlaUDDFfU6fSqmF+WJxz2P665OjOZ5t3sdQciyDaxsRaaHZRdcP50Sejis90/W52AuXn2Ve1bi2yRsbTa6shvyz9w9Zj3QuSOiYSKm9ln66OyYpar51rsV3r/S4eRzTDhwMIXhzs0Va1AzmWvFsm4Je02OaVkSOQ15ow0bbFAgD1hou5xYOqtodGJSSlDVYVovjWYFAUCsIXJMzbZ/LKyF/dP2Y4bxAoMuH3cDBMg2urDYoaolnGUv19gk+b8noXpxOCk+Jz9IKfFXgO+Z9/j+WCQrF4bQkzvW2d6sX8vWz2rZKSh3JCBDnJW+f9/Fsg6urDVYjj7Mdn25o8fFBjBCCc10fxzQZxDnrbY9pUmmvl2OJMBWvnW2w0faxhOD33j9gllV0A5uNhodpCqoaEIq60gpm39VZvqZRczTL2Z+mC5O0mq+thxzNtI32Rstjo+2yHvmfq679vHAijNubpAzmOZahWTdxoU3vNkvJWuRxbTNaTNKCrW7I7jjl6lqTf/dbZ7jQ9dkZZaxGDjsjreSuKknTd7jQF1w/muuIT1vgmiYZNaO4wjZz3jjT5GCWEec1SVFzvheQlJL1lk9dK45UjmEIfroz4Ww3xLHAdy2+ea6NIQSRb2uXUNtaCODUQwPZ0TznYJIjlaLpWvQXeo1y4VYa5zqq9V46phCCpKixTYNz3YBpWnKxH/DBwYyjWc7bWx082+Sj/Rk3jmImacHVtSa/dPGkJJMRehajpGSz5fOrV3rcHeqdwD/56T5JXrHVD3jrTJtRkvPe3owkr3hjM+LNzYjdSYYp4I31BjcGWptQK5hnNZO8Yl1K/sLlPhf6Ie/uTbGEzo4+3/ORgKnAsg1Cx6YTOmyPEqZpiWnAlbUG19ajpb3D0Tznk8M5lZSc6wZc6jee6TV7Oimc4gvjxL7446M5G5HPYF7w+nqTSkpuHsfsT1OiRRMxdBesmVLS9Cwars2dQcYwqfBsk/1JzjfOtTnb9clLxSwvOJ5q98lRUmIYBp5tcXeUEOeStJTsTjNqBW9uRrQCLb6aRq7keAAAIABJREFUZiW3RwWWoWmzZaVwLF2SSMsaxzTZG2eM05J24HChFxA4n6/R+bwxy0qOZwW+beHZBmfaHtePYmqp09gU0PIc3t7qsjNOGMwLlIKirNmdZDimRb/pstL06IUew7jUquVKEpeSvNQ+R6ZhcLbjsT1JcGyDwNX21rcH6cJcTi52KBaTpKIVWEzSkruDhO1RQrQ7xbNMosCh6Zr4rrYTUYtIz0mqnWfXWjoh7wTmYuVrCMFK5C77CSefje4P3D+RbA8TdkaaCvsbr/U51w14b3fK4TQnL2tWGg5X1yKtdK/0AsGzLO10apl0Q4fVptYLHEwzLvQC2kHFH3405sfbYwLbYppXXOo3MYXAMgTd0MU2tbXEuztTjuKcrW7IuV7A7VHK9jjBMg3agctrqxHrbR/XNrm2HvHRwZRhXNBv6p3w/kTbZKxs6knfMQ1MQ7/XWCjZZ3nFm5uR9sTKtXlkv9DKafdz5CY8DqeTwim+MNYiT1PmFje2YWjl6zgp2Z9mzLNah7y0fNJC8s7iJjvZ+uZ1jW8bHM8L1lsed4cJlxbZtdsjReLVSHQWg2OZtDwbqxcyS0rtFmkZRIG2Cfg3Xluhloof3RmTVwmeZdAOXXzL4NYg1uZwAi6vNMmrmqySVJXEdUzyexKsslKvOp+VEO1ZwrE+ZTl1FjYSDc/GMnUzFeDyakha1MRFpXdKC0sRISAt62WDPK/0YO7a2pok8SrqWuLbJl/bbNL0Xa72m0wzrTv50Z0hrm0TOCZ/8WtrHEwzKiXpN+yF0Z6BYxpM04qkqIk8G9cxeetMhGHo3IOdcYpr6dds9XymacXqPeazvYaLZRgYi/yNE1iGWIjzHv5caql7SLYlGCYlZxyLbugwy0ryUjJMdA7Im5stHFOz5OK8ouF9KobrNTxGSYUhdD6EKbQZX+RZKCDyLIqqotf0eHurzVFccLbrkeQ1R7OMduACgk7DpeE7vLXZInC1TuGtM20ajsneJKWotK9VXine25vyjbNttnoBZS3pLspoq5HHd6/qvOi0qEhLbQMihKDXcEiKiloqQtfENh5dMtoZp4wTTWm9d9L9LJxOCqf4wlhpuqw0dSDJNNO1bb1CslFS11Y7vrPwitE3N2if+F7Doah1Qtq5nt4d5KUezMyF3YQhBL9+xeH9/QnHs5ybg5jLqw3+rbfWudQPyaqaD/fnKKXYXzhc2qbBG+sR/abLuW6wiJI02JvqG/nb57scz3Xju1aKpmtzOM2JPJtZXnIw0QE8V1cbz6RO+yzhWrqEV9VqmfwWujr3+JOjWHvqdwM8S9t+hI5Fv6kbkJdX9KD68eGM6wdzLq+GXNtocb4TMM4LJknF1zYjXltr4pqC47jgXCfgYJbwoztjtsc5q6HelW22ffpjl51JympTs8YansX+OCerKgSC/UnKjaMZaVHxjbPtZcZ24Ji4lkHoWA/5GwGPdZR1H0P1vbyqQ48s0yBYsJjWWx5vnWlRSUXoaJq0Yxm8eabFreM5NwcxpgGRr+mw3VCriJOiphs62KZ+7bluQF7UTBdRpW9GHue7wSIlrub2LGYt8jAM+KWLXXzbpKhqzvdChknBPNO+Su9sT5BK4Vp6AdJwLVYjh1881+GHd0YLg8dPG+4nA3lV63jaE1LDRstno+Vzd5gwTkpuHM25sno/dVopxXDRpB/Mi9NJ4RQvBoYh7rPlLWvF+Z42D1uLdAQnaAaTDph3abgWB9OM9YXY5tpGwB8vGmyHs5zz3YA4nxHnmhMeeQ61lMssgeO44PJKg8Cx+N6NIR+OZkggL2vWIh/T0M6iw7jAtg02Wx4d36Ed6K8rq00Op9qgzzR00/DEVK2qlebhv2STAuhJ70HW62Cuw4PmdUVa1oSuxdWTpuTixZ6thV1b3ZCdkfb+FwKkgEu9kGOvYJ7qz2S16dIKbN65M9Zsp1JyMC0whKbltgOHo1nO2mLA2Wz7NH2bNzdbGEKwO075gw8K4kLywf5c9zo2Ir51rk1RS2zDeGblOs+2+Na5NvVi0D3BG5sRg3lB5Nv3/a7Id+iFWo3ddC26DR0RKpViq6f1Ne3AIc4rlNTurC3foe07xEXFnWGBZRjawE8YfONsmzMLRb/emRkoIM5r3fNZ7Eo+2JvRb7r84laHvJaL7IhP7ayHcUm/cf8ArhdYDxMb0mU+gvaxulcvKYSgHdhM0nK5+3hanE4Kp/jS8NH+jLyStAP7vgvzZEA+QSdwlgZ7kafZP0rBNC15b3fKOC14d2eGYxk0PIO1qKFXW7UOjRnGBaN5jkRRSkXkanZS5NtcWQ2Z5xU7o5RZWtMKbFqBQ1VLbg0SKinZWuwkTrIK1iIPqVItZHJejVukWriY5lVNezH53hkkBK55n0NrXmkPKcuAK6sBpmlom5Ks0o34Sco722NWGx7DlsfXz7YwDQNQXOyHyxLHjaMYhKATOJhGRdOz8R0L/57zdWmlwd4k489uDrAtm8CxaPo2QojHrvi/CCzTeGhAO/HpqqVie5QghKDj21zbaKLQCvHA1T5eh1PtM3UwyYg8G6W0225Zy0XqnuAoTtmfZcyykmsbTZq+zWbbY3ecEriavXQCbbRoMM10otzuOMWzNQ31+kL1v9J0GcQlriXIK/Uz2bNvtDyOZjmRbz+yzHmuG3Du85zHz/GeU5ziPsR5tZTXnwxAeVVzPM/ISsW9JU9tQqazfU+2u6tNF1NolgrAVtfn5iCmqHRu7uGsoBVqI7O2r/sKvYbDPNPMpMAxOJjnlJXi7a02X1uPmOcV7UC7Ve6MEkZpwUbbI/JtzvcC4rxeZkXfHaaLWFGtCj3T9rm08iRe/MuHuyPt0qqU4mK/we1BrPMrFgrzk0H4zkBnNCi07UVcVMRZTSq0M2hVaz/+uyPdXHYsbWWSlTW/crnD7WNdsmgHNllRM5B6UBrMc1qeBUKwN0mxTL0r++6VPt8610YufJheVI9msMgXP5pnOKbJauTyq5f6mIbWVwzmOtbUNgX9pl6wjBOdt2C3PdZa2rH3B7eG3DqOEQIajk3kW0zTCs+2GM7LZf6yb5t4zokViSTywHMMjmcF01RnKlS11po0PMFmO8B3nnx+aqnYHafAYlfm2U8U9X1enE4Kp/jC0IlZknlW0fJtbNNAKdho6/zYjUhvh28PYn54e4xnG7x9vsNa5DHNSn54e0RZKdZaLq+vN5lmFVWtOJ4XbHXDxWpUD1hJUfH+3oyqlpzt+vRDl51xRuhYNHs2my2PuyM9yI8SvcWfpCXuwkjv9TWdSxC4umFb1pJ+w2Fvkmmb6S9RfPZloqold4YxUsHZToZrm8S59mDKS8mNwxjLFNSLLIyslAj0wJRV2gdplussg7e32tiWSSfUE/C3zrW1Z88oJS4042s2ShjFOqRoOC/wHe0ndW0jWpr3NRZGec8zy/pxcBfls3wRuZqVNbcGMfnCSnyaVtwexjiWoOFaZEXFnWGGbQqKStJvuoySEssyKeqay6sNZnlJKRWH04xWoBXZhiHu25ndq8k73w15Yz2ilFL/LMOg6ZrsT3NuHidPTOdLi5p3tsdMkpL1loe3iFn9MvBcPy0hxF8F/ge0C+//o5T6Ow88//eBa0AK/F2l1O8+z+N7VfGi8xY82yQtdO7ACZ3Qs00urYRkZU1vYRo3TjUDJCvlMqjneJbrOnhe0alsBDpn2TF1mPpqpPMZTlScP9kek1faumB/nJHkmi3SCxs0PD0IHc0Laqn45Cim33Q5mhULq4tP/WNs8/685aZnU0n5ypSLHoZm36xFLnkludAPF7sqHXJUS7V0SBVCq8YPZ3p13G+4TNIShLYuObMwjVOopWAKtPtlVes4SlOY9BsGRS0ZpwVlrTiOjWVkqRDaCwr0rjFZaAte1E6h5dtcXdOMtnFa4loGo1hfj9NM02s1GcFhZ5Ti2oYW6gntEqsUFLVe4KR5g9dWmwSOSVJIViKXXujQWkSS3gvfMdnq6cVR7x4H2LVI99AG8xxjcU0W9SODJvXr4nzJHEvLmmlWcjzP6TfcZz45PO874B10VoIE/rkQ4v9QSk0eeM1/eGLNfYpXA2c7Ab2wxrHubxw+GP93oReSFxJn0fAF3V9YaWpa5OtrzaVF8NEs56zj07mnF2Eagm+e06K4H90d49oCQxiacx99SrvbaHtM05JaeTimyYWe9qZpPyEj2bEMHF7NXYJSiqxUnG371EotbbtPVuidwGaSlNiLkJeTQf7C4vk4rxjFhd5R2QaRb9FtPNycPNvRNg1pWSOlLgUqFK+vN9mbZJxp+fQamsGjm/ZacXvjMNb0yaR4oWW5kwyHEwGgUgnTrOTaRkStJJ3AJs5rug2Hutaium7g4Nn6uu6HDd7bm7LVCzEMLQqcLNh2T8o10H2CR1973dChrBUKdZ+q+0FEvs04Kbm0EnKxH3DrWJeRjmb5qz0pKKXunPxbCFHxcAazAv5PIcQA+GtKqdvP8/hO8flxQo18Elq+zS9d6t73WHfRJ7h3MjmxhX4QZS25PUjIqppKKuK4JrRtWr6mvt4ZJHQbmrev4x513+BFrlCfB4TQ1N1K6mbzOClZi4zlrihwLN7Y1JHou+OUYVwsE/JATx6haxHGBfvTjP1p9sjzb5nGfY/LhdcVsPTwuXenNc8r7g4TdsYpa5G73EW8LDjXDZguEtjaoc3b5z+9Nue51gHc2/jdGacM4lw31NXCMLDQyW+bbe+p6vuTVGdTe7bJxcXk8jTZG5Gng3uEOPm8KyZp+cSFzufFC1kaCSH+MnBDKTV74Km/rpT6C8DfBv7Ow+9cvv+3hRDfF0J8/+jo6Ms81FN8SahqySTVRnZPS0ucpCVpUTNLK626tU3WWi5fW29wNM+XN9wJPNukEzo/1xPCCbZ6AatNF8fUEZ3Thco8W5Qa1KK4faJuPp7nD/2M47ku5Y3ictl4fxLu/dwe1Ts4KQ1GntYlnOt+vmjSLxN3hwmTtOTOILnv8YarRWvTTAskq1oynBf0Qh2Ac64bUEvdjC4qyfG8eMxvuB+jWMecJnm9pJQ+LYx7jO62egFvnYmemFL3efFcdgpCiP8a+CvA3wf+EPhvgH/7wdcppYaL738shPgfH/fzlFJLZ9Zvf/vbz2T5cept9HxxaxCTFlL7IK01P/sN6BvVMHTJ6XxPDzDnOgGGYeBYBnkpn3mOwasEXc8udT3fMigqyceHmvrYbzpstHy6DYdRXCz7PPeiFdhkk1yrZJ9BSNBJGFIndLjYb7yUk7NnmyQLz64HsT/NtFmdgNfWmjQ9i1lW8fpak5ZvLzNEslISeU83lHZCh3leLRlKXwRfxAn1SXguk4JS6neA3xFCNIH/D/iPFrkM90EIESmlpkKI14Hx8zi2U7wYFJWey0+aawfTjKysWYu8x2YRJEVNYJuc6wR852L3vvLF5ZUGaVkv1axfRfQa2jjuJDsgK+sl+6VcnO8zbZ8zj1ldtn2HJK8XYUFffMA5KQ3mVc3dYULgmKxGXzym9FniYi8kWaTQPYiTc6aUpoNe6If3XXOGIbi61qSW6jMnvMNZRpLXS5X145CV2g7ds81lee9543k3mv8acBH4e4uL7j9GM43+E6XU3wT+wSK4RwH/2XM+tlM8R2z1AsZJsVSNngiHBNqz/kHUUrEz0s21UmYPKVRNQ3wpIeavGu6t6WuLaZ1TsdL47Gbk4SxjllXMMr0rexYceMMQHEzzxc89Ebm9PBO38YTrZr2lnXc9y1ge86NKnZ81IWRlzcFEX9+KbOm19CgcTDOmqc7kbnrWC2HDPe9G898C/tYjnvqbi+f/6vM8nlO8ODRca3kzlrXEMEBKLfB5FIwFxTEv5XJVd7ISfpkGmZcNvaeYDE7g2yYjShTa3uNpVsBP9XMdc5HBIZ5JWep5wbGMx+6qQC9UTnanT+qLWYYOMqpq9ZklI982mabVkr31InC6tPoK4EXrGD4Ltmnw2tr9Bm8PQght5pYvhFZxXnHzOEYpnij6OcXTo9fQNs7bo4TdUcZwXjx1v+dJWIs8Is/GNsVL6SP1efHJ0ZyslDQ864mrf8s0lh5Un7XyX400i+lFnqvTSeEULwUeZfD2IKRSTFMdXF8rtayX51XN43jgp3h6SKmYZSXDpCCwLfJKPpTs9XnxKu/msrJmlBQ0vU+DfZRSS6v17ClYRJZpPPUg/6LP1VdmUjhlF7362BtnWnkLXF0L6TUcpFI/U4nkFI/HwUyzbQBMA860gy+N4fIq4e5Q+0UN5gVvbERLaui5TsA4LX5mF9KXHT83k8LpoP/zjxNjPSHAEMaXwtH+KuPEoiSwLS70w1fY8uPZYsk2EoJ750jtuPvzt0MVSr1cKsOfFf1+X124cOFFH8YSxSIowzaNZZjMq4Jbt27xMp3LVx2v6vmslaKs5MLi+uXpAbwK57OWuklvvGTn7lH4wQ9+oJRSDx3kK78UuHDhAt///vdf9GEAmkXzwZ4WaZ+IsiZpyd1hgmkIrqw2Xhij4Gnw7W9/+6U5lz8PeNnP5+Es42CS4zsml1fCZano9iBeOp1eXAlfGqrvy34+AW4ex8wXavLLq4/ebe1NUo5nxWc2qL9sCCF++KjHX94R6hWEbWozMSFYGrnNshKlWNg+/2yy9lOc4svEycCfFvV9Dp3twEEI3fD8KosBPw+6i3MXuOZj1fUnfbF5Vr10flDwc7BTeNlwvnf/zN8LXdJCh8A3n3LFlVc1eSVputZpo+8ReNkptq8KVpou+5OMxj0hPKCNC1uPUd2mRU29yFk+xcPQfYb7z92D9/Na0+NwltN6SY0aX8gnK4T4ZeB/Qbuk/plS6r+857m/Afw7wAj4x0qp//lFHOPPiv1Jxt1hzEbbv89J0nfMn4nrXdXar0ZK6DacR4pnxknB7jij4Vqc6/qnE8cpPhdavn2fC+jJjiHy9OA1igsOZhlNz+ZM2ycpKv7k4wFpUfHmZsTl1S+uYXiZsDNOmWUl65H3yEzkezHLSgwhPjNA6FH3cyd07rOEfxQOF0ywTmiz0Xq+hIoXVT66DfxFpdSvAatCiK8/8PxfV0r9m6/KhADw4+0x26OMP78z5os072ulljmvZSWXIq17XS2PFyEyk7RccqVPcYoHcTzPuXkcE+fVZ742K2tuHM25M0g4WFiOHC0iTofzgqqWJHm9KHnA4ezpXEFfFZQLF9SyUhzNHnaQvRejuODWccInRzGzrHzia0/u57KW3DqO2R2nTzU+HM/0PX78As7zC5kUlFL7Sqls8d8SeLDY/reFEP9MCPGt53xonxvBQnASOCZPOyc8qp7oWiZnOr5eIbQ99iYp86xib5wt08o6Cxpc4JovPcPhFC8GZS3ZG2f62pmkn/n6Wn4qBqykFq2dlIhC18QyDXoNh7Mdn1ZgcekFNki/DFiGIHT1PXzv7ulRKOWnC7Gqfvgeru7pz5zczxLtqDqYF0tb8yehE+pj+DLyEj4LL7QwKIT4BrCilHrvnof/V6XU3xBCXAX+HvDrj3jfbwO/DbC1tfVcjvWz8O0LXY7muk74NPkAh9OMg+nDzA/Q7pIngphHRV32Gi7de4Lvf95wqjn54jCFwFnYZz/OdfZehK7FZtujqCX90OHG0Zy0kKw2XdYWITBCCL5zsfvMVM4vE4QQXFpp3OeC+jj0QxeltF7mwUH7hLnVCe1lGVnfyw12RunS1vyzsNHyWY+8F3KeX9ikIIToAv8b8O/f+/g9mQrXH3dCvow8hS8Kb2Hp/LSYLradaVFT1grbBKkedlw82wnohjqTWAi9CrHMh62NpVRUUuGc7hy+kqilwhCfeuwbCwp0XtVPLUI7UYbnVU1a6NXuLK9Ye+B1J7+jqCSWIT5zEJWLHfHThil9GVBKPfL+ehBPc4yGIR5raz1JSwSCSVpypq01C65l0g0dgoWtuW0aSKlQPPl4XtTE+6IazRbwfwH/lVJq/4HnTjIV+i/q+E5wPM/JyprVpvfEwbaoJPuTlKZnP7KBVNaS/UmGaxn0Gi7jpKDh2dSypOFZDOOcP78zxrUEr2+0CGyD798eYwptJiYVdEObd/em3B2kvL7R4Fcv9ZcXVC0VHx/OKSrJWuvTrOJT/PwjK2t+sj1mGJdc6AVcXWsuBzbTEA9NCJO0ZJaV9BvuI3cQWVnz/t6UnWHCSsvjfP/hhU5W1nx0MGOaVTQci1ag4zwH84L9Sba8BvcnGbVSHE1zsqriF851OdN5/ir0aVryxx8fI4BfvtSle0/AUFbWxHlFy7fv8yaaJCV3RwlKKYZxgWkIvn2+i2sbbI9SkqJms+1hmwaV1KW2UVwwnBdkZc1mx+d7NweEjkU3dDjbCZbnu6gk7+9NGcQ5V1YbbHU/XykuLWqO5zmR92yV1S9q0P33gO8A/9NiNvzvgf9AKfWfo8N43kL3O/67F3R8pEXN3li3PaTkkR7/oFcg3/tkwGCumQK/erl3H71PSsUHe1N2ximOZbDWdCklmAKubURYpsG/vjkkzms+Pkw5nObM8oq8rml5DklRc74XcnuonSvjvOLmUcy19Wi5sitruYxPnGcVP2ekkFM8AcfznMG8JC1rhrEmHjzOUK2WituDmKNpzg1zzq9c6uHeMzFkZc2/+OjwUwGma6Hu4TEkRcXuKGV/kjHNKvJKMjByNiqfW4UeQCdphWsZlJXCEILdYcK7uzM8x6Dh2i9kUtgbZ+Sl/kP2JtlyUlBK8clRTC0V47Tk8kpj+Z5RomNLbxzHjGYFpVS4lsG1jRbjRO/yd0YpR7OcSVby2mqDeV4zSvRn0fZt9qc5q5HuK4yTQq/8FWyPE24PYmoJ1w/nrDYfHyz1JGyPtCfTJC1peNEzo7e+kElBKfUPgX/4wMP/avHcf/r8j0ijrCVpWdNwLExD+5xIqR7rAV/Vkr1Jxjj+tBRkCrEs8YD+4H50Z8zNo5i1lsvOMAWhBUKXVhoooKhqtkdzkkJfTNOs1KsOs6S1ZXE0y7m8GjKY5QzinE7oMJjnuLaOTbx5HDOMc3oN94WlNZ3ixSDybboNm2Gs6DVtjuc5gaPLFeOkYBAXWIbB2Y6PQFMpB0nO0TTn9jBhs+WxFvmstVyKSqIU2h0VyIqKH2+PubzaoBc6/NGHR9weJtiWoOU6NHyLpmfhO7q0Oc9LJklB6JpsdQMmacEwLihlTcMw6YYvxidoveVye6izOO4NG1JKO+/qf99fhe429IJss+Xx/u6EWire2VZsj1LtIuuavLbSZBAX5FXNO9tjNtsBhgGeZWAYgnZgE3kWaVHxr2/GRL4NChSK4Twnq2qKylkewwnmeaX1I67FStPleJ5jmwbd0CEpKkZJSdu3sU0dBWqZgmdZmTtVoCyglOLG0ZyyUkS+xfleyPlewIf7M4ZJQSuwCRwd5D1fNJJuHM2ZphWuDVmpON8L2B6li1xa3WgaxAUYEJcVh1PFVi9EKcFKw6GsJMNY3zi1hEoqRnFB5Nn0G95C9KKwzZrjWY4Cvnulz43DGe/uzrh+OOcbZ1tUtaIbuqw23c/kTZ/i5wuRZ/Pt812EgDvDhHFS6q+05OZxzOEk4/X1SIe3ZLrebaKb0CaCO8OEwNYr2TNdn07gcK7jY5mC9/YmWKbJT3cnXO6H/OH1I4pa0fIt1rY8uqFDXtU0PYuvbTR5d2dC3VXLFbMQAssy6AQOr683eXOz/dzPT5xX3B2ltHwHM9R/7yQpOdP1CRxtM3Fyv96LrKiJfIvVyOVwkrE/zZhnNZ0AjmY558yAw1nOuY7He3szVpoutim4utpgnpUcTDN6TYeNts/7u1MG85xxXFDUko8O5hhCkVeKtJS8uzvhOxd6yyb3/iQjLWqmaUlSVMS5JmfapmB7lFLVinFScG09Yl5U+Lb5TPsPpyPIAlJpXcA8r5dOiEWlm0RlJfmzW0M8y2CWVbrXUEmkVDiWSVZWdAKHg2lG4FhIqbnMa5HH+V7IwTTj8kqDWVaSVzUX+yGuZfLB3oRhWhLnBWWtKGtFM7C5shri2xYfH844nubM7JJe6CAVKAlZKRFU7E1KVpuerhE3Xb0SOcVXDic9hJO+lxCQ5hVH04xBXLA/TbnQD4jzCtc2uLYZsT/JuDWYE7oW14/mAMRFxdE0ZWec0/ZtRnFJrQpWmx5JUeHaJqapy5mmUPzjP98lcE1WI5ffenOdvUnGLC9puvo6LCttN20ION8LXoh6d55XevdT6nS/D/ZnGAL6DZffvLZG6FoEzqeDapxrCu8oLvFsk8CpCTyTaqyIXL0zbzomh/OUWil+/WqfVuAwTkpqKemFNj+6M+F4nlNUirOdillWcnuQ0G04rEYeDc+irGqSUh/b9jDleLaHQPD1sy0arsX+JGWclMxzHctpGcYyua6qFZahdyPRM4hMfRCnk8ICpiGwLYP5NMc2BUUliXybUVKyPyk4nOYIBB/sTUBoG90rqw1Mw2BvFLM9TPEck+9e6jOIcxDw/t6UrU6AaxkkecXRLMc0BG9uRvyL68f8ZHvKauTgCl2vdS1wTINxUhK2LdJCMisqDMMmdE3e3IyQShH5Nh/tT1mNPHbHKe3ARik9Ec1zzVRai1wOZzlSKTbb/kNGfFl5ol49nUh+XrAeeSRFzZ1hzI2DOcfzgrc2m1iGFleO4hzTNLnQC7AMA8+yuDtMAUmcKyZJwfG8ZJIVfHQ45Uzk4zsWX1tv0PRsHMugYZj86O6QW8cJVS1xbZOL/QYbLY+slNiGwTe3WoS2zSQt2er5HE9zBvOCzXb9uWrnTwulFLcHCXFRcabt0w4c2oHNLCvxHI+ikhxNM47jgpZvsRp5rEceR/OMduCwHnn84UdHpIVeGF5ZaVAp3XTOqxrHdYg8C4nuU2y2fXbGKXFR8f7uFN8x2JvklFLi2QZpVfHh/pR3dyYcTFPG84yilBzPMhxT8PWNCH8x0Vw/nHOm5bM7SfjOhR7zRZ61AHoJS2dOAAAgAElEQVQNR/tRIUjymu1xylZHK8y/DHvz00nhHgS2xfqiJi+VwrNMrqw2iDyTvXFKISVHsd5GXumHvLbaYH+W03AdhkmMZ1tMspKiltimycFiG/j+/pRPBnPqWiGEtsS4eTzn+sGMG4ew0nDwHZuDSYFlmjQTB0MI7o4SnV8sIHAtNlo+R7Nc14bzitGBbgie74fsTlKGcc4krbjQC4mLkmohCfTs4r5eQ1bWfHw4RylYi1xWT/sQryykVOyM0+XknxY147giLSXnewHzouL6dsx4XrDa8rm8GnA8K3hvb8Lt44TtcUJc1LimwWvrTVzbpKoU7cBBCcG3z3e4vNpgnlV0A4ef3B1x/TgmryQGish3aHoW7+/O6DVtLMMkK2o2WwEKRcO1oSnIS8VPdyac6wZYhiDOa1aa7mOb4mlRc2fhLnyhF2CZBlIpPj6c4Vqm7pE8UDLJK8lsIQwbxAXtwMG1TK4smBc7o5StXsg0qygruH0cczDJkAp2RtlSe2AaBv2mg+9avL835Y8+HrAzjDnXDbEtOJzljJKSP/1kyOE0Y2+csTvJiHyLX77YJ7QNlFIcTlPuDmLujFLKSiFdE0MoHNPQf98o5S9/fY2ihmFS4trGktZ+tqsnHNfSuSFCCA6nGUUtyUvJKCk5mOZc7J9OCl8q1lsepimwDMHuOKWoJWtNj0+OYgDqWoIC2zLwXIvLa03GWYVp6sbUeuTRCRwsU7A9TJDSISm1GjnJatKqxrEtbhzF1LUkLSvChUnWKMmxLcE4qTAwmCQlTddikhXEWcU/ffcABFzph3ywP2FvknG24+PbBqsNh+1hzH5cEOc1Z9s+661gaY3x4I1X3aNeLV9Cl8ZTPD2mWblkwzhWjmcbrDVckqJiGJekRcH+RNehO3WNKQxKKTENQejqEkRRVjRsl1FacCEI2ey4WMJidxLz090Jf35nhGMZzLMS1zEIbIuyKmi6Npf6IZO04Ezb58P9OY5pMohz/tKbinPdgF+52GN3knJrkGBU8KefDFDAmbZPKeV9jJ97MUyKTxl1eUU7cKhqRVpI0kLSCZ2HTPlcyyB0TZKipvOAd1FW1twczJFK8vb5FgeTnKKuKeoK2zQRCMpastHyOJzmXFtr8kcfH/FH14+5fjjDEoKsqhCAUhLXECSl5Pr+nKMF6WOWatfTf3lryCgpMIBW6GAZBp3I4kw74FzXZ5RW7ExSxlnJj7c9fvPaGl9bbTDOdC8odCwOZjl5VdNvuMvJrxXYhLFF4BqErkX4JcV2nk4KaNbROClpeha2IfjkKGaYFJzt+BzOMvYXTd79WYZtmsRFyUrTI3AsLENwrhOyWkksU/HRwYRZVvHTnQm1got9HwNFXFSUUtF0TW4NYrZHenUnpMQ0BSuuyzQtEELSazr82tU+Hx5MuXWcsDNKeH9P1yn/7BOTXuiw0nBo+w7fOtclChzOdAI+OpjRbzhIFJYBl1dCTMN4SGPRcC022no7vdo8jbJ8VTHLSnbHKXvjhKJW7E9SbNOgVpJfONfij28M2B6VmMLg7IrHb1ztU0v4yc4YQ8DZjk/DNbkzdJjlFVle8f7OlNA3iNOao3nOh7tTQt9ho637CpFrc3UtxLWb1BKGSU7kObyzPcY0BKtNl+G8ZGeUUtaKNzYiLvRC7gxjfrw9xrVMeg2XeV6x3nr8DrXl24ziAsv81HTupHdiWwLvgWv6RGV96TGTzM4o4WhakBY126OUspKMkoKVpotlKHzH4oPdCaOspK61rfjuOGGaljiL+j0Ibg3mjOKSSioCz8Q1DfpC4JqCftNDSck41VYWlglhbXG27fH6aoTrGLy+0eJXLnX5nX/yIQjB9ijjziBlmOTM84rDWYFnGZzrBpztBIyTgpZvszPWdjeRZ/PNsx2anvWlkUq+8pNCVtZcP9CNtsMZ2IbAs02kVNRSsd7ymWcVP9md4BgWvl1xaSXkzQ0doFPWkk+OY5KiRCrdG7h5nLA/0Vs/A73F35ukhI7JuztjznYDRknFPKuYZwWObVDWglFa0MlcNlsh3YZLNLE53w3xbIPff/+QnXGGawoqFJstn1/YarPR9ggdk37DZW+iZfR3BgmuZRL59jLEo5aKUVLg2yaha9E/zTV+5XEwzZasNc8xuTOIuTNISMuab51r8+M7E2ZFydc3I852A7JC8ud3x7y3O10yZc50Q1zHZhzn/MnHAwDqkSQuaiZphWUIzpqCeWpSKclEKiJsHEP3vqZZtShpCi71GyDgzc0mK00PhdL3EYokl7QCmySvuNAP2Gh5n3kNrkUuvdBdTgaWIbi20cQQ96uoD2cZ28MUUJzt+IySik5g49rmwtPIouHZuJZgb5phCv3dNgSzvEbWknFaEvm2ZvtkNf2GzWrTJc4rbNOgE9pEns2P7k4pKsmFfsDrayFKGRgCxllB5FqMk4KsVvi2iWfr4/zkOOFwXiIU/OD2hL/01hrfONfm7jCl5VncHaUczjOyomaSlVxZDUnLmrgoKSrteDBNSw5nGcO44K0zLWaZyblu8KX0aL7Sk0JaaGfIu6OYyHPohDYrC6/zb55r41qCo5ku00gUv//eAdO05EI/IFhcAO/vTviDD4+wBKy3fc62A0LbwDLAMnR55nCakZU107TiYj8gqyXjpKCWknlWs2OmWKaWwNd1zTyv+NMbR+yMc4qq5kI/4PJKg7yWIGGrHdAObT48nGObBt8828YydfxfVYNEb2P3JykoaHgWSV4xzSqEgNfXmy91AtwpPhuH04zpwlKhqBV5rZkqWSWpasXxLGer75OVLpWU2Jbg7ihle5SQFBV5qVX47dChH7rUSlGjWUuylmRljW1CL7R5bb1F5JrsjlPujDLSUpIH2sLBMmAUV2SlYpSO+M3mGkpo7Y0Qgg/2Z/SbDvOipKgUb55p8dZmhGF8ev3NspKkqOmGDpYhuHE054P9GSsNl7yS91nRW4+4bgfzgnfujpllFd3Q4a0zLd7bndIJLLoNlyurDVabLr3QYSPyeXdnzHheYNsGVxsOu5OCUVoyyyokiqqGclIjDMFK08VE4bk2oWNwsRfy0f6MaVJRV4rtSczOOMExDS70G5S1YiV0cEwTw9B9DgRM0pysVEi0YO2tzTZn2gF744Q/vn6I71j84vmOzqpwTC6uNDiY5cRZvnh/ySytOJxmfL+saXo2aVlzaaXxzLMtvtKTQlFJqlpS1opBnPO19ebS6/yDvSl/cmNMw9GahdA1KWqFYxvEecVWN+Dd3QkfHcyZZxWmAZcdE9PQniYbbZ+iUlim3lLPshKpavYmKZZpcKGnyz2mIREIOr5NVtaM4pz9ccLvf1AsvI5go+WyErmcyXzOtD08yyCvFS1XC1huDmIswyAt9Gqs32iQljV1LfnR3THnewGGEEtK4IuO5T41vPtimGW6yWibJoFjcHklpJZ6VV7V+vv5foBUWjwZ2gY/vTthZ7zoLQQWeam4NYiZZiWH05yma2EJLYJSAkJH0PAcfu31VSoJN/ZnpJXm7pe1JM5K1lo+liGQStu5R57F3ighLyQHE03P9m1Tky+qmrXIY6XhLieEw2nGKCkZJwWBY5EUNeuRxzgpKSvFOCnZfESeyINoBzZ5JbFNgUQxTHS/YJSAY5lUi9zknUlGK7DpLfQ801SXsKLAwTqcczjJaHrWgsFnYQiBEopZLolCgzfPtPnpzpheU9PD/+XNIfO8IkkLfEdnm0ySkklScrbrc6EbsDNOGc0yfNfCMmre2GxybSMiLko+3Jvwwf6MeV5Ro/3TLvYDklLyk50pnm2glF68Nl0LQ5xomXLGaUngmJxp+9QLp9ZWYDNOCnbGKYFjcaEXfC79wlduUqhquVArCyJf1+UarkUvdMkWdJ2sWPi/jFJkrbjYDznfCbUF7lBrGv7B926TVjWBrVkRSDic5myPM3aGCUWlVz6h57MaeuS15M5A0/iqWnE8L0Aomq5+/+3BHGHo1cX7+3MMIYnzmtC1iYuKS/2QlaaHZRjcHWccTnOurknagUVT2rimyWbbpx3YpMWncnshwBDQcM3FTe28lGlPp3h62KaBEHpyj3yH1cjg1iDRTVCgUhLPskjLipWGx/XDGZ8cJQySgn7osNULKStd0pznFYmsqMqKXCmKSpEXFcIUmJXkD94/JKslRSFBSFzTYq3t0QsdGq5JaBtc3y8pK71rmOU103SOa5mc7wfUtcK2TYbzHN+xSMuaSVKSVTU/2Z5QSUVVS8739KDnWgYt36ZqK7qh/chJYTDPOZjmRL7F2U7AWtPj62ci3tufYhq6zNRwLWqpy0mRZy92SNrn6NsXurxzZ4xhGDiWzdUND8sQdEIHxxLkeUVcSgazgryuMQzBwSznn39wSNM1mSYVs1xnTAxiTVftNlyGccEkqTmcZ4zTkuN5wTgp2Z+lrDU92p7D/iTnX904JiulthyZ59RSC2anWUFaekySksA2sEzdOL95OCerFe3A4tpGk+/f1j2N3UUo0CzT49Y5fAZxgZTa7iZ/SofcB/GVmhQ+DSo3uLzSQAjBxX6IEHoLOoy138kkLbWmQAhWWg6bLX/pmTLPSvJKcTzPOZrn7I5SGq5JXNSaCbLoMygEpYRPDuaMGjZJIfFtg1gpJlmBb5n0fY+4qtgfZ2SVRLHwjSkleSUxUdRScmcgGMcFvmtjGorBvKSWiiSvsExBUUpkLemEAY5pMKlLVpouZS3Z6gbMs4r9acbBNGMt8hDAue7TO7qe4uWCZ2u79VFS0Pz/2XuzWMuyNL/rt/a899lnPufOMUdGZlbW0F1d1UN1G8wgsFtiFCDwA7J4MYMQAvHAJGgZWTIgsGRZgJBASBg3gwSCJ9xu2o2x3UV3Vbu7ujqHyCHGe+OO555pz3utxcPa9+SNyIjMyIzMjBziL4V045x7z7j3Xuv7vv8QOHi21WxO4DQpaIcudycJtYZe6BK5Fq4NVVWTlpYRPrlweRyzd5pwOC/ItKAV2EhdmTZSrsiqwrDtbItSKpQCz9XYc7gyamEJ+DvvTdif5viuxSStGCAoa0lSKnqRSy9y6YcurhB0A4+/+cYhSSW51A+ptUYpwSubMVs9k3Z25u569UMcTc9Cpk6TivW2mektcknsOwSOw/GyZBR71Erz+t6cn+7O8Wyac1dhAa9tdTlY5Nw/TTha5lgaLDSnyxrbEhSlpFKaUmmE0vSEoJCSw+McpRWWZbNIS6SU1BIWWcmbe3PyWjNJKnzPpqhrpBLkhWK/zjhx3l/MDG1cMm55oBWzrGaW1WRFbVTWRcXJsqCWmr15ju/YlLXk6thUGgfzgqyU3D4288M4cIxxZuSRlRmR98mzVr5Wi8L7QeWKskmSqpXm4iAy6k1lvE1C1+baeswsqbgwCCml5I925+zNUvZnOaVSxJ6LVIpFUXMwz6mk5nhe0I0cAtcwfhZZySSr2J8X9Fsug8hlFPuN35FCC5Da7Pik0viuYBC6ZLVCoPGa8tt3bA4WOQOliQPX2O4qxSyveOdoyb2ThLRUXFuL2elFaODyKGIU+xwtC+4cJySFZJZVjDvBB7xWvmr4OmQ4Hy9Lbh0lnGYThi2fSpq2wmYvxMa0GXzHInAtRu0QIebMC3PB/83X9wkdm7I5niJPUimF0BpLm3aq1FDX4ApwHU3oCdJCU9UKidHbLPKaeVaBgLSQjDseeW0EbNsDn9h36EUeW72Q/XnK/dMlf+/eDK01bx/MuTiIubEeE/vuytwRjGX0E+zGABMydXZxnecV7x4umTczgXbfDIS7oced44R7pym704z1ts8krbAF3DxYcDgv2OpH5JWkHXiUdc1PHyw4XZYUlcRxjHK4HZjI0oPZWSKdpuU7jNsh87wgLQBhNE7CsumGTRdAKfJCooWg49vUWlNJxe48pZQ+N9bMe9+dpAjLJisrXt+dcmUUcX0tZneacTgrcCwa2m/FWifAsy16UYhvW+zPCmLfoRO6dEKjzA5c+yOjPj8KzzNP4S8B3wN+X2v9b5y7/ZvAfw0I4F/RWv/kaR/z/mnKsqjZ7ISPtZJd6/i88WBO6Nokec3bh0tC1+btg5qskuSV5Nq4xbRhXfzg+pBh7JOVNZVS/NHujHcOFozbAT9/KcSz4c5JBkpSlAohwCugPwipK8NoUFKhtEXLtWkFLvOsIi8llhCEno0jBGFg4bkWgWsTeA6+r0lzSeRZjNoBx8uCpKixLYvQsfAdwaIQFKXCRnDnJOM0NTuL6GWHduBSVMYfZZEbe91x22cYu9xYi1cBPi/w5cPuNCMpahZZxf48o1aaqjbCq1ppykpymtbEgUNdS0LPppKSvDaUzcnC9NtbgYdrW6y3PVLXxpICS1gEnmJeGo69xGxabDS+7VI5FXUNaM3d4xSryVJwbMEodilrzaVBwIWhYcX0IhfPtrl3mvJglnHnJGGWlNi2wLM9qloySZ4cN5lXkr3GXfh8VvlaJ2DcNvz9dw6XRJ7FvdOKb2536Lc8Xt3okFdGB/TXX98nyWvmeUXsOYS+QynBsQWBDVfHLY4XFcICJSWVVCzzijg06mXHMheiolaktaSuNJ7jELqWGb4gTBvNd7jYNx2FUWxmDkUtKZVCaUHgWoD5DiLf5v4sYRj5zPLKsIvyCt+1OZrnHC0L7k0Sbh7M0Qg22h7D2JABZnlJVlkcznIkmmVR89p2h3ePEo4WJVu94KEF9pPgeeUpfBeItdZ/QgjxXwkhvq+1/r3m7v8Y+BcABfyXwD/xNI9Z1JLTxq30aJk/dlHIS8n+NKdWmrsnCZU0/cf9uRnM3NiIWWsHVDLHsy1uHiwYLEqujFtcH7f4O29bOEKwyEoQFt+9NGB/XjJLS2pdUUmJEjBPJJO8oFQgFXR9c/xM04KygmVZYwlBUioCF0LHwfYEUpu+YVYpEl1Ta80yN8KYWmpizyHybZYLSVVXTDNTooaeRa0cfNuiGzp0Q5fYd5imBT+6OyUtKjqBx84geKFe/hKjqCWTZUla1Sslbsu38WyLB7OMQirSUhG5FvcnKb5jmdZQLXFtgQAkJmymrI0jb+C5BF5Ny3LYneZIpbCEwLE1UoKNmaHVUlHV5njen1fYIgc0ceihtSb0XapK0Q09bmy0+fnLQ+6epLy1b2zj700ytDYbs1Hbpx95eI7NWtPmPJ94duY+vD83GSSiEPQaMZpUZrMTejaRZ1xah3HADQSx79ILTSJh6NkEtgm+qpVp8VwZt9juBdw/zdg7TbhZSkZtn2lWUtQKJaGoJHHgsNkx1hKF1JymlfncsxoljJvA8bKgHTgklSRuwnMWRYXV2NhklVFkp8uKWkrQinbo0UJzf2KqAKXnDGN/RZ1Ny5o/vD/nmzs9ZlmNEBaha7EoJb5n2nAbnYBlLnn3OKGSmo1uzfUkXpFHsurRZOOPj4+9KDThNyf6WdLp4ReBv9H8/JvALwFni0Jfa32vea6PtFVUWnPrOKHl2US+TVpIuqE5gE6Tklpphi3Tq5xlFbvTDKk0W72A7X7E4TyjHTjszUxfdKNjHCInScU7h0t811hde7bFVjdgnlUMWh4vrbXYnWY8mKX4ts0ohrK2TV8UOM0tbKEQJg6LybJEonGFMD1e1yErJGiBbZt20iKvSPKKYcunkIo8lXSCFr3QwbYsFBqpBLYFsW8sd/dmBZudkEGkaQc2V0cx3ZbLWjvgd29luJagrDWRb2OL93uMRS1578gIcYxQ5vP3uX+BjwfPtgg9m1lW0g09dvpm4a8URJ6DhWAUG6bbsqwbAVZmhr5DY4h3/zRjoSs8S7DMS/7w3gTHEUgFSV6RVybBzbMNQcG1TRupVpLSsCuxtbkwtkPTy17veIYJ5Vq0Q5vjRcG9Scpb+zP+v1sTZlljsyLM8fnNrS5FZVpWs0wyS83Ma6sXUtaKg3nONK0oKpMT0o+8VX989zQz6WYNtXq9cRH4pt1ZJasVteTtgwXvnSRs9nxkDaO2T60039rpUSvN2wcuy6Lid25NVuxBC4gDFwS4jk3g2QTazCK1NsxDpTQ2MM9KLMumHxg2ViUVbz5YEgdOM7MLsC1B7FuklcYRFlJqJmVtDC0tcx2QWjOIfJZ2CVh0I5dJUvHyeovAFdw6SlDK6J9e2YzZ6Ia8nsyIfWPv3wsNjXfU9hox6rNv+j50URBC/CLwF4EJZgf/PwAjwBJC/Ita6//rEz5vD3iv+XkGvHbuvvPTkcd2Fs9nNG/tXGhEYDU3NmLcRn24yCvun5rAcqU1652AduCw0Q2QSnFjrU2v5XGxH/J7t09puWbXcXeScm0csTdVHC9LYt/m3iTBc2yEBS9vxFwftzlalvzdt4+xLQvH0XhCYAnTMmp7Nr6lkUIjHMsEeTeZud2WS+TZTJc1Smu6oWv0B1rjOy6OBQ/mhgsu0GR1zYUgZK0T8t7Rkt3TlLRWuJY5adPcZ9z2GbQckqLmvZOEP7WxSTdy2e5F7M8KhrGHIyCramZpRTdyWeTGfuOtgyU3Dxb88vXRJ/wqX+DzghCCa+MWF/shR0lJUdbcOUm4f5oySSv6oWHruJGFZ9vcOlqSlrXxIApcei3PsIFsi6yQLMuaWipavkfkWShtKJ2yhgqwbXAtG8tVLPMmUhNohxYX+iHDpoXzYGpo1hcHIVqZIBtLzHnvaMnBvKCsFRtdwS9eHpJUkh/fOSX0HJTWjGKfSWrSytKy5r2jhGXjX9SLXHb6Ie3AfZ9Ozft70bNt6Zli/2wOschrylojEFwexviuxTyrV8Pyb213eecw4c6JxLcFuWXchxEY92OtmCaiqZA086zGEhaRZ0gdRS3pRC6d0CV0fO5MMk6TAoVikSnSvOJgYRwLur6D79gUUuHZFnlt47lmRz+IQy70Ir59ocPBzLgmDCOP3akRIAo0Sam4M0np+Ibae22YYNsWV8ct0lLy8nqbUew/Vr/xSfFRlcJfAf49oAv8FvCntdY/FEK8ggnJ+aSLwgzoND93gOm5+85XIOdyn879wrmM5u/87Hc1GOm7s5KjP5xvevZjL/J4ZaODEIY9cUbX+kdj33jPzzOySvI33zyirCS90KEbeYzbPr/73ilJYdLQJmnB3rxgVtQIrbi2Zqh3Nw8T41tfGBqb7Qhcy0Yqc4ChTXBJXtYsC2XKygUruXonsPBcx+TJqoJKQlHUZoaQm5NbY/6u6/vUWmLbgiiw6YWGq5029shgkt2GsYfGDNfun2aUteaXrg3pBG5jMqYIPZe0fPay8wU+XZS1Ii2NW2Yl1Sr20XMNP/3mwZz9uaE/xp7NIDatmHHHJw4c7p4smTRWES+vt/mlqyP+8O4ph4uMP7w3ZX8uqRUUdYUlXALXQipthqLKDJkLqUwAjQWuBhcIHJtCSq6OIt7aXzLLKqSGtbbXePaYfn4/cJFa4dsWl4YRw7ZPWBozxgdz4xh8fS0m9Gw2OgFZKdHaeHWFnsWlYeuhFEMwnkmha9pHj9q3nBnGDSKPOHC4OAwZt32KSnG4KJgsCu6fZry61eHP/vIVfnR7wm+8vs/BNDfDYscmXhrBqGUL8rJm0Zx/eWXsaDwhyCvNNCmoaonnWISehdYus6ykbH4vSSWBY5HaipbnYNuGDZRXilzBIHQYtX3WuwFHywqpBb3IfLfLrGZ/VjDLSqSG40XOIrPIa0nkWHiOoZ+/vNFemf19mvioRcHRWv8GgBDiz2utfwigtX7zGUMdfgf4c8D/AvzDwH9/7r6JEGIHsyDMP+qBXNvi+lpsQkPOUdhi31nxpHvNfCFwbb6x1fnAYwSuzY31tnE0fTCnbrjVW/2I71zsMU8rtnoB09Q4Lw5aLrcOU2wEvutyddzirQdLHAvKWtPybJalRlUKGl8VqaCSkkVekRXNSWeBdA1f3GqqmW9utanqFj+8dUpRSUolsCyLjY5N6FvsTzMqaVSOF/stfuHKgGvjmN1ZxryoiQNjFXw4N4Za2/2Q0LX5yf0pShmPezC7q1+5PmKzG5BVcmWH8QJfDKgmd1sqjWvnKxPDzd779hCz1Ch4904zyloxjH1yqXjr5oJpVlEryTyvuTqOGbR8Duc5/dgllzUXRjFSCU7THKUFUpkEr9gXoG2SosbzbNM6tQQil7iWaauUUjPNJL97+5SilBR1jWryQKRUjDseLddh1Pa40LDhfv7yiCvjFm/szbk6jtid5mz3Q2Lf5dsXukS+Q+Ca5711nKC1x/GyfGjADEbR/Li52LwR9AFMkrKh7Rra+U8nU94+WCAluAcLRm2fcezxMxd6HM5zXrfmLIqKJJe4jsUgdml5LhpNVkruTRLGLQctNPcmKb5rU+Q1eW2YV+PYBTRKCxAghGkxnTELQ88lcAUXBzEnSc7+vCByjftpO3A4WpQooKwtOqHLrXnO3jzHtQUb3ZDtToiUkkobdqTnWMSBw9HCGOONP+dK4fxOPXvkvk88U9Ba/74QIhdC/L/AHwB3hRD/vtb6LwD/EfA/N7/6rz3N4z3JfvdpswJ2pxkPphlKGWZDUUtcS3B13GLY8jlNSq6uxWwPQqZJhW0Ltgche/OcZVFzf5IhGyFRUdUEjoXv2ESOoKg1pdREjk1ZSQqpKcxagWNDWlUkpcYWsKzMfGQt9rk8jHgwz+n4DpXU9Fo+h8uSludidWy2+gGXhhFb/ZC7pyn3T1Jj2GcJfv/OlLW2OVCOFyUXhxHf2u5xtCgeYh5ZluCl9ReBzl9EaN6PijStBMGDWcY0K/m5S30iz+HauMWyqIwqN3CY5hVaafJKcuckxbXNYFYqze/ePmGWGpsEQ0yAnWHIuO2yN8+ppTZUTGFRIQh9l27sEjfun+ttQ2UupeK4GZ7enySUzbG8PWzR8W3yWrI7yfj2Th/PsfAdh3bokJY16x3TZ7ctQdt3uDCIGbV9pNScLM2xudkLmTXU8bSon/rz8mzD7tmbZkySkqvj2IReuTb3JimjRvZZHbMAACAASURBVJxqW8aCeneaMU0K3jtOOJjntHwTKdrybWZZ1XQEKpKiZqcfIbXRRVwfGevt+4UkrSSebeEKi1oIhJD4DXHEd21ks9GLPIerazFbnYAHb6cEja7gwTQzbSOteGmtwyA2s5NO5FJr4xS71vbY7rWY5caw8639OYvcBPdYwgzXa6kfqzuSzbFwPkToafBRi8J3hBBzTG8/bH6m+f8zTTTO01Ab/IXm9p8Av/wsj/1xkFeG0QEwzUq2eiG2gEJq0tLYRLiWIK0kFwcRvmMUiN3IhJDvTTP2ZgVWIzTTWjPLa2ZZhd+s3i1XsCylachq8B0appBLVikUsglI1xwvKvZnOevtgE5gEzgWtZIsMkk/cok813CRI5fr6zG+Y/Hbbx0zTcuVXcDNgzknic+N9Tad0Oy0tnohm40rpVT6har5Cw7bEmz1AvZmOVcGLU6WBZPUoh24TBLzPVuW4OIgQinFT3fnDNs+toA7JymhK5rkQGPLklfGdtow32zSWuHbPgrY6YXcOUlBCBTGoTRwLYaRa/rwvk1WKdJKETiWqby1ZndmqLCuJWgHFsvSZDtfGcV0Qoer4zZvHy7Jq5qtro9Umr/9zhHTtKIXelxbayFgNfsDGMY+G12TJvhxmHKBa5hGaSlRYEgijsC1LeaZJPQsXl5vE7gOtTTD9NO0ZpaaFk2/5RG5NT/dm1NUkqQwVZYtYJo6CGEsRGwLPFsb+3xtPl/Xssgts+C0PIdLw5CsUmSVYtwO+OUbQyLH5cEs5eLA5FkUUuLaNpOkwrMBIcgrQ1X/2Ut97p6k3DxcsDvNqRT8wpUh07TEd2xqD0qpGDUOx84TRB3vHS3JK0U7cLj8MToBH7ooaK0/u5ikzwEny4Ja6cZv5fEfnGtbuLYgqzSvbXVZ7/jMsoq9aU6tzNCpqM3uYlnUDW9ZMGr5rHVKlNbcnyRUWtANXOa5ZneaGiaEMAfJIq9IiopaK7RsrH89m/VuwJ2TDAeLXtshdGzjI681apbTChz6oUvoORRVje+ZNtflUatxSqz4w3tTxrGH0Jpu4CClYn+Wo7Tm5Y32isoHppR973hJVqqH2hAv8MXELKvRylSyL41j0srYPnu2QHVNK+HBNGeSVmz2IopaIbXmV26M+Mm9GXcnCbvTHGGJxmrZ5WIzR5NL47ipUOSVQipNVpqL4JVhxM4w4t4kY5Ebg8a6obuWtjDqWQWRa5NXkm7koKTgpe2YWimurbV4daOD1BrPsnE8m5uHCZZlk2TG5sKzbbQ23kTAQ4LKcWNetyxrKqme2ryxE7r0W8bGJXQtOoHH7ZOE17Y7dAKXGxsxRSW5fZxwmtZsdj1uHduEhaJSJqch8l0i16bWoJWpiiqpKCpJVteErkPkOVRKE7gOw8gmafzTbCGoasX9WcEg8BjFPuttj2UmuTlN2J+mgKGuXh6GHCc1w9g4uJ4kBUVt49pGi/SNTaM9iH27CQ7SrHd8FnmAEBbrnYCXmnlCJ/zgZVxrbcz4YGXf87T4yiqa57m5sIO5GD7Ju72SitPMyObTssaxQ4axT1FL9qY5SkHsC7Kq5t3DJduDkO1uhLGxE9S1opQagaaoTRZsJSVg4bsWNzZj7hwb35WyUCgBnjCiFzA7GdcRFBLSqqauJYM4QAiIPMMGsYWF7Vjsz3IuD0zL4K2DOctc0gldfv7KEFAM2j5//Sf7/GR3xrKU3FgvVnMQMLuLrDQHyiyrXiwKX3CcXSi1Btu2GLZ8tGIldoo8m7QJbk8KSa0U909TQ630HTY6IWmp6AWm1YRlcZKUpHlFvxVwuiw5WBi9Q600ni2IPI9CKt7YW5CUNVJB6FtUEioFWkuk1Fi2IPIsfNduKt6a25OUP/XaOpUU3D3NKMqaUpmYz9+7fcLt4yW9yAc07dDmYF6w1QuMG/HS2HCfCa/uTlIWeY3rmCH507Q/LMvYgUuluX2SkpWSX7w6RCrd2D40e1whGv+knGHkczTPeXPPCAHXYh/XMYrq945qNro+s1xykpRUtcYSCkso+pG5RtTaeBRZgNA0C6Gx3y9rxU/2Fvzk/txQzCtNxxdUSpCUmn/6u9tcHUX8rZsn/NHujLunGVppJsuSUdvn6jgiKyXfuzRgrR3wW28eUNSKl9bb3Nhor9rjs7Rif54TB85qBiOEYKcfMmso9B8HX9lFwT53EJ1xlz3b+sDBdf805XheIrWm7bursA6pWB1EW72AW8cZtcqYpRW/dCXEmQvefGCCOiwhGEQuIChqmuByQeTaFJUpMYVlWEIm/1VgN6X6MPaplKQsJbUWSNujHdg4lhk67fRDBq2At/YXpKXk/3n7iK3DgNe2enRbLlpqHMfiG1udlRNqHBgBWyd0HqqQzlSmaWmiEA8XObPULA7PKo1/gU8fF/oRp2lJq+Gkx4HDO4dLTtOSwLW4sd5Go3ljb86o7XH7OAENwhKG7dPyuNgP2OpH/OyFHr/+o/sopehELl0sKqkolQnFaQeCNIdSSo6WRj8A0I9sXh61OU5rbheJsXi3NcKyCH0XrSCrFL3Q5eIgomg2HllpbKevj1v8ZLcm8kyr9ErksDMIsYVFUUtu7i84zUpGLZ839+fM0pIro5hSms1LLfUqJvNpIIRRWF9fi1fn8kPQsMgq3jlcMIg9TpYVebOxs1AUdY3ruNyf5pRS0w8cNIKy9sjLM5NLG6mgZzn0Wy57k4x25NLTmnkpCR3BsOVxf5ogEEzSCs+x0VohbIdu4DJq+1S14o39hForxm2fi/2Q3WlOVpfsTnN+9VsbXBzE9Foed08S3niwAGGuR0lhXBciz+FwkVPWismyZBz7K1aWyaj++Of1V3ZRaPkOV8ctaqlZFBU393NCz2Qun4djWax1fJZ5zYVzua/jttkJuLYxGgs9m1c3O0bt2AtxHYu/paEVeDh2zbgT0A9d3tyfc5QIpIRlE1TSa3ms5TXLvMICLGExbLn84OqAtw8SlDbCs3cOEyqlmec1bd+lkoanXFQZR8uCWipGsU8pFZPESNp304xsbnZU18cxvcjn6sikrn17p0f73LC9aMrIYezhWYKf7Bubj1rpF4vCZ4S9Riy52Q0+NkPEc6yHsrU7gcso9uiGxlJCKpObUNaaB7ME1zYXYte2mowCzf1pxrwwO928kviOTeBZfGu7j+9YzFOfP1IzAtcI3MpKcfMwoawklgUCl1uTDN+1iDwLhMV616MTeEyXJZWGzW7AlVGLq+OY9a7Pmw+WdEObrDKVxkbbY29WcGMjRmParDv9iEVRkZUKpU3kpteca/dOE66OYk6Skk7oPrH1+1EQQqxaX93QZVnU/N13T7h1lGDZgrSU7PQDHCF4Y39Oy7MRlmCR1ZSVwrNsAs/l6tijrGIOFwWBbcSo612feV5x+zgjaeaFlTSU4VHsc2ncMlVZVdOPTGs48l0MQUng2oJZWnOSlRzNc0LHZmcQsTOIuHWSkuQV89wsJu8dGovztbaxulAajhfGwPO1rS7d0CWvCiLfxv0Q06gzgWw7cD9A5z2Pr+yiAO/z/x/MzSArK+VDcnqAC/2QSkoGLZPUdIbANYHfB/OcvWlOy3NYa/usd8zJHXsOG12jHt2vagLHptty+dVvb7N+Z8JxE+E5iAzH3HdslqKmFXiErs2rWz2Gsc+DWcFxYtSR37nQZ5qVHC0KlllFUkoWhaSqFePYZ73rE3kOvcjlG5tddvohP74z5aARu13sRVwbt/Bdi0HLeNskhbHQ7YUu+7OceVZz+yThZFkwTSv6LY+fu9T/XL+Xrwuk0pw0JAbHFmx2n101vtENOZjndEKjM/Ecm7xSvHuUMIxcaq14eb3DybLkYJGxe5pzuqxY5hV5rRnGPldHLb690+WVjTZ/448P0Jh263Y/RCOQaHYnwti8a0M1LaVk1DZOphvdANcWDCOX0He4Oor5xWsjQs/m7YMlWSV552hBP3RNKpxjrzQzV0YxvchlvRswkB53ThIC12enH3L/NOON/TnjOGCaVc/s5JuWNbeafPWyYxYfpYyZ33o75LXNDqWSuI7N1bUWNnB3knO4yLCE6S5cGoT8zE6PQtb8368fsShNElslzRwyL2ukhrRU2DSbzLbPWsfnWzvGibWSin7o0vIchAW3TzJi1zEzk1oihMWwHTBoBVwehri2oFQarQz5pVaaK8MWjiW4vh6DhlJqnCaXYq1j/I4+ijxy+yShqBSeU/LyxpNZh1/pReEMm92Qo0VB9zG7jqNlyVv7S7MrLyTfudB7qOTUjbHVJC3phNGqD3+4LOiGHoPGorfWsN6OuLYWM46NcjRwLV4/WPD7tyfsDEJagcMyr+hFhnr30rjNLJON14ygHdjMM8HFfog9bOG5NlobDWfkO/zgSp+1TkipjDpyf5Zhi/eZRO8cJdTKpGYlhTETS4qaWV6zFnu0Q1M1JIWhOHYCl81u8AEu+At8OhBCrHIPwk8pNnHQ8h7qEb+62TGxkmVFVtTMl5JKwrDtcWEQ0vZd3j1agBC8uhETNNXypaFho8yzipMkR2E0AI5l8SdvrPHe8ZJ3DxcczEs0RpjWCT3WOwGL3NhLi2Yutt2PmothQFEpfnJ/SlEqFqLm2jgm8mxcx9jEHC9zbEusBsjnxVcXBhF5ZdpGZf1Y3erHgjpHmpdaM2h5XBm36EUO6+2QRVFRlIp+6BN6xpDStmziwKYbedw5Sbl5sEShqQrFLK+JA5vrozbD2GOxWxEHHrZds9nxjHllUvH9ywPWOoHZlJU1rmWhAM+zjZK55THs+PRClwuDyFiP5BW2DXmt2exF2MJid5pxoR+yP8s4mBdcGIS8vNFpTPvqhzKan4ZNKJsP5KNckr8Wi0I3NPa3j0MlFdaZJaTgAz3ItbbPreMlnm0hm5V7kde8c7QkcGxsBFpBN7C5PIqM1XatuHeacOe04P5Jxqjt4zk2/9h3eszTkkWh2OkHfP/qkHZkgj0eTHP+1x/fw7ct+rHPP/jKOgfzDKlMYMpaJ2TQcrFti+Us5+39Bf3IWBcM2z6Ba9MOHA7nufG+KWo2uwEnSclpYpxZf3A9IvYdNnuBaWtIzcubTzfE+yrh87LWtgS8tG7Myj6LLF0wj/vyZodFUXNzf2HyC1oOg5bPxUGEY1v0Qg/QtAKHVza6OLZANrnhy7JmpxehlOl/K62Z5ybm8TSpqJS59G8PYlzL2FZfHEYssnrVgnj7YMm9Scbf//KIUeyt7GSujlr84PrIzLaEMDbzs6IxtavoRy6TtKTlmbCrwLXZ6gWkpWSt8+wkiNg31fwkqeiFLr5jlOC11GSVXFnWV0rSdxySsmYQuxRKsWzyUVqezWRhxHCha2ELwStbMf3I48o45u2DOfenGb3GrG69E2JbcPskxbEsvr3TMzGay4KO72Jj8QtXBlRSIaVhCH3/8gAw9iBaw6VhhMbopNqBg2Ob+U9eKe5NUja6wSdq914eGgvuJ10Lz/C1WBQ+DBvdAK27VFLTCV1Ok5JSGqfIcdtnmlVIqXn3cElS1oxil3lW0wvNUHq9dxa1aXY6i7ymqCV5qXBsmyiw6QYh/8ArY+LAJclrsloybBlx2U7ftAPuTlLiJpmqG3pYwjCTHMtif17QDlzcrk9eGSvsvKoRwqPX8kzqlbAIXZsLwwjXbtpHjsVWL0AgVj3VTuDSDtwXzKPPCY/aNDwrjpcFlTTGZ2e7w7Pv+8KgReRZ1E0uyNGy4KVxzCKX2BZcHES0fJth7HO0KDhNTE8/Dh3akcdOL+RHd07Z7gUsMsVax0cqCHyLXmBTSfjmdpdR2/j6O7bgzQdz3nywxHcl06ymE3rcWG8TuDYbPePK+75vERwKozqOfYfdacY8q6lVxrVxTCc0uQrDZ/h80tII3jzbYppVHC4KlDIX6Vc22saSQ2kj/AocTpKStu+yN8vwHYfjvObSKDIRtghunyQgFN3AYb0b4Ds2bd/jNK25sRZTN+2folZcHsbc2Gjz5sECz7Y4TSte227TDz32Z2azNs0qfMfmcJZztDTpbC+txQSuWRil0g9VAABb/YDbxwnTtCBwTere+dzqp4WxD/no4/Frvyi4tsXFYYtpWnJvkjFJihXzx212VFIbltAw9lbshkg4XOhHvPlggRaGglY3lhqHM1M2dkKHX7o6pBN4JIU5aapKst41lNODecZvv3nEu0dLkqJCaROMstY2Ap6krLl5sGCWVlwchghtuORSaS70I17b6vDeSUJWSnzXYpqVjVI0wrIEw9in3QSdpM0ube80Y9DyGbU9Iu+z+fpfZDB/NljkFQ/O0azPR1X+dG/O7iSjE7pcGUdN21PRCV1+5aUhtdSMG5W7VJqb+3P2Z0Z7s8xrXlqLmSYlg5bLO4dLXl7vsBPEFJU5JmuFaR0Vku9fbhH5DvPMZCjvz3ITZ9lYtt8+TnjnKGGeVVwbG2dPME6uN9bbVFKtLk6VVNw7TQGzqXqWzco8r7hznDb/0yxyE4B1ZRSv2Eu1NFYV3cjl1c0hJ8uCvamhbl8aujiOqZbyUvKPvLbG37s35b2jhKSo6LdMhvLhIqff8swF3nXY6pm22VrXx7Jg3PLRWrPdi7g8ijicFwxin07kslYbH6a3DxNKqZBa8ce7c+LAVGCP28WvtQOO5gWV1Pzx3ozIlGyf+HP6KHztF4UznPUfbUus/Dsc26IbmraQbRn2R+wbW2oNZojblHW+ba0O7qSoiX1zgqSlIvI0908T8koxSUu8gxm+43B5FJHXyohTlMZ3jRx9siw5WZbkza7HsmDvNGeyLJnlJmClVmdcdYe8llTSYrKsOHUqvnux/9CQbq0dsK9yFrlkf16QNqXxq5udF8rmLwnuTVJOlgVZJYl99yEVq1KayLVXC/03Njq8sb+gHZhULq1hd5pSz0xm8e/dOuF3b5+yP80whYxF5Jt8ggfTgkpKHAuGscsf75l5Wi9wGbcDjuY5r+9NWRSSZSHRWrPRNcZz7cZ3a5pW5JXk/iTlncMlLd8EP0mlee94SVWbBWq7FzYaCYVjWWTPaMpYnZtD7M9zlrkJzYkDm82uYRbmtVzNUywh2OgE7J5mlE1LaRB5/PT+jN1pRuDYLEvjTpBWpjtw5yRHSsU7RwnrccCo4yElfGunS1Ep7p5kWMJUZWlpLHAO5jmBa3O0yLGEub6M2j4IuDyIsJrN5zwvn9jaObPgqKRCavGQ/ugMZ3HDndBZvcdPgheLQoNBy+QTbPYMs8KxrFUZd2nYag6IlDuThGvjmKDRIIxaPi3PoRe6CAxjoagVncgxGc9tH6VMpTFLK+6eprxzsGS7FxC6NqOWB0ITR6bvO01rDhY5aVmz1gnxXYe9aUbZLD63jxN8x6bl2yyKGql1s1CZtCeloR188GsdN3S2M7HTC3x5UNSSaVphWxaRaxSs5329LEvwMxd73J2kXOhHjDsB44bKqrXmD+5NmWeGadZveYZC2ex8HMuiE3mmdSEVoFjkir1ZZvrWQpCXit7IZb3jcesk5Ye3JrQ8E27jNZXtpWGLTuhw5yTl+nrbhNm3zCKVlXLl9FrV5omNUNRQWcNG6LX+jAFQg5ZHJY2XcDuwuXOSEbgWG91wdS6PY5/DRUEvMqSTwHOQGnzXouU5XBm3mGUld08zTrICG6MG7wYu43ZIUkq0gH7oMM1Laq24Mmxx6zjBsUyW9YV+RFkr7pxkRK7NsOVzZ7I0ZoKV4sIg5PpazDQtiQMHV1gcLXM0ml7oPUQjB6OlyiszmL86NpT6x6m8p6kJGZtnH08J/iheLAoYpsPuNMNuVICP40WnlaSUitN5hWdbvLTeZtT2eHWrzSQp+cZGh+OkpJTmZGiHDtu9CMcSzPOK0LO5c5KwyCvKSjHPSw4XBaFn8Z2dPlWtaAXWKuRENzm4l4amBN2d5NyZLHl1s83eNMOxBNs9w6AIXJu8Vlwatgg9+7GCFbv5/bW2z2larkI6XuCLD8+2aPmNalkbf/+kSHhlo706Vje74WMpr6dpRVJI47HjGC+t71ww2VU3NgwzKPYdQJAWsrFaF6x3AkqpeXm9Td5XXBwEzcJhxJL9ls+1cYuTZUlVmxmcEIKWbxhzP3Ohx3Y/wnPMvKNu5nRrHZ+kqB9yGHiS28CHIa8ku9MMr5nLieb5N875e4Weg2tbzfszMG3g91tUoWtzddxinlVsD0J2+hFCmBbSwbygE7imresaRXnLc1Ba8eM7p3R8F9cxHlWGIirIa8Vmz+fBtGAUeyzymmtrhiZ+9zSlHbhcGoZYwlrNm86M+pZFTVKYn42hocXloZlTurZFPzKBOrYlUEpz9yRdzYgAhi2P/XlOJ3A/8YIAz2FRaAJy/qXmv39Za/3XHrn/tzEeEBr481rr3/qsX9NJUqyCPdqB89jJ/qDlGXqaNtTVvJIN48ellnCSllweRrx1sEQ3fOi9aUZS1mz3QnzH5tq4jWNZbPcjfnxngtv4q291zY7rB9cG7M1y0qpGK3Oyh57NWjtgHAd8c6fD63um/3hGJc0q1SRHCa6OWh8p9HFt61NJZ3qBzw9CCK6OjUL33aNlI/j6IK1Qa8PqsW2xqiQc25AMWp7NxaFhI41in195acTN/SXwfmXp2jW/fG1tlU74i1cHKG1EWZ3A5nBRMm4HBK7g77sxwrUt3jtO0Bom2QlXRi3yUq4Wp7V2QDdyySvJu0dLlDJtlWetCADePVwyz2ti3+h2Ht1d25b4yOdZ5BV3JymWEHznQo9By1xct3sh2z+zQ9a0jrSG40Zvst71Gcc+Ra05XpaErsU3tgxRZVEYoz/PsShrzSwTXF9rr2jEV0ZmEZ1lEq1N7kmtNKFrcTA3Mz/fMd9PLTW1NNTyjY7Jaa8USGksSd48WBA4xtH1TIz26IL3SfE8KoXf0Fr/N0IIF/gh8Nce8zv/kNb66X1znxEt3+FkWSLEk224fcfmpbWYk2WJbQmc5uKbFKYPmpUKzfu89DMvJYCTxPT/rIY1sN0PjQ1yUnFpEPGD6+NVHsTVcUxeSW4dG9FNJ3A5nOccNjqLb+/0ePfInMxx4DJu2yyaSuSTKj9f4MsBIQQXBhGnSfVYRerRsuBgZtg9V8YtYt+0ma6MW2itH7pw2kJgWaCUWTi2eyF5pVjv+Kx1DBHiwuD9IKq8qrl5mDBoufzc5QHjtnEyDV2btJRIpVHK5InYlm5MH63mbyWqafcnZf3Y/PSPg0lScppWHC0KdvrhJ6b7noX6OJb1kKbhDKHnEDZkjG5kHAbOev7fvdTneFkwCN2V48H5a8cZ7TcpTOaFY1v0Wx5pJckqE8J1ZWRyYA7nOZOkoqrNnENg5oiOZTUqZfO3Z1kTYKjBWWkyMD7tiv9zXxS01rebH+vm36NQwG8KIfaBf1VrPfmsX1MncHl5o42AD7Ui2OqFdEOzKp/9nmUZ7cLV5gu+No7JSkkncLgzMUZ4g6adc/skZZnXhJ7F5WFM1pZs9HxCrxGpNV4tgWvzyoZpS+WVsSjQ2vQMtxsL7EVRrUrJT+Jv8gJfTviOjWPX7J5mHC5yro/j1bF4vng4X0mctU9qqXgwyxECeqFL4Nj4rsV2z7RffMci7ATEgYMlDGEiK2VTOQvW2wG0zUUeoB24/OD6kLwybsJHi5LtfshmL1j5cIE5v3pRTa30p0KFPouxjTxjzfFJWyWDlkdaGvFo/yPOofNMvbySJGWNBfzo3pTYc7g0jB6y+p6cO2e3ekZgerQokEqx3vFoB95qYT9bhO+fZgSuzWbv8Qtdy3d4pVEiO41bgf9IuNingec5U/iXgf/jMbf/M1rriRDizwD/AfBvPfoL5zOaL168+Km8mKc9sM5ziJOiNkO40FupBQPXXn2hZ0MhMKX9WYuqrDVXxi2KRt1Y1op3j0zK1qVhRDtwH9r1tXwbqSS9yEXzvsillulnEsf3Al9sJE34TFUb8dPZojCOfYQA17IeGzB1kpSrYeTeNCd0jcJ2u6GVHi2Klff+0aJgf2bor5Yl6AQmwzwp69UmB8zCcNaNXO88XhlvWeKZLSvOY9i0dwU8U7vEsa2PlTNwhlvHhgZ+6zjBEsIY5cUeaw+9Rp+DeU43dFfzgncPlzyY5Qxilx9cezgTfdwOGD9FW/f8pvVRPcOnhc9sURBCbAD/0yM372ut/3khxC8Avwr8k4/+3bnK4H8H/uzjHvt8RvP3vve9T5wA96xwbWtVgp+Vyk+CEILNJtJz2PJNGdqUotO0pJbmbcxzk8lrikiDUdtfneSqCcipmwD2F/j6Ydz2qRoblfMXBssSHzovCprB5hm9USlzDAshmGVmsVjkRgfzqMhdCPGJLqCfBYQQz1V8KYSZWbR8B98R+K71gfnFuO0zbr//Gh1LkDTtZDSkpaQbfjHP389sUdBa7wN/8tHbhRDbwH8O/ONa6w8Qk4UQHa31HJO+9u5n9fo+DXiOsS+upX4qpeAo9h97MLcDl5ZvjK/OdkGj2ISF2EJ8gH54fS0mLSXtj7lTyBp9Qi9yP3Wl7Qt8fog85wNuv0+DbuTykmuEXI5lsSxqikYhP4o9jpaGbWNbxvrZEgJL8JG2CF9FpGXNIq8fe65cHrZY5DXX11oIIZ5KBBq4Nj97scft44R+y//Y5+7niefxyv5DYB343xrPnT8NvAz8nNb6vwV+SwiRATlPqBS+SDDJbc/2GGcD5vMQQjwxHMO1rY+9y9DaCIeUMiZoz5LN/FVXLH9e3kjPA+d71bqhXQJs9gJe2eis7vuw4++rDqU07x0ZVtUirz7Qoj3fIv44GLT8FcPpi4znMWj+c4+5+Q+af2itv/f5vqIvH/LK5Dx83AGTaJi+XzP/u68tPuo4Od+itF4cFCsIE5nQhPs8n8/lk57jnwa+uDXMCzwWB/Ocw3mB6wheWms/9UFjuO4tlkX9tWwHfN3wYJZxvCjxHIuX1uLH0pW7kctFIqOkfcFgW0EIPZrPlQAAIABJREFUwbVx/NzOlTO7Csc28aIfN5zpWfFiUfiS4TzzpJIK23r6MvaTlr0v8DC+DO2lM/1MWZtQev8Jx8mzaga+qnie58qZB1QtNaVUX49FoWEf/SWMJuH3tNb/5rn7fg34p4BT4P/UWv8Xz+M1flGx0Q3Yn+Ur//nPAl/1mcHXAZvdgIN5Tuw7L0gFXzKsdwKUzglc6zNzMv4wCP0RKTyfyZMauupUa50LIf5H4C9qrf+oue/XgL+ttf7Np3ms0WikL1++/Jm91kehtRHPWI3jItowgvwPyTx9EqTWlLXCwtDaPg1IramlbvIYHk6Qq5V6SFT0KG7fvs3n+VmeQWsopULAh2bHnkFpKGu5Emt5TxDwrN5zw+I6/7dghGCfZcv4eX2eX1V8kT9PqTRKaxzbMjGmSq/EpRpWx9/ZsS6V4myq86Tj97PGj3/8Y621/sAJ91wqhYaueoYKk3t2Hv+JEOIU+Le11n/wYY91+fJlfvSjH33aL/Gx0FrzxoNFY7ZlrcLTn8aqVinNrSYj9cIgpB243JukKzHRRtdfeSk96blvHSekpWSzG9BuqIOPHkzvHC7ISuMp8PJGe3WRvX2cGItujBHa43aP3/ve9z6Xz7KoJWWtVu/1/OdwaRStKLjzvOLuSYrvGHdIqTSVlNw6TjlNSmqlGMUB19ZaH9hRzdKKH946Bm0My76x1cW2xGomA7DVCz4Vr5gn4fP6PL8u+Kw/z0oq3msibS8PW08lDitqaUK4jhIjUC3qhuLrY1mCludQScW47bHTjziYFxwtCua58VTqhi6XR9ETz/vPEkKI33/c7c91piCE+DYw1lq/fu7mv6y1/jUhxEvAfwf8icf83aeuaH4anFUJZ7i21iIv1WOtqh9FUtakhWSSFCzLmu9e6NFveSyLGtDsTY3X+pn3zKMoarXqE9+ZpLiW2V1cX4sf2l3HvktWmoSm85XC2eIhxPNlmhS15O3GNHDQMgrtovHBty2xEliBubBrDXml2J9lxh9GKrSGXuTh2IJLw+ixJfZJUoAWpKWkknrFs+mGLtO0Qgiey4n4RcSXYUbyeSAp6lU29CyrPnJROBvm25ZxNa6kJq0kncBlUVRcGrTIK8nd03SVs3xl1DI2I5HLWtsnaqJIv0h4bq9GCDEA/grwz52//UzRrLV++0l0sOelaLYso+pc5BX9yMN37MfuuPNKcrwo8ByLcdtfCVxqpThNmzi+RcFWL+TVzQ5JUfPekTG6Kp4QWO471ipS07ZMXrRUmryWq0UhryTtwDFRnLaxEj6LCt3ph7QDM4f4vJTQaVkjEA8J+2qpV22f+6cZkeeQljW9yCTZec775ffZouk51upvXNtavY9R7D1xCOc7xm56re3xyub7FtOBa/PyxgtrkBf4IBxLUEpF6FkrL6Sz3b/v2B9obT6YZpwsS9qByze2OkilmCQOWaXY6oX0I5fdqVk45rmJ3hzFPq9smFz0L6p1/fMaNDvAX8W0h/Yfua+jtZ4LIUbP6/U9DlprlDbmYuf92WupOF6WBK61ovXdP025ebCkqBTf3ulybS3GtgRrbZ/DeY5ji4cuzC3fXMjnecn6EwLLhRBcHBr/mLyS7E0zc4FsXsv5hWWnH9Jvecwy034B2O6HHxAj6cab33WeTpX5cXAWbwowbnv0Io/AtWn5JtS9qCXd0OG9oyW704xXNjvcn2ZcHrZ4+3CBUkZQ9eqmEVSVtWJZGoM2jTYukuc+w/ocSyMpao6XJd3QY9z2V06XL/DlR15JjhYFkWd/qq2/opL8dG+OAJQ0VfbBPGeSFNTSVLE31o3A1LEt8rJmWVTcPknohi5Xxy3WOgH9R8RpO81G56f3Z3QjF/ecmeYXFc/rbPlnge8D/2lTDfy7wJ/RWv/rwH8mhPgmYAH/znN6fQ+hkoq3DxYoDRf60UM0vnunKYfzogkTMYEmu6cmOrEbuitHybySvP5gwTStsYTge5cHANw9STlNS5ZFbWyyFwU7/cikVEn12It14NofUEBXUq0G4KU01YY65wcsH+MNfLgoOJwXCMEnsk34MJyV4adpySyr6EUl18YxoWevPGH2ZyamMPQc0lISujZF/b7NclbKld1AyzcZ2EfznJNmx7U/y5FKU1Q1ke9S1iZt6mRZMM9rNnsBUr/g33+V8GCWs8xrpmlFHHw0s6qWCqU/msBw+yTh/iTlaFFwZRyzKCpsYXGalgxj0xV458hs9MZtj1lasT8rcW0TvrM/z0HAqOV/QBOy1g74lZc8Dhc586xEKc2FQbRyRX4cylo1s8uH399ZBoTvWFwZxZ9JtfG8Bs2/Dvz6Izf/TnPf4xTPzxV704ybB0u8poVztiiYwfOco4UJ6Wl5Dgq4PIrY7IZcGISr0HLHEsZXXms05oI9zUomSUmlFG/szRi2fTbywER/TtImxtNlvRN+4Ms3B1jNWsfHty0O5hmnScmo/b6/Ur/lIfX/z96bxFqaZHlePzP75jsPb/bnQ4SHh0dEZkYOlVWVlZUtqtS0GmjUYomQWIEQYtHsWbBALbGDFSBAqFdI9KZbAoS6Kaqqu4asznmI2efhzffd+X6zmbGw6y/cY8iIyIwcKiPOxp/f6+9+z7/3mR075/wHizYGYwyni3ytpOk+q14niif+D59WPNHur427thQCa6Eyhph3H3IpoRH6bLdd0ixri9ZOiz8rapphxN2zFeNVycks4+75Cl1bNjoh7djD1pbv3Z9wMs/ZH8TUNez3Y7RxiqGJ77H9nvnMLHM6/J3Yf0aw7PP42xFPNnf1FKLsw6KoNbdP3zX3SUK19pH4AKQaTm9sntd0Y4975ysCpejEznltsip4MElpBj7zrKIT+2y2Q9LSY6sTkleGk1mBNpbQUzwcr6i0Ya8b00ucPH5eGWrt5LRLvSQtNIES9BoB7dh/yrvC/dzWumr5ab20aVphjPNvWZX1B6rh/qLxeV39MWKRV4xXBRb43au9iwz/eJzyk8dT7o1WBEoybEZoa5DC0kkCfNWgvR5Ce0qy34359r0R2li+/2BM5HtM05IocG5s86ximlV8/8EEs77GyTzneFZwY6tJc/0A1NpcyGq/eTRHCcHxLOdSLyEJ1DMJZNgMGS0LjqZOBlkJcVF2b7cjlBAEnvzUhl3WWm6fLskrw2Y75At7HU4XbrEcz3JOZjlXhw0H35OS7U5IqV1LQFvLo4lDaCkpQLjFOl4WPJpm3B+lXO7HdCKfbuzz+uGcO6MV42XBTx/PGLYipIDrW022uxH7veSZe/FonPLjx1NaoUdWhvQbwW9sX/fz+ODYaYe01zOlj2rD5KW5qDofTVOscW2i5zcb72vz9BKfw0nG1WGCsRYl4J2TObGv2GxHXB4k1LVFRc5y1Dkw1gyaIZd6yUWrtKgMR5OMP39nxKqs8KTkG8/32GzHeFJwb7SiGXn0jQM83D5b0I4DYs85uF0bNijXYAp417viSXQTn0Xu5mwC1yr9tAfVv9VJYZZV1NrQbwTvK9NqbSg/pD0D7pdxNMtohv7awjAi8iWLvOJ47tA9Z4uC+6crztOS7XZEpTX7fedyhRW8c7wgLTRRoNhqO8PwqgYbWo7nBVcHHsNWyItbLd48nnO6KAgq7YzDxymh575vkTs1y69f7eOtMc1xIJ3bm4XAl+6UISzDVrj2gq7Zake0Y4+nQEh48t2FpKT4ufxxn46s1JwuHJlu2HSSznnlVuIir9hqR+x2Y07m+QXsdJZVnM5zKm1JAkla1JwtcvTCcqmbMM9rIt8N068MEnzp/G2329FFSf3W8YKjec5onjNJS5K1N/CydE5XiS85mjnTkmlacTBJmaTueXh4vuLGVpuXdlrAByeFJ1Xdr4M89Hl8cGhjeeNocWFm9VHRipxVZ6VdK+ZklXO2KDEWXthyMvVni4KtdogS8sLPQBtDNwmp9BJPWk5nzmfiyjBm0AzpxQHLvOZSz834Qk9xdZi459l3LadaG07Xrc7Tec6//coWzdAnDiRpWdNPnGNb5Hv8+OEEa90G74ipikbgEfrqfVLobqjtM88r7o/cvPByP/lUmem/tU/8sqgvhqza2AuYp+vVGe6NUrSxDFvBBxqe/+WtM370cMqwHfIPvrhD1o+pjXOu8pTEWo/pqsDzFLU2gGW3G3Nzp80qrylqQ15rRsucQTPiaJbTjn0CzyltfXGvjRTObu8790b8+TsjGoFimTso3OmioOErsJaNVsSjsWaSlTRCj+eGDQaNEL8jEAiOZhk3d1oXs4gHWc0yr7k7GnG531gbpyRM04rH05Rx6nF1kHwqYl+Hs4y00MwzV8oGnmTYcovmaWhtO/IZLQs386gM//rWGQI3o7kzWnE8Xd8fmdOKPG5utZBSMlmV9BsBv/9cn9cO5hxMUs7mBeO05PbaM7sd+bQjn8vDhMhXPB6n/Mkbp1wbNtnuhASeZJY5n4BSG25st2iFHj9+PCUJPK4OGhcchmaoeDjOeO1wRuQpXtltc3On/eE34DMQvymQVW0ccq2oDFmlnwF8fFA8be6TljWTtFxXGZKzRcnRLONsUXIyz3lxq3XRXuo3AhqhR1Zq7p+vaIeKtNDUGh6eT8krzTQtqYxlrxVxOs/54l6HOPS4d56SBIp/94tb/LMfHlJUmvNlwZtHM64NmoCgNoazRc5mO0ZguHcmeTTO+Jt755yvCna7DXa6EV+61OHxxM0crw0b9BuhS27znNGioKgNka8uZoifVvzWJoWnmdpPvloWNfdHK8raUBtD7HsXp9qnQxvL7bMVk7Rinjtf1EobxquKJFCsVhVf2A1J1qfjVV5xbdhkpxPzym6bfuJzPMv5y9sjXj+ac33D8HvPDTicZigpKLThndMlNzZbTFclbxwtOZxkxIHHVy93CDxJVWseLN2D53sSJSSFNhxOcu6eLnl5r4PWbmDVbwQUteHBaEUUKCJfcvcsJy0156sCJQQTVfLm4QIpXHWQVfpTOQVHvlswvvcuxM5XksCT+E9VJXGgeGW3A8BfvnNKWtboypI2amZpiVKwLCrnRtcM2GyFHM0KjucZjcCjFXr85OGUx9OMnzyec3O7QTPyMNZyuZ/wu9d6THNNUWl+erCgNoa3j+dEfpfnhg2SQNJvxGy0AvLacL4sMdby8HzBLKuYZRVpocmqmiuDhINJRuJ7dGP/M58UflPCUwLfE4SeIvmYEi9Pdwu+frXP2dKtB20s989XjFcFHeszTkte3e8SegptLDvdmOc3mrx+OGOWV9w+WVIZ6/YPbdx8wBoenKeU75xxc6/Fi9sd6lqz10v42pU+f/xSzT/97iNOFxlvHs7pJcEamg7zTLPdEWy0Y0JfcTzPSQKFLyWb7ZhAOb+LxxMHe52mFd+8PuTxxB1YPOFseC/1YxqB4tE4pRl6a+vUX/A+/8Kf8Bsarcjncj+hMubCuCYta6x1m1YSKmJfXTgmrQqHCorXPfmXt9tkRY2nBCfzgnujFYuiYr8X89J2h2sbTnny770iee0gpBX7bLRDekmAlIJxWnE8KwBL5CvakU+a17x+OKeoDYu8phP5hJ4gr2oCD6ZZDrazdnVyzlhGmwtEUYLEk5BVmtO569N7UjIvKrBumD1ouiFsLwkYNJw5+3Yn4miWkVeaSVqy0w05nGa0I/8DiXKfJPa6MZ3Iu0A/1evkdDjNGGcVw0bAlYFLXO04ICtq/uL2GYeTnF4jYKMVscw106ykqDSBrwDBNK/JS82Ds5ReI8B2Akqj157BPr1mxM4a3rfXjTmc5dwbZQwSDyUd8a0Zu/bbsB1yddjg0SQl8BRXh00WecUPH07xlSDyJPfXMyMpxFpzRhEo8RtHLPoshxTiGc+Hj4rVU92C2li22tFFO+bNozn9RkClNUI4EAgW7p4teft4sR4kR6Sle32vG/FwnHKpn6AEzPOSRab5/vmYqjb8mzslp7OCZuRfmPNI6dj054uSvLK8c7zg1b0uxlqmacU8D7k2bLLbibk6aFAZy8t7bb58qcN2Nyb2n8iwOLl7h8Sr0NogpGSrHbLTibl9uiQr9QUi6xflIf1WP/Hv7bP1k4Cs1AgEe713ET3jVcnBxA2Knttw9PZv3Rhyc6fFqqh5/XDG6TxFW8E8qxlnJXmlaQQeeW14eadNLwloxj4/fDhZO7FJNtsheaW5Omhw/3zF3fMl58uc0HPeuFg4nhfUxjLPKmoDP34849XLbe6dpSyKmmsbDSJfst1xTlgH05RJVuHPMp7faDBJS5R0JyhrQFvDeFUSBpLYV3xxr4MQgrNFjpKCa8MGlbZYa8jKgs6n4MI2SSumaYWnCrbbEffOV9w+XQGGvNRkpWGnE9GMSg7GK07mJazZ261IIQVIIdnu+Awart2TVzV3z1dsdUKMNcxyTegrhq2AXhLwtf0uQgqyUtOKfF47mHE0XXH7RDNoBsSBh0By52zFfj/hdFGQFprv3huz3Qn51o1NvvFcn6N14t7rxbxzvOTmTotXL/VIS0Na6M+s0cxvQ5S14WThvKifRpo5zpGzs52v24raGB6MnfdyUbv2zptHs/XzKHg0ySgqw5Vhg5vbLfa6Mf/njw+5N0q5dTZHIThdFq56NfD9+xMqbbi51WKROd5MbeEHj6Z4nsRow71xyh+/uMmXLrVRwtl1fv1qn+tbjtymjWW/F/NovMKu4PbJAmsFzdDjyiC5sEcNPUlWajz10YisjxO/1UnhveEp+T6NorSsmazKi79X6/6cEMKdFIqaO2dLeo2IeVZxOM9oRwF3ThfkleVomvH60YJ26Pr2zdCn0pa9rhtMW2t4PM340YMx/99bJ6SF4YWtBje2EgyGN4/mzNKKvHaeu7XRvHk4Z7yqMFimq4pW6KqeO2crpqkb0uaVoRl5PLfRRAi32QdSkNfGlaLSoxP7F3ODnY6DagqBa4GtWz5Pt3h+njiaZbxzsqCxpuuXtea5QYOqdpC5JPBoBIokcIPgJPS4NmiwLKs1XFQipSTyJNY6H+u3ThbcOl6SlprH4xXbnZjdSKG1g5xutGKK2nC6KJhnFZ4nuH2y5HjuEp+fSRqBxzKv+OGDMZ6El3fb/OTxlFtnS04XBbW27A8aFJWhHXmsckO/ETLPKiZpycksp9JOp+rz+NsXZt17P5vnGAuv7L5bYRxOs3UFYek3A945WvDOWnpl0AgJlOC1gxnzrOZkUTBelpSVYasTYYyl3/D50zdPeONwhpKWQRIgpWTYCHlxq03oS45nBVJAVhu2uw4gMU7dYbIV+lTG0sLnr++c84fXB3zrxpDXjxY8Hue0Ip8rgwZHs4zbpytmmab0LD9OCzabEZf7CcNWdFERXOrFdBKf2FcfCLf9pPGZSgrvjbSsuXO64s7pksN5xs3tFl/Ye/fhmaUV08wRpb58ucvdswVpYRDSsZsfj1N+8GDCvVFKEipmeckLGy26ieL/+skBx+vh8j//4QEn04LcVPSTiFVZ86OHM/7NnSnnacF4XlAZQ+A7qJ02EPsCbQSbzZB54bD1sSfoJR4/fJRhEZwuCtqxDwi+fKnDo0nGqtAIXMvo6VNurxEQ+nLdHlEXzk6/yENU1obRoiQJFIezjG88N2CjFVEZh4LKK402rhf89vGCwBdcGzS4PEiQwlVdh9OM0TLn4TglqzSvH83Y68YczzKysmZVGkKV88bBhMpaQuXze88F/ORgxv3RiqP1cNgTYI3lcJZjjGWz7XM0K8nLmrujFV/e75KEikVWMl6WKAGhrzhbFtzcauMpQVN6dBuemy+UTk7kV68h/Hl8nDDrTTb0JEII0qKmHfucLQoejVOSwGOcFkS+R6k1t04WXBk0GDZD3j5esixqrLVsNEOmWYmn4KcHc3Y7EXlZc+dsxSyrmKYFAkkr9hDS0px4/M//as54lfNgnLLIa4w2xIFipxPwxy9tcPdsRVZpHoxTaqNZFgYpJQjYasfsdUJCX/FwkvLm0ZzxsuTFrSWhr/A9weuH5kIex3EXLCeLjO12jKdgnBYYa1nkNbGvaEbep8pX+EwnhUpbLJbXDqcEnmK0hqsp4SCJD8euHxn7inbk0Y1DHp3POJhmDJsBzVgxWhWcLXKqqcFai9U1jyYlJ4vMkVjOU4racJ4V1LUBUxD7rtwra0sSKLQAz1N017IPUiq6kc+rey1WteXHD6fciVbklWZV1CS+R1bUKAH3RylKwHfuj1FC4EmBtvYDiVlPD5Y/DS8GXzmOw5v350gEt06XbLRCBo2Qd07mLAuNMZbaGB5NUiKlWGSav//KFgfTHITl1tmCHz6ccLbIacUBJ9OUN49mzFYlaalpxx6TtHSY7FKz11GMFjlSCg5nKfO0pq4Vi7ym1BaNIfQElXZl9dmiptKGt48XbLUjBw5IQipj+Padc7LSAQle2Gjx6n6HYTPibJnTjHxWZc3OLzhz+Tx+OXG8hnvWxs2yAqU4mGQIASfzgk6sqY2lGSnSwlJow8HEIYMslkeTlFobGqHHoBFxvio4XxUcTjNOZxnjNazUl4Ks1iSBpKwNB2OnYHA4Tx0k3Biy0mCWFavyhKLWvLo/YJHXRJ7kzaMF1loCT3G5GxP4iv1+k812QF4ZDqY5R/OCrNI8v1YCvrxuNye+R+xLXtxusSxqHoxW5LWrNGapa2v3GgF73YQv73c/8oCnjWVVOpLtz+LnfKaTQif2KUqnyz/PK7Q1vHXsCCs7nejCp7UZ+yzLGiHgdJHRbYS8dbRgrxuTlRopQWjL+bLkcJKBcMNgJZzG0SzXVLXzC8irmrtnKXEo6CchG63ItXKUYFFUCAvGGHqNEKEE43nB2bSg39QgpGvBBK41tNeNOZoX5LXb9DZaIW+fLIg91x66OkjoJgH9X5I8tBCCy/2Y262IUluy0p2+/ubuOSdz1355YbOJ73nEvmKeVaR1zf/6V/foRD6twOP2yZLRomC8KljkJYHnsSy0k/m2Bm0t7dgl5shTGCRpqZksSxZZjTYGhU8UKDzt+CdKSXqJTxgoZquCrHbfU2qNRfJgvKIT+dw6XSAQDNsh7dDnYBLy/GaLaVayKmuwcDjLf2n37/P4+eNJBSfggugVBdIhdbISYwxJ5LFMa+Z5yb3RikboIaVk0Aj4+pUeJ/P1xu8J9roxFri7XPJ4lqGEBASBcECR0lhWleH++Yyy1tTaECpBqqE0hqIy1AvDX98bM1nVaOuqVmssVW3oNZ2q78u7bfb7MfdGKVeHDR5PUypt8JXCAFvtkG4ckJcGrWsCT7HRlMyzijhUPD7PqVqWQEmkgLK2TNLyA+/Re+PeyM1M4kByffPDRSE/00kBoBl5bHdjJsuCQSPEGKfXc7LICaRkvx/jK4mxFm0tg0ZEbS2Dtdrh710bcOtkySx16JV7qWtZRIEjtBzNCoQxaO1MI4yxhH5NWiiGTYGShmE7xBOSR6MFFnfCbYWSHz+aMc1q+knATjdypaqVtAKPOPQYryr6ic8sqzieOeyywVIJwRtHc948nDMvKm5stXhpp81uN/5UvXi1cQvm1f3uBaTuO/fHvHU8ByvY7gS8eqmL70le2Wnx/7x2zJ3TJeergiMp2evF+NIpw0olaUY+RW2wxmKsS6IId9+zSvM7V3pEnuKtkwV3T5dIKWkFCiMNG3FAZQyX+xGNULEsNDvtiLtK0g4E262AVhzSb/jcOl3yvUdTJquSTuzRb7h7OM9L3jqac74swFp8pZyR0nuirA23TxekpebFrRatzz2vf+Wx044InkCflZNIbwSKt46WNEMPbQ1Z6bg9xkArDFDKzQx7SYBSDtp6NMs4meUXh7i81PRiH2MF7cgjq2sqDVlZr8lpCl/AaV5jrGDQ8Ah8l4xCTxJJxfEso9Zu3phr10I9Wjixx1lW8f37EzqRT6/p87XLPbY7MT89mDnZmbU5Vr8R8u0757Rjn997bkDkKf767hlKWkJf8tX9Dp5SLArNlX7ywdId1vFyngBJnuiRfZgS85P4zCeFzXaELwTDVkReaYSA0aJglleczArqW4btdkQr9vCl5A+u92mGPq/stng8yXl+o8XfeXGDzVbI//7t+xzNMrLCorXh9YMFRVWzKDTWqTagLfjK4evP5jmTtEJJEBYmWYknBVvtgNePF5ytxeoCJfjugynjZUkz8rg2iGmVAcuy5vef61PWEKia00VBFEgWWc2N7TYPz11v882jOcNmiJLyU0sKs6zi0ThFScFuJ2ZVav7q9hmhpzhfFlzfaCCl5CcHM27utPDEGt5pnW5LHIh1b19SG4utLZNVReRLQk+y6fkoJakNFLWlMJrvPZjQDiWPpwWLwmAxWCx+KlimFfNS4wuIQ4+9bsIqryhqQ60F56uaONRMU5eYjbF4StAIFN+6scE0q3njaM4bB3O2Ok5/qpX4XBu+3zzpfFVwa62po43l954bfCr39PP4+CGleKZFmgSeU9ItKpZ5zf4gYbsdsdOJyMqa2lgWueZ8VbLTjnj90JFXb58uuHW25Gyes9kJyWvLVicmlDDLNWcLB5V2p3npmPZao5GgIasMkacc0EM5tvKqNJwtS4qqprYCYwwIz60XkWOAfuJjjeFgu823XtjgC3sdjmcFu92IyarkX75+TFppNlsBnUOPRxNHtBNCEitJpeHGVgNPqfeJ5j2Ju6MVaaHpJj77/YT9fsw0reh+BPv51+mn8N8BvwP8wFr7j556/QvA/4TbQ/9za+1Pfpk/R78RsD9IWOQ1G62QV3adv8H3H0yYZSXNwCeLXethktYcTVN2uzEPxykHs4xuHDBaFby026KVeM7rwEKpLcZWLAunv2IATzrtkk6sWOSaoq4paouQ7r2iMtRScjgrCZShrB3MbLRwsNWiNhS1JitqrgwTtmVCXlk8b22iIywvbLZIAo/fvdbjRw99Hk9TfOkkq9uxdyEBrqTTSxot8wtOxyeJxdo5qtaWo3lGVTutpryJxKQMAAAgAElEQVR2TNNSW47P3MaZ124W8u0751TacKkfcbooeOdkzmRVXbTEcu14CKUxNALf9XuTgHeO52RlzTyrORVQGVd1KdzsZ5q51/JKoxScpxWRUuRrjaRJVtIKPU5nBbGv2G47FEleGf7whSGeUqRFwWhZMmgEBJ500MOd9gfOXhLfw5OCyloa4ef+x78pcTp3RlVKCa72G7yw3SRfo8uOZhlvHi2otWWcFpS1wVjD6bxgllaOO7AsWRQa0A5RtK4cSm1QQlBpNx8z2qBxbOJBK6AVBjRD5UATq4Jlrh37Gkh8QRKHtCNFXhpqA1prThYF2himxZSiNvzRzS02WiGh7w51pTa8dbzg9gmMlyXdxGl15bXmfFURT3NKbfk7NzY+8F5Ya0nXplzOyMtxtz6OsdSvy0/hq0DTWvstIcT/KIT4urX2u+u3/xvgP8Tto/8D8A9/yT8Lv//cgPGqpJv4DrdsLZutkHbiYSxogzsFFM4oY5rVbLRKsJbRouBwkvEvXz9a8wlCCm3JipJKW6R1/xEJa4RMjUU5rZ7CYhGOtBV6+NKdgDCWIHAeru1IsSqf6DRJirWvwBuHUwIBmD79JGCyLJ0JT17x0m6bnU7M7hdjfno4AwuX+jH9JLwQq3NaTDkPz1M+iUCqMa6V00sC8krjSde/fzTJeGm7xY8fTxkvC9Ki5tbaK+GLl5woXlZpTqYp46XHJK04mmV0IsWwFRJ5ktNFwck8x/cUzUARSofVlkogpcSsy15PgrKu6hJCIHiirAqZhtBzv7NW5LHRCmn4kkmac76s6TYCuk2fv//KDtk6gSnhFk5W1gy2mnzpUoebO50PHcYloeL6eih443PDnl95WGtJS03kPyv+mNeGduwhgLeOZ9w/X7LXi537Xm3IyhpfOdReoTWrvOJqP2a8yvFVSFbVTLOKk0Xt4KTra0jh1mWgJKU2FEh8BBvNAKxgsqrwpWCeVqxyTVlZEKCkq2C+drlLO1CUBu5PVkxXFbO0JK0tpS55NE75/r1zNjsRW+2Yr13pcTIPeRBIOnHA4SyjtpbNZkgn8rm/ck5u7fjDt2+xVi6YrdGTnyR+XZXC7wP/7/rrPwG+ATxJCj1r7SMAIUT3k3xoUesLe8xPArVshB5CwPnSoVwWeYXvSW7utNlct5UWRcXjSeYQRsaSFRrfcwPlk0VBVlYMGgEbzYCWL1lmoLW9aBtZAaUFW1q0KYhjHyElSliUUISeZDBwIl+TtFxbSFrywrAq3SDakwI8j7NFDkLwYJLxeJLSb4Y8nmZrkljMlX4DT0lWRe0GZgKWuaYZmgtZj2VR0wo9amPdwP0j+oxP4sE4ZbkWrHth690NsR37HM4y/vr2CG3h8TRjqxlihKuAqspw53SJFDDLczwpySpNrSt6ArT2qGrHvXC9YsF+L+ZglqOkAmqUcvcy8tcwxFJTa8ustjQCLqaPxkAjlLy42WJZlbx1smBV1hgjqI3lhe0Wm92QZe78GpaFIa0qeknIbiemHQccTjMGTSdLMFoWjFclvcSZ9pzM3SkNcPaLTzFInXe0Zdj8nPT2y4rHk4xpWhH6khc2m09xcVwFeG+05N5oRVlbbp0s2GjHnM2d0JzB8vA8o6odJPtwnjJb1Wy13YZfa8N4UVJUhk7sEwdOjXW7ExB5PvM059Ekx+ASU+h7+ModlMJAEVaOhCpxScFTkihQPJwVTNKStKhJfIleCzH6UlBry6NpxjSrmGdOaO8fvLpL4CtunSw5WxScWHf4/MbzQ2Jf0U0CYl8xTcsPbQlvtMKfSx7+15UUusDd9dcz4JWn3nuaTfWBO/t7PZpXRY2SgjvrdsWTHporEe0zLYAnvgHvPQU+njgZiHdO5pzNchqRz24nYrMTc3/kNFJmeUmlnayzMZqiEoyXBfW67bHyNUmpSWtDoY2TTfAkkbBoK9yw2ljSypKZCiUEwv1/MAhCZThbuvJTCggCybAhkSWkRc1qbcQT+Molr0Lz5smC61YTeW7YNc9qsqrmcOoGtc1QkdeGQdM5n/UaPmmp2WiFtCLnDbHMHQv448QTKd+iNhcS4qfznHFacjzLLiqCFzdiRqkmDhRncyeLvd2KKK1GAudr+O+qMKR1QaAqhg2PQRiz1415PM24NUrRtaGqNXXtqP4C0NqglEJJyJ3wKvPC5QSBaytpaylNzV/cOmee1+SVJvZd5dAJPO6cLbl3mjJaFGx1Q8oKPOmYrX91e8Q8rxg2Q/7uy1scz3KshZN57pzcfMWEaj3vefdxXeTu4ADPam99Hp9uZE+ewcpcQMjPFjnvHC/YbEe8uNPiZFFQ6wor3fO5LGpakc/hbMkbhzPSUrPTipjmlRNLtBYlBcF6plXXmqx0SKVKGg4nBYlfkJaaXBsipZCsDwHaMGiErEpNUVskTusr8FwlczrPmaxKRquKtCgxWELlESnoJB5COM7BqtB0kuCiwgiUYLMV8ONHY+ZFhRQSbQ37/YTQE7x1PCevDF+53L2Qw89KzfE8pxGon1vC5teVFGbAE5ZYG5g+9d7Tq+kDj69PezS/+pWv2rtnK4dSWdvmVdo8Y1TxxJ4yKzV3zpYAXBs6OYtKm7UEQs0sq7g3SpksS4YtS22c/WbkSR5NcmZpSbZu5UghKWu3UVtr8ZS6oKrX1tKNPWcsoyHwoBOH+AoOpgW1rklLVwkYIJAgMTzOSrJ6PX+w0BASJRXbbUcOA0noCXpJBFhCXzFLa8arikvdBG3g5nZrnRwqWpEblD4tkvVE7tda529grOVSL/5YlZW1lmaomOc1l7rvqqyeLgqshXeOl2y2Im6dLThNHWyvH4RUlaEZKpa5R7+R0G/63DtLmeQlk5UzAEIKFnnNoBGhBIyWOVo7LoSzL4XUSTxRa/CtRklJ6Bvq2rWSAg90DULC+bLgL26dkxc1Re30bXwlUMIptq5yp3S5qmsOp5bnh02+dsXp0tw5mzFNKxLfWyOUnPZ9K/KotWGeO02sy/3kmQPHM6qzn9s0/NJitxszWhM3nxzufrhGk50uSv7eK5t847kBj85X9Johj85TauParufzikBJprrkbJmircRgyUrNZjt2swRS0sodtNJKU1U1oa8YZzVFVWOta/kKYfCUwpNuL6jWroFmrRyw1fSJQt85IAqo6wopoNYCjaYV++x1EwptKGp3mL253cYYy//2l3e5N0qR0vEWzpclgRJ4QvLqfofv3BuTFs4462mE3NHMEViXef2Mcc8niZ+ZFIQQ14Eta+1fvef1bwLH1to7n/iKLr4N/GfAPwX+LvBPnnpvLIS4hNsb5x/1QRf9cCvY60aUxjBsOpzvk8NaVml6wGotiAfvmlMcz3JO5jmzrKQTBbyw0eBtY2lHHpfWEgeLoqYRODtIIaAR+Gy1AsYrx3z1PUWxThBK+QRSgPQcSUQIrIAkkDw3aFGbKaNFTlXXGOM2ucpAVVikeDcLNkInprXTjdhoRWxNUqZpTRgo/uD5IZ6Ee2cpSsGwFRF4kt1uzKqsmaYl07RmVeoP7XlPUseSBsc4fq9u+wfF2aJgmtYX3/MkOuvWUS928tjNwInS1Wu/hHJtiF4ZS78RUhtnbH5zu8W9sxWrQlPWbpM/mmU8Hq8otKXWBouDhQa+RHlQ1W4BCaARSJTySMsarMUKgVFO8FAgyCqNpxQbTYUQgmbgcbnf4GSRUxhDZTQtXxH4CqXgxnaL0bLk2rDmwXnKcxsNunFAJ/HZ7jj0yWjpXPaefoaeRDP0uDJMqLWl9ynq238ez8Z7fdK1sSyympOZ80ZYlW5T9DzFPK/Y68fcOV2yzDWbrZBHk4xAOTXSWV66w4Jy7OHdboznCR6NCxZ5QaAUxlPM0orKWGJPgRB40v3+08q1qy0exgqEFHjK0o0Duo2IjXbAwTRnpxsT+x7nq5KsdO3X7XZ84eF8uiy4ud2mGXn8+dtnzssl8tmMA64MG0zSCmvcXhF6kiv9BtambLWjZwiWSeCxKvT7fOA/SXxUpfDf4/yT3xvz9Xv//s9zUWvtD4QQuRDiL4AfAQ+FEP+VtfYfA/818H+s/+l/8VGfFShnkZmE6pmBSqAkg2aANu+ye7uxUzC01l6cnn0lOZ7nlLUz3Lk6TBBCOknswvkSNEO3we92Y6SUXB4kRJ4EIThb5ljjkAxKSAxcaCbNi9qR0SxklSAr51gcJR5hKStNZdz7noKydL0zX0E7DvE9yZ3TFaW2/Dtf3OX26ZJW5HE6z/ny5R7XBk1O5hm+LzhfVlgrCH3nGdsIfJqRembx/PRgytE0Y6cbs/VUEgjVB58mam04mGYXAoLPlHBPtUe2OxEIiD3F1Y0m90cL3jpeoCUMGxG+JylqzTwtOV3maG1RUrLVjphmmsArGS2cVlJZOZappyQbrZBZ5to0dS1oBDA3EPoQex6B79FtBGwLQalrzhYl2rjfbaUttbZstUJaie+EEIVgnJbYzHAwLhi2Qq5vNmiGPpe6MffPHcT2ha0W/9bNLTpP8Q+eLLBG4PGkIHg6IdTacL4qiXz1Gyei91F+CH/b4wlJcrMVMmwG1Npw/zxFCvjalR473RhjIPAy7p4t2O/FHC0cmqifBEgEmTZstQKwlp12g7N5Sekr8lI7+1y7VtANJYF0hNRSu0PcMqsJhKAVSchBYIkCD6UkvlIsM83ZIqcb+YDFl4J2FPDNFza4vtHAU4LzZcHlfoM3j5d4SuIr1xXY6kT84QtDtGENyfZoBD43tj1e2Gqy1Y6eqVC3OxGd2HeJ7ueUsPmopLBlrf3pe1+01v5UCHH157riu5/xj97z0j9ev/4T4Jsf93OEgMuD98MphRDsdp8VM/OUfB/ufLsTcamX8OB8ydmi5Oow4bm1q9P9czesakcelwcxJ/MMJSWbzYCsNCwLTVZpIk9RaEvkOWLZoBEyWZXEypWfWMvpXBN5FUno9I3yWtMIA4QEa1xVk0s3xFZKEvmC47mDi4aeJPQ9hq1ozQyuGS3dqagZBXzn/phVUbHdidhpDxk2A9JSX6gogiPf3D5ZrRFHGd+4PuDasOEqnw+Rhx6v3IwCHOJmoxlS1A67PVu3p4xx9pv1evB6ZZBw72xBqR2EthF5aGNY5JoXttooKRwRyFiOp4ZO5DFZ5kS+R+RBFbjTvbTwzReG/MkbJywKJ0dSaIm1klBJ56rVcD/PVjtmvHL3zZMQeIqyriiqmrSSfHN3wLI0bLUj0rLiJ49mjNMSYS373ZhLvYDAUxxMUtJS85XLvWcSwtMRB4qXdtrrluG7J7Gj2bvOci9sNT8VGZHP4+NF5Cu2OhGt2Ge7HTHNSvb7MRZLI3SSDpcHCULAfr/BaJFTW8tzgwbH85xpWjpggHCtynleEXqShvXohs533c3wKtJcsxQWT7gXnxTMylN4wEZTkRaOe9RLPI5mOauqJlwLTyohkIGiFXpO4gbLyaTgztmSx+OC65sN2lGLq/2YGstoWfFXt8/56uUeie8qn4Npxhf23o+O+zBU1ieNj0oKPwv987dSPnKWVe40mbyrIPrKTotlXlNrw6qoeXm3TVVbfvBwsm5tGLqxRzcJudRr8OX9Dv/61ojxw4nTY8f1qbWFQTNksxNQ6QazrEQWMFlWlFrTjJwZTmvt8OQrgTGWbitmvMyJfEkzVDRDhfIUpc7xBOy0Ezf0bgVYA6fLnMNpju+5oVheOblfbZzB+ONJ5pjRvmS//0ReV9GOPU4XrndprUPx/Cyf2zhQF6fiJHAKjNa6B/t86dA4gScvEkISOj7E42nO3dGKbuTRDCXNMKITB1gL+/2ERuhMQY6nGT96LFHA3XFK5CmysqTWko2Wx3hZcmXQoDaWsl5jxE3lWj+BQGDICs29c2eC1Aw8+s2Ar1zu8i9eO8H3PUBy62zJoBEyTUuu9BPSTVfFNUKPjXbIlUGDvW7Mn719yjQt0Q/GF3r6H7S5uwX37KJ7cp+EcCfKz+NXF3m1BnoUNYuiYtAIySvHLRBruPFWO2K0LPj9awO+++CcmzttjmcFSeg4J/O8RuuKci2znZcV5dwQBz4bTZ+idu3MRaERwmKtJvQlvhRYHFx1txPiKcXRPKed+DQin2boM14WTNKKOPQuRPsMhllW0U/cnjBeVbRjn7zW/MOvXGK0LPjnPzhgmdWIvjvkKukS0+mi4PEkvVB8NsbyYJzycLxyhlSRz42t5rMzrk8QH5UUvieE+E+ttf/L0y8KIf4T4Ps/1xV/jfG0RWetzcV03vcU+/2YN4/mRIFyJ9zAY7MVsQxqBg2f02VBErhTfnNt/9hvBheooMAXBEpRG8ODUUZVO3q5FAJjJUoJ4sCjEaq1H6xwjF2t0cYRYYSQbHdjnt9o8HCcUtaW6xtN9voRt0+XJKGiEztXt6LUbDQDer2YVqgIlKQZ+E6Ebo3ff3LKB4ez/qMXN/jKfpdSG5qR/5HG5+7haiHEu+0Ta52GSugLrm828JXkUi9mWdQMmyFZpdnvJ86HthHw3EaLrDLEgUczchaHnpRcHTY5WxR4SvLKXpsa1/Irq4BRWlIYuH+eEnmS59dWhKfznDePF5SVJqsNJ/OSZelUKn0luLHZ4wv7HbLKcrkfOba4EBzNCtLSsN8TPLfZWg/Vncz4Xi+hm/jrpK2oag9tLK8dzLmc17y43fpYvdndTrx+Ppz0wufxq4nDaXahjLrfTxivSjZbEXvdmDcOZ/zo0YReEvClfXeyfjhOiXzHAt5sBXRij+N5xqJwBlStyGejFbLXTVgUho1WwEY7ZLeX8J175xzPcrKqJvJ8Am8tF19pGnGAVJIv7XfYmEYU2sGlrw4SHk1SEIJW7KG1Q+SNljVZWeEpSa8R0E48FnlFGLTWLo8ll7oxVwYJl/oxrdiZbuWlxVdibarjQBCPJimHk4xlrqlqe+Ee9/Tc75PERyWF/xL4Z0KI/4h3k8DvAAHwH/xcV/w1xgdZdGal5miWURvLXte1oeRakuHKwHkeD5oh5nhOWdsLxuvXrvY4mWdU2p1WlYRZVpOVmko70xwloBX7DBKfvW5ErS2b7YBF7garZ8sSbQTSWpLQJ/YlX9zr8PJui1bk8+bRbD1Q9ZASJIJlVjvf11XBnZFYb0KKwAOlBFnloHfbnZjL/YTTec6q0Gx1QpLAuxB3yyvNPK8+UnL3vRtc6EuuDp30dVlbGqGT5e411mQ2AbudCCng1f0uu+t7mleaHz4Yk4Q+x/OMybLk7ZMFZa2RQrLXiVisIbf9ZsgbR1OKGmot+cMXhnz1cp+DaYbvKW6fzskqx8wWCMp1yy2rLPdGOceznGbocXUYEnmKw2lKO/a5PHDJqhM7tnQzckJonhRYK7ix2SLtadLCSRJb++zs5GeFlOI3bpbwWYh0XSGMliWhL3l13zU3RsuC00XB/VHKolnTS3wOpxlvHc9JAicdP2xGbHUivrTf5YePprz+eIavHG/gUi/h0TRjtx1xbavpDJeSgNa6ndQOHVN+0Aw4X5TMc0d8e3CeAZbH45ReErDVCvmdK32+/2BM7HuUWjJoOjhrI/BYFhWLrOZSx7WLfAn/6u0zKmPwPMGVQYMv7HYYrQouDxoMWyGt0COvNI/GGQcio9SGcVrQCDw22hG7negjD3w/K35mUrDWngB/IIT4I+AL65f/b2vtn/7cV/w1xLKoGS0KOrHPfj+mNvbCovNkvWkCDFsBkacuhtBP/lwWNaEn6Sc+pTaczHOuDhr8x9+4yr947ZgfPJowyyo6oU9tDaNV5SQXpOSl7TaXNxJGs4KjecH50hnRz6w7GUvPyVPMsvrCTvPlnTaVtizyinboU9aWXtMn8ASLrKYZ+ZS1wRp4+3RJM/AoKk3cDjmZFygpeX6jQVpp3jpyhj3b84gv73eJ1wviRw+njNOS59ZyDh83+o3AoRukWHs5uHjiXncyz+kmPje22hczHW0sP3485bXDBVJYIt/j1smcu6OUq4MGX9hr40nB64cz7o4WlKWl34zJippO4tOOPBZ5Ta8RsNuNqIxGa8iqmrTUzDJFJ/IIPElR12vxspp20mTYDNjtOQvFF7ebFJXmR4+nvHm0YKMZ8vxmybAVsshrsspwfaNBrxEyz2riQL3Plc6Zx9tfaNH9tsVHDbLv/7f/3i/t2judiEfjlGuDxDkYppVL+oGTdek1fDbbIQ/HKffHKQLBLC8Zn1dc7huMjdnpOJ2k5bBacx/c2vvm9SH3RiuOpwXjtEQqSaCke743mnhKMkkLpBWURjt2c1qi13yk++cpm+2Ib70wJK8NldYkvqIysNMJ2WzFRL7kJ+nMrSlPoIQiLyveOpnTbYR8/WqfSVoSKMlWJ0SJiGbk8c6xg9bXa0veJy3Qwaeg6PuxeArW2j8D/uwXvtqvKQ4mGeXaF/mV3fYzmPwkdFr8T6zs5nlF4Mlnhq/Hs5ysNMzzimboc7ZwwnU/PZjxcJLS8D3yyln4dUJFN/bZbIZcHSbc2HK8gdNFySJ3PW2L84Td7oSAYFXU5JUjm3kSaiOoa8t4VZGXmnbi8Td3z9loBjQDj/1ejLBwfbPp1CFD7wKp8L37U+ZZze3TFVeHjfUD6hQj88ptdLWxnC6cx/PBLOPF7dZF/3GyKi+IWx80gA49xfXN5vtef0IoCpSk0pY4cC2notaOEZ7VDBoB1jrD9IPpWlZYG1691MZXim/fPuNs7iTMdzohWDevuH2yZJRWnM0dH2KnHeMpBzlt+MpBhkOP3W7C/dGKrbalEfq8tNVCSMHRLKfWlu/dnzDLnM9tw1cO4SEFWWm4e7Yk9BQn85JmFDhE1XviCfcF4Oqw8Qyy6/P49UQj9Hhpp8290Yo0K0krzWhZsteN+erlPi9stsgqzcPzFcFU4nuCG8Mux1MnTBd5Em0ssa+4vtHgtYM5RWWwMbx2OCctNXdOF/hKOg6SceihKFB87UqPf/LX90E6qZxpWnLnLHUtIl+h1qi7R+MV58uc43nJy9tNrgwTdruOJ9WKPPKq5mheEnmSOBDcOcs5mOacryreOVnQS9xGf23j3Wfucj8hrVzLdrGGSH9alepn4qmOfUVZG+c89p6p/GYroh35SOHcwcCxdW88JeGQBMoZxidOh0Qby3jlStPRsuDBeIWwjnW81YmZZ86DWAnF/qDB4bSg2/Cx2As2cr8ZkBWanW5MpY3DIVvD168MiHzJqtJ01/pCJ/Oc42nG+bJgsxXyyl7n4nu3WwE/ejxjWRiuB84M6HSRc3e05KtXenx5v8cPH44Bp5r45Ti48Hg9XxVc6sbPDKSeMHLfew8+KjaaoWN2NgO6sY+/XmzffzDhbFnQDj2GrZDYd8zuk0XOQeGS8Z2zJZd6DeSaeIgAX0gybTjJnC+D5ymUgEbsX7ToOnHAsqi5sdVyc57Yd5pJvnPdutRvUGq9rgZrZlnJF/c6TFIfaQ2FsdwdpwS+YrX+zMmq/FDkhiMqvvv150nhNyO2OxGtSHH/PMUYSNbggMCTDJoh89zZ3fabAS/vtgh9xVY7wvMkN7eb3D5ZUdQag3BoOVvTSwLiQPH6wRyLWw+R58iuQsDxNOO7Bhqhj7FOsG5VGnqNgMRTBJ5gsqoBwZ3zFGsFq6LkreMFD8cZl4c52+2QF7fbCCRCuH3KSbqwbglLVnlNoBRniwIhIVIChGC/n9BJXCX+abctPxNP9X4/ZlC6Kf/bxwuakcfeU3DVYi2loKRzY4vXdpUHU0dyudSL6TeCtSaPG+LM84pmlDNNJVf7DR5PUpRSPDxf0Q49/EggBVwZNLi/dl/7g+cGCCH407dPmaxKFqWm1wjcoFpJdrvJGmEDndhj2AzoNXxOFwV7vQQB3Nxp8mic4itXbdwbr3hwntEIFUcLB63zlKAb+ywLN+zdaEXcO1tdIDOuDhu8ut+lqPUzMg3gFlJZOzngj4rRsmC0LOgnAZvt/5+9N4uRLMvTvH7n3P3abuZr7EtGRmZWVWYtWVXdPd3TrWkQm8TwAAhaICFeWARCAzyAhGA0PAFCLQ2IQUjwBDM8IBAzL2imgR7RU13VtWdl5Z6xePjubvvdl3N4OOaWEZERmZGZkRFRkf5JLkWYmbubH7v3v/+/z/+4/nVeMIpy6tqk09+93OXGUcQ0LTnXC0w24tp8eBizPUoJHJtraw26DdPAP5xnZEVNs2ux2fXZaPvcPE441wu5eRRxHJmSYFWbjebtcbr4myrOdQMarsXeUcrNowQp4eX1FoOWz+9ea/GLrTEHs8K83pasLvZSeg3noca+G7oLTQtN7zHqUpzis8FE3wkguDgIcSxJw3O4vt6i1vqekl9ZK7aGiQkMXYt24HJ5pUHomoXG4yjHd8xWskCx0vTZ7Ai+c6FHw7c50zFTaUfz3PTrAjO66jkWeVUb/rBasTM2vQSlNLlS/NalNX6xNWaeVZQLWdo4r/FtG9fBCHMJQZSV9Jue4U1aTPJZi2XX9bbH77ww4MPjhJWmx+1jcw/7tiH9u/oJQjlfBF8JpyAWjeO9aURRKUNFG5gZ4nlWLfmQoqyk6TsMGi5H85wkr0moF3VtUz9fa3u8tz/HseAvvbDKMMrYGaeklaKvDa2yZxvnkpY17+7N+YNrKxxu5EgpGcUFtiXISrP/cPPYLKtMUzPj/qObQ871Q5quw3pLEXo219baOFIQFyWd0KOoRtSaBXlWwErT6C6stjyqWlNrEz01FjzrF/ohR/Oclm/f0zi9v14OcHW1QVap5fd+Eg5npgR1MMs/xrMyS0t+cOOYO+PEaE6vNZkkJXuTlJ1JhmMJrq418W3JwTzng6OYlm9xfbNNP3QZRjlxXtNv+Xxjs03gOSSl4rXzHcZJycWVkINJSl7D/iylHdp0A4eDmVkiCxyJEBKUZrXpklWaTsPllc02V1ebDKOcotZ0Q4ffurrC23szoqzCsawlZ9YsK+kG7rLZbklxz+7HKZ4OpklJWpjd/2laLhmAznIAACAASURBVJdWbUt+zKDJxVgqQC90eGG1ge/eWxo+nOekRc1Gyyy+lcqI01xsenz7YpetUcI8KylqRdt3eHmjyWo7YJ6Z++/GUcKt45hKK6SAqysNxrEh1yxqU3Z+ca1BK+ji2RavbLYRAo6igsMo53ies9r2eWWzzdv7M3pNj25ogrfAdbg8aLAzSUnLknlmstRhXJDtTllteY/ERvBZ8JVwCidoB/ZSjq6ojLZqUZlNWlsa+T3PtogKUxqYJCWWFPdEzZPE1NyT3EzNfONsl7PdBuf7Ie/szQDBasvl9nHCvKj42daYd/bnixE4Dw1cHjRI85pzXZ+dWcbuOGGclNw4jhYcP4p4oe+w0THTMWKRxWwNY5q+jSUkg6bDmU5Iv+EyaHnYAoaxEdE40w2WzdBu6PK9y31jZD8l1bQtSfMRm6id0GG0oOy+H3vTlKwwJZ7QtTnfCwFNXmk8VxKlFcN5TqVZqJ+5VMpslUsh+M6lPklVE2eGWLDpSm4OE0OOV2sC1+b8oElSVOSlQghB6Nmc6QmizObVc11uDRNs28L3zPl5tsU4LnirnBG6Nr93bZWVk2330KGqjaqVVop/+P4xZaW4tNLg62c7j3Qep3gyaPo2R1GOQHxqCc+SgrWmx82jiHbgMklL+vKjseFO4LAzTgk9ix9vTczkmWeZhnRasdp08WzJatPnQk/Sb3l852KPrVFKv2HIJPenhsq6ETj4tiQuFC+u+8zSgqJW+LZkoxsyS0qurDb5w5fXuT2MYT9iFOWkVY1lWdwaxlxdbSKF4QG7MDAUGK7tLkg+A358c4xAkxQVgWNzPC9OncIXwVrLZ9DwDCmV0rh2gZQ25/shUsA8qxBCLKPDpm8M1EmNuaoVtTKG82AWY1smCr8wMF/fvthHK827BxFRVnG4XyBahj3TtgRxUXN9vUngGJ70pm+htGAcFay1BC3PwbYtPEvSH4SEjkXoWsRFyTiu2JumtDyzPf3KZpuW77De9bm2yGKKSpGUpuZ5v6F+VIGNz4Kz3YCNtv/AGryZCkkJXMnZnk/gSFZbPt8418GyBLePY4ra1GCvrDb5rcsev9yesD/NKX2FbUkGoc9mW3B7mBANE+YLkq9SKbq25MX1Bm/tRdyKY9al5Btn20gpsYTAtyUaTeg69BoOaaGwLQg8CzRYUrLR+Wg5bbNjSoSOlExTo7ZVK5YZ3CmeHYSuzcsbJtp+lAWteW4kNY/nOWWtWGv5rLRcNjsB5/shg4bLziTl9jAhK2uitIKuGWE/jnOurbdZa3qUC00DKQ119clwRSf0ODcwbMxn2iFpVTHLKi4MTDN5mhma+hfXW3R8l4NZxrnFTkXgGucjJGaEte3TDR0ceW//UwiBEIL1RUZe1iZT+jLGoL9STgE+osx2LMH1+8jiNu4LCO9eWsorM3lSVpozi9JM4NpLfYLl6y0Tybx8psv5QYMoq8jrepGJKH62NWHQcLm82mCWlXRCh+9d7jOcF7QXSzYt31nyM53rhby1O2WWGidkWZIzTRdbStba3j17Bq4tHzgZ9LhxNDe9hF5475TOSY9CCEE7cPnDl9c+dtNeWW2y0fFJ85qf3B4R5RVnuz6bnZCjyOhcb3YDznQDNjo+b2xPERIsJJO0XO5bjKKCoja0GvO8WqhLCa4uKEo+OJyjtNnbuDRoEmWGXn2zHTCKC0LX+ti28kk5reE5XFwJmSUVr3yGcd2nheed2+hB+Cx6KU3fZqPjk1dmKggwpIaL+10IMwFY1opu6PD1Mx0avm32ilouHxzGjNKKTmATeg7zxX3bwaFuKo7jnH6jxdW1Jo5lBizivGa1ZQKerFD37Pv4jkXbd/jda0Y1Lc4rqlrTWZAoPqisC4Y14UzXp1Ka1ab3mc7gs+Ar5xQ+L7LCNICtxXx+eyFME7oW7x/M8R2Lcz0zyXOxH5JVNY6UvHc4RylIioq/uDnCkgKtzUVSlJoLgxBLCv6ZV1v0Gp4Zj3NNM3tvmrIzSTnfCylrTcs346QbbZ/Lq82nNv1ytBhnPZob/iUhBHdGCZOkJHA/GlkdxgWj2Oxl3E1WGLo2oWvzzQs9tscJaanISjOyKoDVto9vS0LP5h97eZ2bx0Zo5Hf6A9bbZi7dlZLDmaELWG269Bve8sarlSYtFE3PXrDH+hzMMpqe80jCI64tee1cb6kXcYrfbKy1fFxLLoWn5lnJWtunVpqfb43ZGiV0AqPr3W86XBg00GiG84Ki1gyaLrPMLMhdW29xvt/i7b05Ak1aKr55vkc7sLm+0V7sJxjalQv9EK0NL1boGvqMolLLUe+srBdN8ke/jx/HHsKn4YlblYVAzr+++O/f1Fr/7fue/1MWYmXA33hWFuXagW3qzgvW1RNvfus4JiuNotmJUpeUgtC1maal0WNwJJNEsNkx2sQXV5q4liR0bYZxTi/0FhKf/tKwjeKCcWxKF54t6TfcJafOxZWQtKgZxwVrbe+hkcWXhW7oMFz0Ek6MZlyYWekoq7gzTLBtoy0NRgv6QZKAtdKGmlgZ8kFbmumQXuiwNUoRwmRL3dDl6upHXC7n+yHDuCAqSs60Q1abPg3PWipQWdJIEc6ycikm9HlKZ6cO4fnBybXR9OxlCeZ4nnNnlKKUZhQXvLTZYbXpGk2QQzMAMksrxklBVta8sNbkTDeg5dl0AjNiHhcZvvMRQ7MlP8pWT3B39n5SfdidpEYjwTbqcXdH/clCj7wbfj49hC+KpxFq/n2t9f8ghHCAHwJ/+wGv+UOtdfWAx58axGI2+H60F3Tcri3vMc5ZWS95lqRwONsLsaSk4VpsdgOGC5KsVmU+gqJS1FojF0RrnvNRuuktiO9O2BvlwtCCoWG4fxT0y8aZRS/h7gt5sx1wFBlB9MmyDm+efxiVxqBpxoRtKVDaZpZWOLZYluQmacU8MzrKgo+iJNuSfP1sh1tDc3Zrbe9jN8/nlSI8xVcHLd9eUF7Ay5vte7RHNjq+Ia7L9YLTygyfBI4hhjT6xyXfvzz4zPK/YOg5wNz3ldJGgwXTx7h5HKMUZmrpM+wKPS48caegtb61+Ge1+LofCvgTIcQ+8G9rrUdP6r19HvQbLm3f0PPeHVmejMJpbWirTyac8srMTZ/tmZX0OK84nOc0PfueHkbbd7i2biKME4P3tTOmCFrWCimNwtOTzhJOcP9N0AmNtOckKbgzShECrqw2lmn7g+DZ1pLKXGvD9DhPS7TL4kaD3XHKPCsX298fwXcsXtp49uv9p3i6NBifBM+x+Csvr1FUisCxTNZf1ZztBnQCh07gcDjLOJjlNFYbXFtrLjP5Lxp0nFQNGp51T79BCGFINNEPZdsdxQWTpGDQ9B5K8f5F8DR7Cv8m8H8+4PF/Xms9EkL8EfCfAP/+/S+4X6P5aeNBRs+1JVdWG2SlYpaWzLOKwyTFs03ZKFjUGBuezeWH1BQfljo6luTaWsuwnT5jW7XdBZ22FOIzpb5CCJK8BgTTpOTrZ9uMk3LJ9Fo/UJj1FKf4YnAWgjam12CutVFcLMuNa21/IfokHmsA9kn3/ZXVxlJO835orReLcpBX6W+WUxBCbAD/630P72ut/yUhxPeBfxr45+7/vrsyg/8D+Nce9LPv1mh+/fXXn1mFdNNQNXXGKDcfssBw7gePsBz2STDzy88mKVvofr7LqtdwOJ4XdBdaF4FjGalD/cXP6xSn+CT4joXvmEz+fkP7WRrBjwOebeE1H3y9CyEIFrQ7jc95n30avrS/Vmu9D/zB/Y8LIc4C/zXwz2qt6wc839ZazzDqa59XA/qZQidwaJ9pI4SgqEzI+6wa9KeJzY7pVZyU4QLX4vpGC3UfdcEpTvG4cSLD+pswcXZlpUFRK7wvyYY8jdrDfwqsA//74vD/KeA68B2t9f8I/D9CiBTIeEim8JuIkwvt1Bl8Mu6/IT+v+PgpTvF58Kw7BDD9PF9+eUHS02g0/xsPePgXiy+01q8/2Xd0ilOc4hSnOMFpGHaKU5ziFKdY4tQpnOIUpzjFKZY4dQqnOMUpTnGKJU6dwilOcYpTnGKJZ2vz6SuArKzZHpslthMCva8a0sKo2n2Vz+Cz4HlnQX1WN56/LIzjguMopxu6zyQVy2mm8IRxtFB5miQl8/yZond6YjiOPjqD6Ct6Bqf46mJvmpGViv1phtbP3u7tqVN4wmj5JjmzLbHkdv+q4YSaw7Y+GxXGKU7xPODEBjR9+5nMksWz6Kk+C1ZWVvSlS5ee9tv4XKi1pigVCMOE+jACrCeFW7du8STOMisVWmssKZ7rZb4ndZ5PA2WtqGqNEA/n6HrceJ7P82ngpz/9qdZaf+wG/I3vKVy6dImf/OQnT/ttfC4czjMOpjkAZ7r+ExHQ+CS8/vrrX/pZVrXi7b05AL4jufYUqIGfFJ7EeT4t3DiKiHPDUnNtvflEHMPzfJ5PA0KInz3o8d94p/BlY56VzLKKfug+dlK2QcNbiM4bfdavAmzLKKHNs+qBTbaqVhzOczxbPnUneYp7McsM2++g4XKmG3AwywgeIGt6it9snDqFT4BSmtvDBK2NjurjFryw5IOFe553DJreQw3+/ixbKs75jvXEGSpP8WDUSrO1uBfSouKFtdYTF3d6VvC8T0s9lYKuEOL7QogfCCH+TAjxx/c999eFEL8UQvypEOJjWgpPEkIYww1gP4KyUq001Rck/p8kBe8fzDmcZ1/o5zxNfJFzOCHAu/vsPyv2pikfHM6ZZ+Wnv/grirJWD5x8mSaluf5m915/8p574fntA53i6WUKt4G/orXOhBD/ixDiG1rrX931/H+gtf6Tp/TelhDC6K2mRU3T/+SjysqaDw4jAC6tND63+M3+LKOsNNk0Z6XhPVTmr1wY3WeNRTQraz48itD6853DetvHdyw8Wz5SWSIrazxbLqc48qrmeF4AcDDLP5c28/OOnXGyOBubq6v36gPvzzKKSpGVOYOmt3QEd98LrU+5F07xm42n8ukutBZOUAL36yr8F0KIMfAfaq1/8eTe2cfxqGI2cV5xEnjFefVQY2iW10wa3g0ceg33HuW2pmczrkoanvVQh5AUFTeOYgAuDsJnyvDFeYVSH/3705yCUprtcUpR15zrhfiO9chqUndGCZOkJHCtpTi6VpCVFZaUrPunPYm7MU1KSlXzq50paaFYb3tcGIR4d9Ewt3ybYVQQetbHMrXPIuxUVIo74wQpBOd7wUMlWU/x7OGpunwhxKvAqtb6rbse/pta678uhLgG/E/A7z3g+56IHOc0LcnL+p6I6WHoBA7zrEJp/YlN46N5ziQpuXEUc2EQsl7US51igHO9kLWWwhImG3hQJpAWNbXS1EovIrdnxyk86jmcICoqpqkp8xzN83t6LGlRI+WDdairWjFJCkCQFjVaayplRM89xxi0tbb/uf6GWmmGUY7vWrSfobP9IhhGObuTjCircC2Jso2I0f1ne6YbsNL0UFqhlP5EQfqqVsyzirwy1+Dd/Z9xUizkVc19NGh61EqjtT51EM84nppTEEL0gf8W+BfvfvxEjlNr/f7DFjsehxynUpqdSUqtNGe6wccioKys2RomAOSV4nw/ZJqW3B7GdAKHC/3wnsUT25Jcusu451WNLeXHnIljSd7fn3NzFFNrRfiQiaZ3DyKKSrHactnsBPfcnC3fYRRPKSrFRufzGb7HiYNZxiguGDRd1lr+PefwSahqhSUEtiWolb7HAI/igp1xitaaq2vNewxOnJf8+NaYWVriWpLNTsAwKtibZtw8jhg0PZqeTZJXJGVNN3A+kyHanaRMEuOontS45YNw4ugepUT4aWLuRaU4nGXYtmC97RN6Nme6H7929iYpb2xP0MDFQYPr6y2kNIqBUnykR66U5oOjiJvHMUpp1js+3zrfW17vDc9GiBww7//usuKzlt2e4l48FacghLCB/xlTHtq/77m21nomhFj5Mt/fLCuXN/5xlLPS9O656IUwX1qzNMhv7kw5nOUErlzWvmuluXkckZXGcXQCZ7l/YEkjMam1JvRslNa8uz/jIMoIbIudccpay+cvbgyRUjBoemx2PG4NE0ZxwSwtOY5yskpxdbW5fO9xXpGVprabV09f0f5onpOVNXWtWWsZQ1Mr46sflmHllenBKAVnuz7theHWWnM4z7k9jImzmsMoIyoqrm+0OJrnKGWM5Tgu2ZkkBLbFattjZ5KiNRSVZmsY0XQd3juYc2lhgDa7wdJYKqW5OYyZpSUXByH9hkdeGdqNlm9z4utProGnAa01Hx7FpEXNyiIweBiUUnxwOMe1LfJKYUuB0voew1sphWNLpDC9nkppylpzd3VvkhS8tTvj5nFC07fRaLKyRgBRXjGKC66tt3hh1Xz/PK2YxAW3RwmzrOLyoMGg6VFUCt+WvLTR4me3x7yxPaXfcO4qK5rMYn+aLQOb53mJ8TcNTytT+BeA7wL/5SLa/o+BP9Ja/7vAfyWE+DpmMuo/+rLegO9YCGGi1eMoZ2+a4tmmNm0anRaXVxpkZb0sg5zYN6XBWfwnLWvSwlztk6SgEzjEeY1Gc+M44cOjGEsIQk8yjAv2xyn7k5ykqFhte/xqe0w7cGk4FpOkZBRn5JUmyksqrWg7NsN5gSCi6dmstX0+PIrYm2ZsjxXXNz59TFZrM1ob5RWbnce/JJeXNXdGKWstF601SVFz8zimVppzvYBaaUqlWW95S6eblQqlYJoV7NxKGDRd+qFHy7fZGafcGSbcOI6RQmAhiLOSo6hko+1zvh9gSUCDY0vGsTHuu5OUpm+hlOQ4MpHzNClo+w5ZWbPe9tnsBmSVyQIniQkM/uD6KndGCWmhOJrnvLTeInCs5XXwNHBSGgSYZxWbnYe/9s445TgqUFqz2vD4B/sHBI7Fdy/16C8+a8+26IUuRa24cRSRV4pZWnFxENALXSqtkUCtFZbU+LakKBVv7c6YZxW+I/Admze2xhwtJuOO5+a+caUEbZYx06JmnJRICS3PZmdiXutYJkNRWtNvuMyykqO5WdyU0pRNnxV8UQLC3/SR1afVaP47wN+57+E/Xzz3ILnOxw7fMaLwHx5G7E1TZmnFpZUGaVEvywUNz16WLZTS9EMXS8Dl1RbWwrjZAhwLlBb0G8Z5rLc95ot+hGtZbE8S4rxikhSMkoKNtk8zsPBtySQpsS2L9w/mvHymw1Ek8G2bvKxZa7vM04pCFdRKcafSNDyLg3lGWStans1xVND0HEqlyIqa5uIxxxbL6LKsNfPMEM+NFyWGx4lO6HDVklRKc2eUUFRqOde+P0uxLcla0ycpKtq+QzdwqGtFWpqG+eE0R6N5Ya3JtfUWRVWTVoq27zBNS4Zxzv48Y5YWbI0iXt68zO+/uMYbOxPGUUHoStKypt/w2B7HzLOSZiDxbI9pWjPLS97anTFJS1ZbHsEiIJDSXAdlbcTay1rh2gLLEk99cc62JKstj3lWLrOvhyErFWe7AZUyY6ZxXnE4y7jQD2gFDlKY/opnS24cx4zjku1JQuDY3BxqDmcFTd8mK2sO5wW1Aq00N0cxu7OM8/2QVS/kzjgmrxTjtKDl2xSlCQCans3+LGWeNtgams+/E7g0XZt2YJMWFZtdnwv9j8qKGr3MxE+X354tfKVnyxxLYluSTuBS1ppO4Dx08uUoyilqTeA6uAuHcPM44kc3R4SOxfcuD5bpum+byaGNTkBaVlxebbA3SRknBYFjmpdSCrSGoGWaoh3fIctrLM/GDyWVqslKBQjqWvPjWyNsS+I40PUd8qaiqBVlpXjvYL7kTbpVxgSO+Vgbnk3bd3BtSTuwmWcV/cbjN3brbZ/Dec4oKpimlSlVWALHlnQDm1FcUivFwbQgKxRbwxjfsUnLGkcKHBvyCjxH4tmSTAr6DRvPlvSbDrXS/Gp7ynGUg4A3dyd879KAvKxJypq80si85jjKeGN7wqDhc34QcG015GCaszNJafk2Hd8hLU3p4jsXe8uxTNeWCCAuKkLPe2ZIyjY6/iP1jM72AoZRvujJaN7em9MJHCZJyTt7cywpuLrWoLW4FjqhQ16bbfoorZAYcra8qrEFfHAY80YxMdefhkHoI7sajck4KgWDZoBWCqS5j7Q2AcH2NKVSmutrLVxb4NsWyWIiTWu9PFvPtnhxvUWt9GNnCjjFF8NX2ikAXOiHjJOC6xutT9yetaVAo3l3f86vd6e8sNZkb5JxOM0JXcmNowjfMaR2lhAIAW3fYaPjc64X8OudKTeOY2zbot/06AQWQljsjhOkgNC3OE4yAq9BWSqajsXWOCHOay4OGviOhS0Fh9OMvNYkecVa22Nr8f3rbR/XsggdC42phbt3NSgfdftUa1Nr/iw13hNjI4Eor3FtyfX1FhudgCiruLbewpKSOyMzipuXit1pxCguWGuZpvDV1Qa+a/P+wZw3d2dUteLVc116gc3b+xGeLSlrjS0F7+1HXFtrcWeU8P5hxLluwF/95hm2hjGVgklWcFmEeJZkmOSstV3agUM7cMjLGs+2aPkOLd/0fz44NO+l7TuUj9CjqZXmYJZhf4EJp8eJpmffM/r7W5cHZJXiKM6YT0ravkOUeXR8h37DJS1qKuXy650J07TCmUnOdUOurDb48w+OGcc5tiUoakXLd8jrkp9ujalrjSMlV9abfP9yjzvjFN+xGCUlFwYB7+7PcS0LiaLh2ZRKU9SKSsGdcUIvdOmEJnCaZyUanpvprucJz7VTmKYlVa3oN9yHRn+ubZrGn4ZB00OjeX9/jm1bbI9TNto+wzg3ZY1xwtYwIXAtrqw22eyY5mdWmsmPvFK8uNbi9iih1oq8kkzTFMuCWVqZue5RSllprqw2KCrN0axgpeXRCWz2ZilRpsjqCpAUlWKl6TPNcgLHwbMlmx2fXuiSV+pzM5CeNDcHTcNv8yiYJAV3RikazVrLoxua3YuVpsfKXWUYb63JPC0ZxTmTuDQlHAH78xyBpum7HMwyLAFRWbM7Sfj1Tsk0LShrjSUh9Cw2u4H5HVLgOaZstTvLOd9vYFuStKiQUvD+kTFSlpRstAOivCIpaoZxyfUNE6WeEBKmZcUwqumGDnlVf2Iv4WieM4zMgpxnW0tD92WhVppbQ9OjOd8LHxpZV5XiF9tjagWuJbh5GPPmjmnyFqomLzWDpkdSVgS2TVUbJ77asnhrd8J7hxG708xMJnU8rqw2saTgYJZxNCu4NYoIPZur601uHie4tmSl5eM4kvO9kKZrszVKScuKb57r0AwchvOCrKipa7VcuJym5XKy73zffJaneHbw3DqFKK+WF16t9GOJ6AYNj6trTbZGCVdWm5zrBjQ8i0lacus45mie0/BsBk2X0JVsj1MmccnBNONsL+BonrPedlG1icgPZ6YcomrNixsNxkmJJSRCCxxbU2uFRnO+Hy6iOxjGGdOkJK80lVK0XBcEhK69rIPfbzSOo5xxXNBvuJ9aK7+7ufkoKCrF/ixDaY0UgsCxH1oj9h2LKKuoak0nsAk8m7d2pkyzgp/fmfBbV/poZbKeCwOTwSWlKaPZluRCP6QduFzoBeyOU1qBSzcouTBo0PJNtLzadjmc5uxOM6ZpweXVBv3Q5f3DOe/vR1xYCbm2WHSTAgJXkhamP9MPzdkk+Sc7Bcf6KMBw7C+/1DTPyuXM/ygpOOs+2FnfGsXcGWVoNGlRsTNJF4GB4N39CKXNeHWv4RC4Ft++2GVrnHIwyXjnYM7N4xitBZtdj999YQXbkuS14mzX42dbU3y3zTSpOJ7nKK0YNH3e2ZsjgOOowHME622PSyv9paG/vtnCtSVb45gf3hzy/cuDeybSKvWbTd3/POK5dQp387o8ymV3d70TzMjqzjglcCwu9IPFdIep3zq2pO07HM5zfnhjSF7VvLDWwrYE87Tizjjm7d0ZHx5FZJXi971VuoFD4EiOZgVZZaKmOC9p+zbdhovnWLy02SJ0LHxX8oMPh+Sl4oXVJpdXGniO5Bd3Jpzr+fQCm1mmaPs25wcNBNwT1StljIJlGaoIo/BkFJ8+zSmstz2m6ac3N8E42w8OI4ZRziQtuLraZBTnFLVitWWWlaRgea5ZWbM3TVEaeg2XiysN7gxjJknBOM55c3tKNzSPv7Te4sOjmMNZztmejy0Fo6TCdyS3Rwnb45TDWUboWkzTgmGUc+MoInRtbCkQUrPZ83lpo8X2KOXN7SnTrMRzJN84a0Z56tosqSVFzdfOtJmmFZYUn0rjMGh6uLbElvKJ1MND18axBVWtaT/kvVW1CSDMRnLOatOnUib7PN8LsKTAtiS705Re6CAEfHAUIYXkhfUmah927Zx+w+Kb57u8uWu4o5JCsdn1efVch8O5ybwHTZf9SUZS1EySnLKCvVmCJczEVi906YYub+9N+UfvH5tRYq1peDa+LXntfJf1jmf6FY3TLOFZw3PrFFq+WTArlfrEC08pzY3jiLRQnO0F9BsutdIcTjOqWjOvK/ZnGcOoRGnNJC3ohx6TpORHN4/5s/ePkRJ6vo2QZqolzhS7E7N4lVc1v96ZUCvN7WHMrWFMM3BI8hLHkvzo5ogXN1p860KfV892+eX2lLd3Zvzi9pjAs1lteShtSMjWmwF705S8gnbg0FhM8tydBWmteedgxvsHZoT1tfNdWr7NLK0eqX671vYfOatSWlNUahElSg7nOYOGR7SIag9mGZYUvLDWXDQjAQS+I9meJIzjknZgs95ysa02e1Ozk5AUFbPE1Jz7DZujeUlWKTxLEhc1fa14Y3vCwSxjteVSa81Pb4+IsorvXRlwrhOwPUrYGacczzKavs0oKYiyit++4i+Xwd7cm/KLrSkNz6bfcHntfO+R/m7giS5fubbkpY32xwKXE0yTkh/eHJLkFRcHId+80OGDg5j9meS3r64wS0t8R/LG9hRLSt4/jOhHOW/vzZmmJd863+P6Zotuw+ZolvN3f7lHVtbkVU0ncLhxFKOn5gAAIABJREFUPGMY5fzla2uU2uyj1Bre2p0xTSuS3JT3Bk2Pc70QjQmqfnZrws+2JpRVTV4rOr5DrTXzvOKljTYvb7af2Bme4tHx3DoF4JFqvXml7tkzCF2LD48iZmmJFIJB06WqNVvDmKwy46pVrbnQD02EmxQINO8czrkyaHM4y5gmBYFnI6SkrGqivOYHHx4TupJRUjBNSgYNm91phiUlt4cJf/7BMV/fvIJrCyZJQaUgK2rGcU5ZKXzHYnsc89OtMYPA4VuXegSORVxUhm9Ia6Zxzs1Rwo3DmNC1yaQiLUyj+mGUGV8EzqKkM07yxZZ1zs3jiJWmZ6ad0opxUlDVNY5lcaYbmHNLC7SCN7YnlEpxpuMTujYvb7Q4mOVkZcmfvncAwGtn2mSlounbzLKKrjA/t6hqoqwiLSrqusa2HIraTCkN5znvHM7xLIufb8347qUu5/shSteLjM+MbkZZhUZzHOfcPI754DDia2faXF5pMooLbEuw+ggZ05PCNC0pavUxosRZWrI/TdmbZtRK8bWzHTxHMmg4JEVtpsBCD4Gm1jVxXvHKRos/++CYutYIYLPjE2clvxhPGMUFeVkROJKbRzEKzdYo4a3dMS9tdtjshLyw1uAokqRVyQdHMUobTq71jsc0LaiUKVM1PIvKEvRsi0HD5WiWYwnBPC050/XpBA8P2IrK6Bh7zqP1/U7xePBcO4UHIStrlNaErvnTfUeahbOiInAsfr41ZhgVnO0FrLc9+g2PP3v/mElaMM8qvn9lgBSCsjKG7lw3ZJaVCCT7M8M+mVc1k6zi2+e7RHnFrWECWtP0LVqezSQt8RyLtQYcYxzTJC35f989YqXl0mmYMUmtNaWCv/vLHYpa8YutMXvjlNuWJFeKb53vs97x2Z9m7E4y04ysTQnBcyQXB+FSyObLYlPtN12+e6nPNDWZT1EpXFviOZKf3xlRKc2vdiZcW2uxP8v47asDAtdinBbERclKw8O2BK+e6xC4kvcP5vzwwxFZaXhyjuOChu+yt+DtmcY5UaHYm2SkZcVGJ+CF9S6TpMC3JbVSvLsfoYWmVoqLgwAF2BImiWYYJez88A6DlkutFOd7DXxb8JPbE6LcjNMWlWJ3mpEWilfPdbi61vzUc0iKit2JEZ05e1cp784ooVKasw+gUvksiPKKO6MUMGW7uzecV9seaVGjlCYpFQdTQ1WR5DUvrDd57VyHrVHKq2d7/KMPj+n5LnfGCettn6NZRuhKotw48O1JSlWVxEXNNDXUFsdxhSsFSV5zFBWstQI8e4NLg5CyVuyNM4QQWNLinb05b+3OubzS4C9fW6MdOBzNcrLaZB3TtGQUF0RFze3jhFfO2A+kIKmV5r2DOUVlgplTXY0nh6/USafFR/wrJ6UiIQQXBmabcneSYkkMxUJRcXWlwY2jiO1xQsO1WW/bhK6hEigV9BsuL240uDNMmWYF80wwzyr2pinnegGl0lwdNLgziikqhdYKpY1j2pmmvHauy0pLUSmFLS1+sjXClZKbwwjHEgznJVFW8OvdKd3Q484oZXeSYktBqTVowUubLW4cx7yzN8V3HJquafSe64W8vNnGkoLtccI0LfEdi8CxWFnUxD8rqlqxN82olFoYOYuqVmyNDIdUpdRCGMcyvZNSMctKtDZb4Cdc/TujBNeS2EIwzyuEFPzo5hC00a1ueoaps0IT5yXbk5TVls8kzbm9nVCUCtsWCATjqODWccRa06Pt27x7EFHVNa+c7fD711bIKo1jQ61ge5yyM86YZYY+xJICS0he3mhyaxibHQZP0vJsxklFw7OJ83sb7ie9qvvLOAeznLSoSYuaXugQuja10ksqlWGcfyJVxafhbraQu7W8a6XJK8Xrl/rcGaWEnsX7h3OmSclxXNBrOBzMCs73Q947mHN7lPDhkbm+OqHLLCn5h+8e0vAc3jmYE2Ulw6hACEFWKkJL49gS3xakeUlWVUyTkvWmx+9eX2O97fPKZodWYCPRvL0/ZXuccxhlvLDWoFJmEa/jWDQ9i9Wmxy0Zs9b0mKQFh7OMzW7wsfO8PYwZxjnTpOTySuOe8epTfLl4bp3CCYdOWSs22j62JSlqtaS3zqv72bqhGzr85FaBFBKB4Gd3JriWacTVSpu5+dBlf5pxNM8JFkbWtQRZbraNlVZ0QxfHsnjtXIdxmvP/fSAoCkXlCI7jEqU0ldZ8cBjzykYLBOxOs0XzNKeoamxL0AkdJIKirLl1ZMYBe6HZWD6cpBy0Pc70fG4eRgzjCkfWXLjQ40wvIHAttNbUCsZxSVkrbh7FXBw0KCr1yKR1d+Nwbpq5o7jkcJ7z7Qu9JVsrQL9hShRv782J84p+w6UV2Jzr+Hi2xe1hQlrW7E9TorwiKmvWfZsbRxGzxYSNZUkGocPl1QbtwObDo5hKG6M7Tyvz+wCpNAiNbZmyyiyrmKUFriXphQ7fu9TnTDfkR7dG/OCDYzbaHr9/fY0rKw1mScXfe3OXolT0ApthyzHnUtesdwM6oUcrcOiFHud6HxnyvKr58DBGo7m80lhmm2B2BaKswrHFcnJJLvZVtOae134ehK7NpZWQstb07iqL3jw2I8QNz+Z3Xhjw41tDfvThiL1JzmGcM4pyHEviyg7TRamzKGvyynAQRXnF0VzQCm2irFwKJJkdA03DtXl5tUFW1cwzw39U1Yp3jyLW2j5XVpu8er7D3tSMTKe52U0Itc3No5jzvZBRlOO5ktA1We3V1RZpWWMJwTAucReBynFkHOta2wwp9EOPhmdzba31XHEjPes0GM+tU5illRn5xJCybXYC2r5p3Ja1YvW+KZy8Mvw9Tc9iteWamfbc4rioubTS4OXNNlII3tufYUnDZXQcFRzOCiZpyeE8I8prhNCsNHxWWg43hwkfHMwMdYID87xEArZl+HyOo4Jf7kwX26cV+7OUtKjxLIFlSRwLolzRDCS+o3Ech6xURIVCSrPM1Q89NnsBSanoBA7negGOZXYUDub5kv47rxVFVRMXFd3POVfvO9aSgM9a0EKErs1m1yfJa3oNh59vmU1YKSBwLDq2w4WVBmUNb+9HHMwjsrIm8GwC22aWlUtCQa3hbDfAdyTd0GyXn+nWbA1jY2gciZQWlqrxHImDIC8q9isNaJQW+I6i5dv86XuH/Hpvyt4kY5JWWMJkTK9fGnCmK/jpnRE3jmLuTJKFE5X4WlJVmqN5zm9fHXysjh1l1dIBvncQYQlBv+lythuw2jLspLYUy3q/EPDSRguleSxG7f7mdlbW3BklOLZEK83OJOHNnZnpZSmFqjXTtOS9/Rm+Y3EwL2h6NtOkRGCa1krVZEpTzGscS1JqzUrLYxSb2r/vOlxbb3F1tcn/9tNthC5IippxlPP2/pS4rGj4Do4Q7E5TSq3ohy7Oolf26905vi159UKHvWlGVlYgBK+d7zBNTBZmS0N/vjNO2ZmkOPuC6+stPEfSbzTwTzeenyieW6fg2nIZpZ2knkKIh9IGnCyQrbQ8zvYCJnG5aAQLLg0aNDybn9wa8X/9eo/9Sca1jQZFBaMk52CWI4UmLQrSShPlNZXWrDR9XNei1pAVaiHpqdno+TgIpplilhZIAVvDhKio8C1BXoMtNbYwJGLb44Rew+GFlSavnOnyk1sjqqrm6lqLF9ZbfPNilz9955CjKGdaVFzbbONZkr1Jyp2RGUE0VMhNylrdE/1+FvQbLq9f6jGMiiUdSF7VZkGtabKztm/x3n6GxlArDBoeDdfBtsyi2Tgx5HgrrsVY50ziAq0N+Vvbt+mGDtfX23QaLr4l2Z+amnyW1yg0g9CmVNbCOVaUlaIbSmzbxncEw3mOpGCWzfgnXlk3jLJFyXZe8f5hxIV+g59tTTicFwuOHgfHttjsWgwCj3lec6brU9aKDw4jeqGzHONtBw7jxEyhRVmFZQnGcbHsITzI8H+Z2gG7k5SGa3iHJnHBzVHM8TynKCsCz6GrNFpppDREd7aEK6tN2qFjSp6L3pYsNa5j4dqCr53pMIxzKqWIchOguJZc9GwEoWeRxYpRUvDhUcw0rXjlTJusrKlqzSD0CD0Lz7HYHiXsz3NCx0LuGAZbgZlYu7ra4NJKuNxqLmvDl5WXCqUEb+3NONcLWW2eNpifNJ5bp3CixlUr/UhNqpZvcxwJQHBx0KDhZuS1wrMlriOZZyV3Rglv7cwolBnDvLoSsHWcMC9M3TyrICuMc1hpumRlzfW1Nr+6M6VSiqxUeLZNWWq6bRfb1sRFRV7WNH2LvK5BCqy6plIWhRJ0QhvfaVAqCDybr222uXU459aoZDzP2RknbHR82r6La1k0PYfLKw2avs07+zMqVTNO9IK3SdJvfjFun37DNN+HUc6HhzFCsGSW3R6nlLVmoxNwrhcwSkqKSjFLSwTQcCVnuj4H05xJWlIoTVZrysrwTjmWIClrZkXFMCn49e6MtCgpiprDqKReRKGqNplGWlb4rkVeK2yrIrA9Gp5DjUKgkBZcXWuQFgohDZvr3/vVDlFWEWU1l1ZCzvZCAlsiLGM4LwwCNto+b+5OsYQkbXtLp+BYcqnwdjDLGEZGQ+JuaK3voVv/MmEJQa01SkNUGgfZ8Gx6oYslJZ5lOJ0OZgVH8yNmacVGx6Pj2kx8i4YjKRaUHYErcW0L0JR1Tct10FrgWIK/uDniKMoRGFU7rQ2hXVnXlAuW4cC1uLLS5Cg2QklSSJQyo6v2ondjS8WdccooKZnnij/6/nnOdMPl2X7tTJvAlRzNCywpOF6UaB+l0X+Kx4dHdgpCiFUArfXRl/d2Hi8+C/ui71jLuemqVswWpYJB08WzJe/tz0mrmrbvMM9M+v3m7pxhlKOBhmtzYRCahmVhmCsHDZfQM5M4amH8ssJQOszSkobn4tvQabpklaYdOHiWJMpKsyAXSHxHMk8rXlhv8uJGi4Npxq92piRFRVlrXtxoczQvuD2MSauKb5ztLpXivnamg2MJdsc5VVYS5TUvrj2eZaFsUUbSGoraNJijvDKRpzTTMi9ttIjzinlm2FBtKSmqmm9d6IKGH98aMo5zzvYaSAlHC7GereOYSmmKqjYLUlFGWipqDVF+wnTqMAgcDuY5eWkavFmVgtJoYbHWsOj6DtNUUKoaS0n2Zhnz1FBgrDc9XjvXoxM6bI9TlIJr6x7X1ltsDWOitCKpFKttz9BaxDn90F3ucKy3/Y+Vl4pK8eFRRK00FwdfPhV0XtVmzLRWtH2XKKixJdw6jheBjWBvmjOc58SFKSG2ApuG53Cu32BrFOMAnQVZYl4pyrpmnhZsjzOEgCRfBDuVQitoeJK2J6k1tAMX15Y0PYcLg8CIGdmSeVbTCSRneyHfutBdsAFX3Dg2DAPTpCQrK3Ym2dIpAHiOxcubHRpezM+3JthCEOUVs6w85Uh6gvhEpyBMSPmfAf8ORt9ACCEq4L/RWv+NL/KLhRB/DLwO/Exr/e/d9fjXgf8eEMC/pbV+44v8ns+CE7nApKypFaw0PTzbQiD44DDi/f05r1/uM01y3t6L2J8V2NIY/YZnYS3oJiw0aVnxgxvHhI7FJCoRQlOrmqKCYVwQ5YKe0iSFopdWrLRcXlpvktaKoqwpK0VSKt7Zn9Nvemx2fC71Q/7ig6PFMldNJ6xJiopmYCaOxmnJreOEm8cRZ7uGI+dct8EkroiLCikwy1+P4azWWh5qoQp2csNudnxuHEXY0hiKcVLQ9hwSWePagpbn4TkWWaX4+daY46ggLo36XNOV7GnF4SRnFhe8drHL0Swnryui0kxtGZqGmr1Zznob1ls+6y2P/XnOrWFCVRlNgNWWjbAke9OMWV4xaPrYAmoNrrCY5gXXN1sMmg7b4wzXkkR1hSMFaV4zSkp2JimrLY+GKzmYmY3ww3n+iYt9SWEoPODRaUK+CEqlzeeelKRljW8LhNBcWmmQlWa0VrMw6Nps0W+PEy72fY4is4S2O03J8opKK9JcUWpNXZtms+tI8spsfteLuQylNFfOtMz1WZjrVAEX+qbvtjtJ+YubI8ZJjm1JamXez8WVJn/5+hrvHcz5+ZYZ4AgW02t3l9jSomaaVPiOxWwh02o9I6y1XxV8Wqbw14C/BHxXa30TQAhxBfhbQoi/prX+48/zS4UQ3waaWuvfE0L8LSHEd7XWP148/Z8D/zKggP8O+Kuf53c8DGWtEHy81nu3XOD5nuE0uj1MUFoxinPe3Z8hhUlpXznTJikU07TAsyWD0EULwSwtWW8J9iaavDB6Am3fJXAkpYJKGcMktEYjqSqFJ833jdOcJK/oN10saeG7FgpBqTQWsDVKeO8w4ke3xoSepOXbvHauy5l+yKDhAIKkrLCk5ic3R6RnDdXERsfnu5d7/Gp7SlIYXeONzkdbvVtDM6663n50Sm0z1WQEdO4uRfmOhWNZFLViZ5JwcdDgTC9glpV4liQpzVTVr7Zn3B4mHM4y8rrG6wa4tku5MGQpwgjsSEGVm89KaEGtFY4UZGXNLK2pypRXz3UJnYKVhsthlCO0Ji8UXluwN0tBmAjeDxxeXm1ye5Rgx/DG9oyjqOCFtRaDpsvXmx2kFNw4jhBasdb2ubgog3RDI+TzMFr1Exid4sJMznzJ9A1ZWXOuF/Lu3oyirtkeG4K6g2lKYNustD36DYcoL/nGuS53hhFeXlPUijd35qy1PXxbUBQVUWEcimVL0rxCK4VtCWxp+nIdXzJd9FB8y2KtFTCKc7OBnmccRTllVXGh67M3ydidpMzzElcKDqc5kyTn966tgYDvXOxxoR/y/mGE0ppbw4RLA9NbcCyJa0vUosfUdG0C53RH4Unj0077XwX+ca318ckDWusbQoh/Bfj7wOdyCsBvAf9g8e8/AX4bOHEKPa31HQAhRPez/NBJYhbMVlveA0tHUV5x6zgG4MrqRyOF47jgw6OIpDAqa2mpGDQ9ZmnFOC6YpEZ4xLGNMT7XC7ClYLPrczDLKauaX+/OGDRcylqauugsJylL0NAJJFKKZbQrhOHXWWt7oAW3RwlJVvJ+XuMOjQZBt+HjuxZ1VZOVFj+7NSYtK7Qw/ZKWbyOAcZzTcm3+ya9t8H+/dfD/t/emMZZcaXrec2KPuHHXvDf3ylpIVpHFpTfOZkyPp2dasDwGJBkeATP6I1mGW+MNFmwY3mHAgH4YsLxBBuQGBMiW3e4xbGhsA8ZYGrVmpjXqcYPd7Cab7G6SVWRVZVZVrnePPeL4x4m8zNpY1Uxm3lriARJZdSsz76kvI+Kc853ve1+u7k240Q/JJFxeqbPcdHBMg6WGyzBMZ4fvoHZGw3I1dhAkjxTjopD84MaAIMlZaTl32ITmhapwilM1YS7WbSZxxrWDKVd2pjRcEwqVg76+P2EQZLQ8g1GQ0bRzbMNAEzm6AXlWoIuCJM8xNEHbNymk6gPRRE6e50gDvnd9n4ZjkWQ5WZqTFBJNz9keRYyjnLqj0/KUd7RnKV9ileJT7njP93xeXWsSlQ56u5OY/iRFIunUlGyDZWisNOUDrUUP0TXBhd7J5793xzG3hxGGLpgkGWFaMAlT6qUfSLtm0/KUZIWmCYIk5Vy3xg9uDAjjnIEA01RudoMgJS0kWaFW7oaQSFPD0nVWGiYHQYFhaLzc9hhGGVIW7Ewj0kwyTXLSoqBf2nj+L9+9QbtmcWV3QppJdK3A1GOGQUzHt7m82pxd+75tIIQgSDLe3hoyClMuLtXJCiXbrqrQdNxjlvJW/Ow8LOLm0QnhECnlrhDiOEm+FnC1/PMQePnIvx1dwj/yvjHNi1nHZ5Lf6Wl8SJBkswfiNM5nk8KtYYQuBJMoY63l0KlZXNufcqM/JSsPThdqNnvjiFujmDevD7i8qkpUr+xM2TyYEiYZe0VBq2bRdC2CpKCQOXGeM44lnqERaAJDk1im0gHamyY4uk6eS+ICirjA1AvSXBImylMXIdkdJyBUauBit85SR8lFJJlaWX/3o31uHAR4ls6l5SbvbY8xSgG0Q1ZbDqauVtlRpjwPdE2VVA6D9A6J60/i9jDkve0Rhqa+/0K3hijLPb93rQ9SMo0yNATb4xhTn2AINVFqGoSpJEpyhNBoOAaOoXOm4zFOUsZxStMSFKgJaxKrMlUpRCmiZ2JqAomFqStTnHGUkxYp0zgnK6UPwzTnIIC8EFiGYLFhqwkqSrg9jBhHKXkOKw2HtmcSZwUCwTBUq/yGa5IX6nD6sKLocEIoCsn2WKWTlhvOqRwoH2VvEvPDG31AVaaZmmDBs5iUhjzDIKVVU+KLwyDHNg3SouDFlRaygB/dHrE7VmJ2cZKpg/68QMYFmZWrcmvLxDN1dsYpDddC1wSpBM/UGMeSrYMpTcdm0TfZD3LCNGMQZHywM+FM20FogoanUzd1BnHG7iThh9eH/NzZCb5jsl9ahypRyIzdcYyuaXz/Wp+1jqdKfWsmdddk4QRMoY5rt/m087BJ4ZOWj4+2tLw/Q+BQDasBDI7821FR0/s6ngghvgZ8DWBjYwNQjUK6JsgL+cDux45nEcQ5QkCYZHywk7DcdPFtnau7E3IpubIz4fp+QI4yptGFYLXlUkjJdz/KyIuIMM159+aItmdxbsHl3VtD9qcxAo2llst628CzdTb3lQvVNMkxhGC946JJiWsrc5c4galMAFU2qCkjK0wNhAb9KENHYmgSUwfXMlhsufzZl5cQQuP6vjo/uHEwpR8kPN+rcWGxwaVln/W2d0c/glHaZU7inEkccHHZx9A0Wq7JatN55IqkrUFEXsAkSfmFI+mjWwN1WJtkknGccHMQEaQZPd/GNARnWh7dus31/pS6o1OzDSwNLi03EJrg+v4ETYMghYajM4lzdcYDZLkkSFSvQc02ibIM29BJCw3XAknBWtOmH6pcvmMI5dUMNF1VM//e7RGDSJ0bnO/67E9iRknG+7tjarbJJM4IkxzTUBU3ETCYpvSnCe0jqaB+kLA3Vpe+WVpmnib7k4SWZ7E3iRGapGabbCx4LLfU7zAqvSTiNGeaqEPvL57pUHd1zvU8bo4islw5rh0ECUWh0qm6ARJBlhdMo4RhCJaAIQLf0rkdp4zDRF2fZX+JY+j0aoIw1Ugl+JaKR7duc3ahxoJv86dX9nj31pSdccSb1wd86dzHooOaEDRd1QzqOzptzywPLpUw42mKDlZ8zMMmhc8JIUb3eV0Axykg/g7w14D/Dfgq8HeP/NuBEGIdNSHc772RUn4d+DrA66+/LoGZGmeU5dQfkIPMpSTK8llNtW3o7IyUsXiU5qrbNslZrDu4lipD7fkONUvnwz1VkSJQukmLvkVSQN22ONN2iVP1c5M0x3QNNMAyVCdzkYPh6MpvwNaZxhnTJEcXYOo6UhO4hk4ucyzDmJVnSqlW9A1Hib3ZhiDO1KHra2sN9kqjl9uDGM1QN+zllRaaZzGOUuypjiFCeg37Du2jOMt568aAq3tTer7DhV7tkTuc667Bha6PrnNHv8OZtsfeJKHpGAwjVVI4CjOVLkMQpkoOQ62uNZabDkGU4dgG4yAFTZDmAMr3F9Rh9iBMmMZK12dcCtipvg/1+zJ0vRR6K1jwXRZ8ySTOWGq4pTSJxYf7AQfTBNfU2Oi41BwLgUQXglGYM4xSDE3jvZ0xhq7x+fUmFxfUmiVMc45qpx7tRZhHl227pmr6L680ifOcW/2Aumuw5pls9gOu7E2hgGmqRBIzKXl/d0w7MBhMMzQNkKhFSZrPrDRdW6Uj01wjzwvyvKAwDUxNKK2qQUKYKKMjx1ITZ1pIHMPANnN8XafmWnxuo8Nay0WgKrQ0KbhxEKMJtVNfabp8sDNhHCbcHiWYuuCV9QZLDRffNtBLm9qnqYP5SeMTJwUp5Ym0Ekopvy+EiIQQ3wZ+AFwXQvzHUsq/gap2+t3yS/+Nh/2sQko+2BmX+eJPFh0bRxlppjSD0lwZqfiOwUd7U1xTJy8K2i2XMM0ZRTlxmuOZBtf7AVf2Jlw7mKBrgs+faXMwjdk9CLFNtdppeibnHJe1tseb1/tc3Q+U9rxrYtsa0zgnNzXVq6Br2IaBpKAo69rVOk1DCIFnGjRrOo4lqdsGv/5Sj91xwiBQEsj9acKtQchPbg35YEeJv9VM5R39vet9ikIqVdEwZXM/oFO3+KULC6y1XDxL59Yw4srOhO1hjBCw0nr01e7ZTo26o5rXju4u7FJvSdPg5ihAE4JhGHN1d8z5rs/mQPkfFEXBzWFAIVUjVNs1eXtryN5YCeTJQj2gmo460HxhpcE7W0P60wTIyXOdIMtJsgINyIuMAkHNFtR01WfScE2e73lYpkbNMgkSyWY/oCh0hNAwNVXlomvqQFggabmGqnKRkt2xch/ThNKWOkrdMXl+0Ucijy1d8bOQZMp/YzBVO8sgzbi6O0GgVHWf79V4a2vAR7tT0izH0CHNBdMkZW8UE2U55zo+5xZqJGnBjb5GlmtIAUWhtJXqjsHuOCHICnShGigbtip6sMpSUyFBUGDqyqvZtXVVTGHreIaOrQu++2Ef19K4lOUstxx6dbM8SFZ+CwI4CDKCWDW+CTQ8S/+ZSsgrTo65neIcLUMt+Rvl62+hKp4eicP8e5goZ7H7XVhBkrE/SXBMVd0gkVxcamEaGmleEKc5SVHw2nqbF5Z83t8e88OtITf6IS3Pple3eHtryDubI2xTo+FavLza4PJqg7e3hizWbXQdDKGas/7p1T5ZqTk/zQoMKclyKAxB3TGJkkw9VFElqUmeomsaOkrGuBASQzNouvDFjbaq788LLEPQcHV+fEu5iPWnCVmRc2mpDkLQrlmEqcrny0Ly4d4Uz1Y55f40oeOrRqw4K9hzTRYbSqJhvf3oNfWupd/X+WuaqBLMj3anSNTB+vY4QWwNWaiZtFyd71+bggDLUOm1pbrNWtvDM3SSVCIL1X2uSUGQSKIs5Yzjcq7jkecFkyglk8pcaBConVEqBYauzhx8WyfTeSUgAAAgAElEQVSTzOTKN2oOdUfnhpQ0bINzPU8VGgh14N/xdFVaW+5k1toOH+4FIOCdrRFLDYdr+1OeX6zfE4PT5NDMaBimTONM6SwlMSAIkhzX0rm6N+XD3Sl5UTCMcxZ9i4KCOJNIQy1uOqXFapjk5c/KCZKUQZARJXnZlMaRiUDHtkxlJmRq6DpkOYRpgaYVdGq22m1FOVuDiI2Oyx9/sEfN0NlH8PJqg7SQLLc8fFun7hr80U932OwH1B0TTRdoQhWIXNmRLDedU0/HVdzLE3+0f1jDbJvaA88SNvshcVogBFxeadxxOHhrEHJ7qKo0BmGCoWu4loFvGdhtjfW2UgOtWQaGoczM06wgKu0xoyTne9cOSHKpmrXSggXP4GCiM45SJnGGqWss+jZNz+JMp0YQp8SZ0qu/NVKNcLqyKGO5obpRERIKlSN+sx+wPYwpioJe3eLiUkOpjwqlkbTcdPnFC112JhF/+sEet8cxZ9oul5YahKnyW7ZMnYNpwu1hSCElzy/5/PIL3U+UYcjygpsD1cS02nI/sfqmV7fpBwn9IGVnFHJ7GFK3lSyybRrEeUiYFhRFwbmVGo6t03YtfnjjgDjL8SyBa1vYuqbkzQtJkqtu2LUFj81BNCsvNTWNc50apqGTZjnDKMO3NKQUREle7r5UWatvaTjljvD6foiuq51W3TFVVVLDIZeQFQUvrzZpuzYIye2Bkm1eb89fZuFQdNC1dPbGMVGaYRlKojtMM8ah6tB+Za1Jy1UmUUIIPtpTFV6aEFimxnNLHks1m7c3h7RrFitNwdZAde7nmTrQ90zlKGeVKrQHU9WtbOoapq7NvCh8S0cXEluHa/0QXWjc2J+iCY2hofH62RaNciy/eGGBaazKpX9wY8DBNOaV1SbnOh6FlOxOYixD/d4r5s8TPykYuuDSch1TFw88LDV1jThVtddHv2QUpQzDjFxKTE3DswyKQrLSUlaGmhBsdDz2pwkvLtexDQ3H0nmhVyfOcjQh+dZPtxkGCVEqKYqcy2sd/szlFVreLm/eGDIO1WFegeDiko8uNN69OSQvCtZaDpeWfD48mOKZOm3XpuEZJOUEluQFm8OQMCmYxCmTKMPSBf0wVXpGIuVz621Wmi7nuh5hmtOp2eQFNB0LUxdcXGrx3GJNnYvsHlZUwfmuql4ZBimWcX9byYNpMitZdS39EyuUbEPn+V6dzf2AN64dUEjwLI0vbLR4Za1Jf5rSdi1uDUPSosCWOpuDgLc3R0gpafsWXd+eGatM4oQgVSvYpabD+V6Nd7eGmLqGa+uc79bQS3P6JCsYFcrRa8G3Wai5ZEXGNFEqsZO4oO1Z+LbSYHppSWlG+bbBuV6NaaT6J3Rd8CuXekgp0TSNoigeC1N5y1CLk0mcYZQ590JKLi753BxGTKIJu5OI5YbDl59fYK3tEWUF/9ebm4RpxiTOObvg0vMdPtoL2Zsm+JZOlGastz2CJEcWkkGUoQmVsoySjIMgQhNq12mZSn1W1wSOobHcUOXY+1Nl2Vm3BJZpstpy8WyDQgo+3J1yvldjteXQqdlc2ZkwDA/QhCDIVEnw3iTFMTT0UucL1GIkygpqln4sSZaKT8cTPynAww+lznY8xnGGd9dFpgvBOEqJM+VpsNx0EAJ2RqpEbrWlJLdNTWAZOpdXmzimRpJJTF3wk9tDPMtgZxTPDkCnYcLVPUmaCxqORZQq05mao3Ky5xZt2r6hrCKnKa6lEScFYVltc3G1h176Cry3PcE2DHQtY7VR5yc7U/phytWdCV842+bllRaepeE7Bo6psdpymaw0aHsRyy2H1abD3jTlzRsDfvm5rtK30XVMTRnO741j9ibJTL/oblxLn02i7iPke11L57UzLb5/o0+SQsPTWWt7XNsP+NK5Fv0w4eqOQadm41oakzBlFKbYlsaS7/DqWoM3rg1UR7RlKaeuSQoIVhs22wOL7UnEzjjCMgQtxyIrCgZhghCSM22PhmPxwmKNcZgyjUN2J6pSaRgmLDVdnuvW+I1XVwmTnLe2hryzNcQxdDYWasqTwTWRUnJ5pcE0ye6bzoiznJuDCFMX6lD1hB5cQaLKNRuOSbtm0a5ZWKOInZGSw94exUzjjJvDkA+2J4RpBtTZWBB8uDdFNzRWmg5RVhAlBW98dIBn6PimTpypQ+YwzalZJroBvmuqswRD58c3h+QS4lzJmddcE98xQELXtxBCQ+gaSZ7iWRoLvs3agkfLs1hqWBSImWzGSyvqqN5dq/PhntrlLtZs4lSyN4kQQmOl5ZLmSjTyg7LPoeWZnOmcvFxIxZ08FZPCw9A0cd9u1JqtTHOyvCDJJJsHAY6hz4xR9iZKAbMA2p56AIWJqgjaGiQ0XYsXl+vEaY6ugW8ZpHlBmGTsTGI6NbUyNUo9o+sHAQ1X51y7Rpqq3gFdEzQc1WORFZI//PE2Ly43lfl8KTr22nqLaZQhdia4loZhCCTKyW295RFnBT/aGinN/YUaP3++Q9uzeGtzwKSUW9idxGy0PZbrDghKKWUlLS4lM0noo9Qdk4tLKp/+qNUgK02XX7nY48c3xyw1LMI44yDIyArJ5ZU6rqFE2M51PFxT59YooB9kSCl5fydgse6QZAU9z2KS5MRpRj8Ax3LwHAM3NBjHGQeTlCxTHtiubZBnBYaus962MXQNTdMwNJhGGVMyGq6JLgSepRqnRmFaVroIVlouZ7veTK5DCPGJ1Vi743gW14Zrnpguz1Y/VEZFYUbdUam4pYZD0zX506v7TOMM29BIM5Uu+nB3SrfmsD9VNrGTKEcIQcMx8W2TgyBhHMYkUgk9RplkY6FGx0sZx8p5MEoLNgcB6y2Ha/shjiHIpFQpKF0nynOmqcS3YaVpk+cFjqGx0vJoexZnFzzOLtQYBAlJrnZoeaHSo7qmihHCJKdXtxmGKW65qAqTnFvDSLm5ZepavJ/nScXJ80xMCocMgoRbwwjfNmYrkPWOxz/5YA9D0ziYJtimQNNURUatTKks1CxuHASMw4y6o3N7qETYlC4SdOs2NUt1KDddk3e2hniWTs3SudDzSbKCH98acTCNubKj8VzX58sXu+SFpOtbfLgXqC7kUgtpGKkyTNsQDMOM7149wDJ0luourqGz0fVYbDg8v1hDoBFnBeMoZRxlLDUcHFNVi5zv1hgE6WyH9N7OBCHguZ6PoasUgCbU4e6DpAQeNhkkWcH+NMazVCnt9YOA/jSlW1dGKbvTBCHhYJLgWDovrjSJ0gzPMnh/e0LbcxhHAVFeMBlHLNQs1dTm6DRrFlf3pqRFgS7UA3FnoB5UQZLT8kwWGx6+nRJlkp5vURSw0fHY0iL605SlhuTmKJ7tes52Pd7bmZQOYxHnuj6vrTfvOFvZHkUMgpTFun1Hj8IhNcugP03RNLBPsHTSKR/SpqF6cJKs4O2tIbujiEJKkkzimEIVOpTyH4Mg4UbpFNh0TdqewUJNdZZHaYaBWrzsjGPSQrLVD7jQ9RmWjoGGplKsQSqpeyauodHxTSxNYxSmjELVMPjSUoPPn2mw2gjph6r5sShgEKZsXdnl0nKDlaZLlBa8e1MVaNQsHd82qDuq89o2VQFFXmpoeZaOoWustV0mkdIDqzh9nqlJYW+SkOXKInGxkc8cstZbKr20UkpCXFqqMwxTru0H/PT2mPW2MpsXCLbHEctNFzPQiJOMUZQRJQUdT+MvfnGdgyBhf5IwTXLqtkndVWmQzX5AnCufhTNdF0NXB63jKOGFJdVMtT9NWG44rLc9ojTng70Jcaq6nHMp6fg2F5d8Lq80qdkmRSFwDEHN0lioqXxszdZnu6K2Z3FpuY6uMZO3kFKVY8ZlN/RS/XhduZv9gGmcI0SCt1xXZji2wa1ByELNZqlh8+HeFNdSh5TDMCHNJZ5lcq7n49kaYZKx2Y8403FYaXp4js7NfohE0PIsXlj01ZmHgLprk0UJjoAFz+aV9RbrHZuPdgP2SnntQZDy2lqDosj5aLdgHOfoQomzXdsPWW06bI8ifMdkwbc4uknKCzkzZ9oeR/edFNo1C8/W0YX4xIP647LedmnXLBxDlSrfGgZc3w9IcpX6Obvg8cKiX6bH0lIuIkNKwfOLNTq+xVY/RNdBzwS//MICH+2FNKflfRCmeJbaeeW5JEhSJpHaCavdr5IXeXG5SZrD7eGUFNWjcHbB4+Jyg5ptcmsY0nAMsgJGYYIuVOn13jgmyQuyXPLBtQndus1z3Rrdhk3bs5QmlanzylqTpmvOKgc7NevEtaMqHswzNSm0PLO0LtRnlUpBnHO+VyNIlINUlOY4ps4gTJWCZKJSOw3X4IPdMQ3H4NYw5nNnWvSWfK7sTVXONlXqmr26MzO12ZtG+K5Bt2ZxpuPRbThc7NX4wpkFNg+mBIlqYusPI1ZbLucXaniOwZmWxyjOiLKc0MtYbngsNiyWmy5rZcPYzjjiIBDIQp0/ZLlkteXSPnIwujuJZ6mw5aajqlcmER/tqwnBK9Ndq61P7x1saBqgusQF6kHmmjovLdXZncSlJHmd3XFCUUgWmw5xecg4jhKiNGe55bLUdDA0jZWmiy7kLG/+0orPFzYWWG7a/H9XD5QzlyEI01wpe2Y5Sa4ezpkscE29NCaKOJhmjJOccwsuo1DVxedFQZCqSXGrFJFTDzl/1jzlO8pa85PSQocLipNECIF/ZAfXcJSzm9B0XlttcL7nlw18GosNh89r6iyh7ph06zYrLRfb0Pjf39jEsXSGQcoLi3U0XbDWdPn9d29jGirNlqQZQawEB21Dp5AxaaphCA1NCC70PII0o+k6FLLglbUGTc/i2n5ArTxY9mwdu9B5brHG9jBW8htRhlnKhSSZUmE9LFhwLZ2zCz+7LezTzrztOp+pSaHr2yzUrDsOBhcbNllRME0yBtOE3XHMlzZaZVexhjQAJO2aSWNkMJimKmVQSM50avzqxUVMfY+WazKNc871VF7/5jDE0HSaro5paCw3PUDSq7u8ut5gtWXz5maf799QPQ2LdRvHEjRci3e3R/R8m+eXfFq2xXrHVRo2ec5Sw+HdmyN2RjGTJGO57tDyVJpgo+PSPDIpHC0h9UoRPbVLyOlP1SrxuGek622XRindbegahq7hdQyu7U/RNY1cSmxT1agXUmLogm5dmRPd7EdYhkbPt3EsA9vQeGmlQcs1afk224OITt3i5893yAvJb7xqs9FxeePaAXvjhE7Npudb7I1jPtidsN5yWWm61CydzUFIP0jwbZOskJi6zijIGIcpyw11lhMmGW9vDrk9iHhuMeLltSZrLZfz3do9ks6PA+2axVcvL5HmOQ3XYmsQcjBJMA3BxcU6C76tmvGEQErJqBS8a3kWNwcBH+1NuDmIVLrMUNVwSVawM05wbQPb1CkKiSbAs9VK3tA1XlxulKlRgyhVO8GvXl7ixkHIcsshLS1Mm65FISVf2GizN0kIYiUbcqHr89bmgBsHAUGcsTuO6NXnX+pbcX+eqUkBuKdSxDFV3j8vCn58S8n5dn2LCz2fr1zsKblnTVVSdH2bf/L+Hp5lYJnqgfHyWhNdF7x5rc84SvFMnfM9n36YcGVbmcX0fBuJJIgKCiTb45hxmDIMcsJU1X1bhsrrh0lGnoMuNK7sjNG0kA8PpnzpbIfdsbL+3JvE1GyDZcfhxaU6mZQ0HPOOCQHUJGjqGoYm1GqukDjluC+t+DQc89jbdE0T9y3bzMqcjCydtyxdn1U5GZrgJ7fGGIZGIeErLy6iC+W6pglBr2HzYt5AFuoc6I9+uoNj6Gi64PWNDp6t8/bmCMfQKSi4PQyQEiZJQcMzCZOC1YbNh7s6Ldek7ZncKntRDF1Qdw1GUcZiw2V/moCQM0FBUxcs1h2u7k3ZHcdcWqrTfYwaqlxLx0XtUsIkLx/8CUmW06s7rDRVc9rNYUgQ5+xNkpkQYtd3yEtFSF3TuLjc4PYgRNc0rmcFDdek5qjdYy7B8lT10iBMWGq5NByTXKYs1R1+uj1RyroSlpoOvYbNYJqy3HRouhY1y2ASq7Mjy9C4uOSjCcFWP2QUZry6zgOtcSvmyzM3KTyItbbHzWFUyl2UN46u4aC8cAWqG/kLGy1MXXCuq0o4dU2wULMwDZ1bo5A/ePc2Ky2PpmtSdw2yomB7FCnXtFFMzTKYxqoaRxYFi75Flhfomvr5DVfn8kqdcZxjarA7UbIG+5OYJFMPTd82ON/1aNeU8NgwSEnyQq3y7jofOFp1pZX6UHkhT3wVvN522Z8k6JqSF7F0jbNdD1PXCJKMlmtwaclnuelyaVnpDBWFJEpzbg5C4vIAO0hyov0AzzKo2QY/2R7jGCafP9NmdxLy09sTkiwnL5uqNCHQNIGtGfzSc13Odmo0XYMfbQ0Zhik128QzTX7hvMfmQDm1DcKUW6OIQZAQpwXTKOOdLSW7leQ5X7m0dKKx+rQs+CZXdpTk+82BEmREqrOzm4OQjq/STRsdF4Hk9ihmqWGXdpmqr+fllSY3+lNqto4mGliaYH+aUIiCaajsNqNU+WePkFxqqFTjOzeHHEwTDJ2Ze9raqjqTS3OlY5nkBWZelmTbJo6pdo6+o7M1CHBNnaZXid49blSTQolnGXz+TJtReKeM9ME0YRRmHAQx++MEIdQhm8qlq/LEW8OIW8NQ2WjqGme7Got1h5uDiDQrWPRtxlFG0zVYabosNW02DyIuLjcYRAk7Q9UvsNRweXmlxYWej5SSzX7Id67soQnBWlutAJNMcq7r8UJZKjqNM64fBEiUW9bKQ84HhFCrZfjYae6zniCiNGd3rHo3lLOZPktl5YVU1py6zsaCdYfEuaYJdicx+5OEvYnqYLZNjU7NxrN0XFNH1+DKzhgE7IxD3r89ISvUQbwuBHqpV2RqgiSThFlOt27zZ15e5vYwIsmV4GHLs9go89nX9qf4tklaFNQdA9PQcCyNKCloOo/vgWfdNlnvuOyNddJCVSkdHporTxF1HQ6DlDSHjm+zN4npT1POLLilQrBBp2Yq3+2xcqpzLBOQbBOyO02Vz7mlc36hRj9ISfKc/UlMv6xsC1KlKbY1CAiTgvWOQ9OxlCS5iHlxuY6ha1xebdL1ba4fBBSFMo46p3mVGupjRjUpHKFZmpQcxStLGaVUu4Ki9CTOi4Jr+yFXd6d4ls5GxwMpyzQNmIbOz51fQKIevLcHEdNY4popF3o+57oawyAlztp8L+sTZQWG9vGWWgjBmY6HbS7y7taI3XHMSysNenX7jptICFXPfZhDb3nWI2nzHHWaO9et3XGgeVw2+yGjsnqr6RrkRcaZBfcOpVa41ywjywt2ykl2GCYseDbjJONXLvawDLXD+NHmiCjLabkWay2PSaSkM+JcNTsleUHdNhiEKW9tDmm5BkmW87kz7Qf2HnRqFkGSY5eKtJom+MqlXmnY9PimOAxd4/lFn/V2gW2oFF0h5ezsZrmh5LSLtmSp4fDt93cJE2VytNH18G2DnVHE9ihGCEndtRjHOUtNG9fUGQYxu9sREouGq/wN6q7J+9tj1tou/SBho6MUgqVUixKALFOyIffj0M50u6zwOgkqv4TjUU0KD+GwgWul6TAMU4Ik50zHI0xV6eMkVnLEr6436XgWTdckLyTv76gH7lLDwbMNtkcx26Ng9hCvOyZ1R8kG3DgIKWRBEGf8w3e3ubRc58UypdKwDQ6mCRJJmOb3rKo8S9WhR6kSihvH6SNNCtM44/C+PRRZ+6ywDVX+2Q9ibFP5F7ywWJ/tFp7r+Uzi7A6/B1BVVI6h063b6jA8SLnQq7EzinhxuVEaxxtMYgPfNbm0VGel6eLZOllW8NbWCEMX/OT2iLpjoQt4b2fCettjtRXf0Z18exixN4lpeSbrbY+XVu4ci2MaOObjf3vYhn5HJZSGuKMLOMsLkrxgsWGzsVCjVfaBHMqeD0oZk91xTNuzWajZ2IbGctPm+v6U5xZ9NAHv70x4b3vCUsPmg50JH+0HNFxVVffBzpSub1OzDVqexUrTpetb9IOUmq3fsxPtlX0VhqZVu4THkMf/qn8M2BlH7E0S9icx62131rBkGRqrTYcCiJKCgUhnjWNrpYx3zTaQUvL59RZ128Q2tDse7stNhxdX6twcKKmCJA8ZRSnP9fyZDIFj6kqKI7+36xhgre2SS/WEb7mPlu5ouiajSHUStz9jfZ/1tjIleqloKB0m17yjEsq19PtOXLahq8al2ynnF2rcGkXsT5QbmmVMudBVOjq9us16253Fem8S0/MdtkcJ7+9MuG1E/Py5DtM4YxKlaBLljVG/My0oJfSnKWst+VRq7BSFnElG1Gx1ViVRZzxb/VCpkvo2t0cRDddkHKeEcUacKQG+L260Zzay4zAjSNSZ1ihKOdupAZJWKX8RJDmrLZ9X15uz93+Q4qkQgoVHdPqrOH2qSeERiFK1ih+FGVMvZ3+q5C8uLtW5caCM7z/YmbDcdMhzOesbWPAtbEPjyq7qSXBMbdbNeYgQSv/fEILNg5Aoy3ne9xlHGZ2ahWsZbCy4ZLl8YPrDMrR75J0fhqGrjueTQJTiZuNSCqLuPPpl1qlZXF5tcuMg4MXlOuMwxTYNojRH08Q9de3vb4+Vz3Cez9IYXd8hLyS2aZAVkndujzjTvVNDp+tb7E5i2p71VE4IoCrA0kx5L2z2AyaRcmXbGcVl6WrM+W4N29S4sjNFtzXVd2AZ3OgHPL+0yL/w2ir7k5hrBwFRltN0DV5ebbLZD2fXT5ZLbFPwwmLVc3AanHQfw6lPCqWV5l8t//rfSSm/cde//yEq3SyB/1xK+a3THeG9rLYcpJQIQemEpsJmGRotT1k5Hto4OpbGMFAPw0M3tyQrMDSNrn9/ga/nej5Xdif83PkO26OIXt2apXNU81eTQspZTn4YpkgpHwsFT1CHx4MgwbOM2Q5Ajbtxx7gflaZr0lxTK85heK8l5lGGoZL36AcxXzjTJi8E622XM22PWyMlv7FxH7+IxYYzy28/rViGxkrLYfMgoOsrqYs4y5kmGZpQ1zUoFWFVNyFYbzv0pxnduo1jqgKB5aZLzTb43Hpr1nX8Svn7+eGNAQs1i1rZ51Dx5DOPncI/kFJ+XQhhAn8KfOM+X/PrUsrslMf1QDzL4IWlunLcktxR9rng27iWzsUlHyEEjqmzZ8UEcc5iw8bSNeqOQZIXSlKhUJPL9f2AzUHIYsPmQtdnoWaTZpILPZ/nF/07NId0TaCXx7LDMOX6fgCoh/E8t+F7E9UzMY2Uvr8Q8NJKY5YqOjruT8v9Dv8PYyiE4EzbZeRmnOk46LrgfK/G2QWPjm/z6y/2eHW1QVoUdJ6BdEWU5tw4CNDLHZWuCbq+TcezuDWKmMZK5rpdyo8cToqmrvHCYp00L3h1vUlRqMPq26MIQ1PaSg/K/YdpzjhW8uufZsclS+fB40itVHy2nPqkIKX8qPxjVn7cTQH8gRDiNvCvSykPTmtsD0MIoUxBxkpg7XA1f7ctY9e34YgS9blujaKQXN2bECYFLc9ksx+yU6ptNh2TxYaSoTA08Ym2hFJ+fK5wH2HTU2VnFCvRu3Eyk99Q4zu5G3wYpNzoB5i6xnO9Ghd6PkGaq5THQcA4yrg5iKjZqst67a6dWVFIDoJk5n39NHEwTYhSdbY0jtLZTlLTlMQ3qLLmoqySO4plaLOFiKYJdoYxB6UHuGM8uJ+g6ZrULAPT+OTfeZqrwgzf/ng3meUFV3anpHnBett95J1vVV10sszzTOF3gP/zPq//ppTyQAjxl4D/BPh37v6CMgX1NYCNjY0THeTd3ByEDIIUIeCFJf+RNXCSvCBM1A0bpTm+o5Qqa44xS688SgVQq5QiLkpd+3nScJVa6AtLPr6jmstOuiluFKVIqdRZDw/sG/rHB/8Amqa6qO/H9jhib6weds8fCu09JdQdVamma+KB/tGP+v89ulP9pAf+uYUaoyi9rzT9Ua4fBARxjqbBS8vK/TAqRRkBRmH22KRDn3VObFIQQiwD37zr5dtSyt8SQvwC8BvAX7j7+47sDP4+8Ffu97OllF8Hvg7w+uuvz3m9/Gg4pk7LMwlKJ7G6bfBcz0cIHihb/SAel8qN9bbHSlN+ok3nZ82CbxGmuZL7vuvBt9J0qDsGtnFvGeSzQN0xubzSmKXWjkOnpook9IfsXB9USfYo1CydRqmntDDnBc7TxHEPosXRdMRpIIRYA34X+HP3Sw0JIRpSypEQ4qvAvySl/Nce8vN2gWufYihdYO9TfN9nybzHcPf7fxH4/jG+/zSZ13v/LO/7s8bzs3rfz5LH6Xd8NJ7zvneO8qSO5ayUsnf3i/OYFP4H4NeArfKlfx64BHxJSvl3hBBvACEQAX9FSrl1/5907HG8IaV8/SR+9pMyhuO+/zzHP6/3rt738Xjved87R3naxjKPg+a/dp+Xf1B+8LgEt6KiouJZ5NlLvFZUVFRUPJBneVL4+rwHwPzHcNz3n+f45/Xe1fs+Hu8973vnKE/VWE79TKGioqKi4vHlWd4pVFRUVFTcRTUpVFRUVFTMqCaFioqKiooZ1aRQUVFRUTHjmZgUhBC/Wn5uCSH+phDi94UQ/70QYuUUx/CKEOL3hBD/WAjxh+Xn3xNCvHaKY/jr5efPCSH+WAjxR0KIPxFCfPkRvvdXy8+nHsN5xe448Trm+/5q+flUYz3Pa/RhsX4c7uHy/ed+Hx8Zy8lcn0q69un+AL5Vfv4G8FuAA3wV+H9PcQzfBlbuem0V+PYc4vAPgOfLP3eBP3mcYziv2B0nXp/R+55qrOd5jT4s1o/DPTzvGP2sMfu0H8/ETgEQQggN9cv8ppQyklL+AerCOtVx3Ofvpykk3xFC/BrQkVJ+ACCl3EMZGj2MecdwHrE7TryOwzxjPa9r9GGxnvf1d5R538eHnMj1+SzZcf4joBBCtKSUAyFEHbjXkuvk+B3gbwkhWnycttsHPlHw72/wo5EAAAUFSURBVDPm7wNfBv7vu+Lwo0f8/nnFcF6xO268jsM8Yj3Pa/RRYj3vexgej/v4kBO5PqvmtYqKioqKGc9K+ui+CCH+5cdgDP/hYzCG//YY3zu3GM4rdseJ1zHfdy6xnuc1+rBYPw73MDwe9/Ehx70+n6X00f34rLTuHwkhxJeAXwJawADlUf13TnkMLwO5lPInR17+X4/xI08lhvOK3QnE6ziceKzneY1+ylif6j0Mj8d9fGQsn/n1+Uynj4QQtpQyPqX3+q8BG/gDYAg0UNUTmZTy3z6lMfxNYAlIUVUKf1VKuSuE+JaU8tc+5c888RjOK3YnEa9jjudEYz3Pa/TTxvo07+Hy/eZ+Hx8Zy8lcn6ddRjWPD+C3gTeA7wD/AR9Pht86xTH88QNe/6N5jAF4DfhD4PVHicM8Yziv2B0nXsd837nEep7X6MNi/Tjcw/OO0c8as0/78aykj/4t4BellJkQ4neA3xNC/GVOt4zsDaFc5/4hMEKtMH4dePMUx6ALISwpZSKlfEsI8S8C/zPw8iN87zxjOK/YHSdex2FesZ7nNfqwWD8O9zA8HvfxISdyfT4T6SMhxHeklL905O+/APyXwKKU8tIpjuMLwC+icpFD4DtSylO7mIQQPw98JKXcOfKaDvxFKeU3H/K9c43hPGJ3nHgd833nFut5XaMPi/W8r7+7xjrX+/jIOE7k+nxWJoV/FdX5eP3Ia2vAfyql/J35jezJoYrh6VHF+l6qmJwez8SkcDdCiG9IKf/SvMfxJFPF8PSoYn0vVUxOjme1T+FURbSeUqoYnh5VrO+liskJ8axOCs/e9uizp4rh6VHF+l6qmJwQz+qkUFFRUVFxH57VSWEeioZPG1UMT48q1vdSxeSEeFYPmpeklNvzHseTTBXD06OK9b1UMTk5nslJoaKioqLi/jyr6aOKioqKivtQTQoVFRUVFTOqSeGEEUL8BSGEFEK8OO+xPOkIIXIhxA+EED8UQnxfCPHPzHtMTzJCiGUhxDeFEFeEEN8TQvw/QoiL8x7Xk8iRa/Od8vr8d4WyD33iqM4UThghxO+ijL2/JaX8z+Y9nicZIcRESumXf/7ngP9ISvnPznlYTyRCCAH8U+B/lFL+7fK1zwENKeW35zq4J5C7rs1F4BvAnzyJ9/wTOZM9KQghfOCXgX8F+K05D+dpowH05z2IJ5ivAOnhhAAgpfxhNSEcn1Kg7mvAv1lOvk8Uz4p09rz488DvSynfE0LsCyG+JKX83rwH9QTjCiF+ADgomYNTN7p5ingFqK7FE0JKebVULF0EnqjS2WqncLL8NnAoYfvN8u8Vn55QSvl5KeWLwJ8F/qcncSVWUfE4U+0UTgghRAe1kn1VCCEBHZBCiH9PVgc5x0ZK+R0hRBfoATsP+/qKe3gH+M15D+JpRQhxAch5Aq/Naqdwcvwm8PeklGellOeklGeAD4Evz3lcTwVlNZcO7M97LE8o3wJsIcTXDl8QQrwmhKiuz2MihOgBfxv4W0/iArDaKZwcvw38F3e99n+Ur//x6Q/nqeDwTAGU9s1fllLm8xzQk4qUUpb2jf+NEOLfByLgI+Cvz3VgTy6H16YJZMDfA/6r+Q7p01GVpFZUVFRUzKjSRxUVFRUVM6pJoaKioqJiRjUpVFRUVFTMqCaFioqKiooZ1aRQUVFRUTGjmhQqKioqKmZUk0JFRUVFxYxqUqioqKiomPH/A2dQQztxLfz1AAAAAElFTkSuQmCC",
             "text/plain": [
               "<Figure size 432x288 with 16 Axes>"
             ]
           },
           "metadata": {
             "needs_background": "light"
-          }
+          },
+          "output_type": "display_data"
         }
+      ],
+      "source": [
+        "df = pd.DataFrame(np.random.randn(1000, 4), columns=['A','B','C','D'])\n",
+        "\n",
+        "pd.plotting.scatter_matrix(df, alpha=0.2)\n",
+        "plt.show()"
       ]
     },
     {
       "cell_type": "code",
+      "execution_count": 92,
       "metadata": {
         "id": "56rZWzjU7z7d"
       },
+      "outputs": [],
       "source": [
         "import matplotlib.pyplot as plt"
-      ],
-      "execution_count": 438,
-      "outputs": []
+      ]
     },
     {
       "cell_type": "code",
+      "execution_count": 93,
       "metadata": {
         "id": "lSXL2MjJ8uBG"
       },
+      "outputs": [],
       "source": [
         "np.random.seed(5)"
-      ],
-      "execution_count": 439,
-      "outputs": []
+      ]
     },
     {
       "cell_type": "markdown",
@@ -5621,34 +5598,34 @@
     },
     {
       "cell_type": "code",
+      "execution_count": 94,
       "metadata": {
         "colab": {
           "base_uri": "https://localhost:8080/",
           "height": 262
         },
         "id": "YvqD2CHo-UiM",
-        "outputId": "b23d56e0-245a-4e51-d670-28bf7f7cedb1"
+        "outputId": "8b5fd7e0-be2c-4890-fc15-4c4abb0f9344"
       },
-      "source": [
-        "df = pd.DataFrame(np.random.randint(10, size=(10,4)), columns=list(\"ABCD\"))\n",
-        "\n",
-        "df.plot.bar()\n",
-        "plt.show()\n"
-      ],
-      "execution_count": 440,
       "outputs": [
         {
-          "output_type": "display_data",
           "data": {
-            "image/png": "iVBORw0KGgoAAAANSUhEUgAAAWoAAAD1CAYAAAB5n7/BAAAABHNCSVQICAgIfAhkiAAAAAlwSFlzAAALEgAACxIB0t1+/AAAADh0RVh0U29mdHdhcmUAbWF0cGxvdGxpYiB2ZXJzaW9uMy4yLjIsIGh0dHA6Ly9tYXRwbG90bGliLm9yZy+WH4yJAAAQfUlEQVR4nO3df5DcdX3H8eebS/QSwciEQw3neQdtJGYyiST+QGi1YG2Kjk7UPyJjSJ2xGaalwdppm9TOGP5otaO29Y9OZ25Em456mZiK0NIRpAkUCoMQCCRwJyoGOIEQQiUFEwjHu3/sBnOXI7dh97v74fJ8zDDZ73d3P58Xt3uv+95nv7sXmYkkqVwndTqAJOnYLGpJKpxFLUmFs6glqXAWtSQVzqKWpMLNqGLQ0047Lfv7+6sYWpKmpe3btz+ZmT2TXVdJUff393PnnXdWMbQkTUsR8dDLXefShyQVzqKWpMJZ1JJUuErWqCWp3Q4dOsTo6CgHDx7sdJRj6u7upre3l5kzZzZ8H4ta0rQwOjrKKaecQn9/PxHR6TiTykz27dvH6OgoAwMDDd/PpQ9J08LBgweZO3dusSUNEBHMnTv3uI/6LWpJ00bJJX3YK8loUUtSC33/+98nIhgZGWnZmCfsGnX/umuP2rf7Sx/qQBK9UsNnLzhq34KR4abGnPR50X3xuO1FA33jtneu3tnUnDq2iY9Jo9+nkz2WzRg376N3H32Dee8AYGhoiPPPP5+hoSGuuOKKlsztEbUktcgzzzzDLbfcwpVXXsmmTZtaNq5FLUktcvXVV7N8+XLmz5/P3Llz2b59e0vGtaglqUWGhoZYuXIlACtXrmRoaKgl456wa9SS1EpPPfUUW7duZefOnUQEY2NjRARf/vKXmz4bxSNqSWqBLVu2sGrVKh566CF2797NI488wsDAADfffHPTY1vUktQCQ0NDrFixYty+j3/84y1Z/nDpQ9K01O7Tbbdt23bUvrVr17ZkbI+oJalwFrUkFc6ilqTCWdSSVDiLWpIKZ1FLUuEsaklqka6uLpYsWcLixYs555xzuPXWW1syrudRS5qeNsxp8XhPT3mTWbNmsWPHDgCuu+461q9fz0033dT01B5RS1IF9u/fz6mnntqSsTyilqQWOXDgAEuWLOHgwYM89thjbN26tSXjWtSS1CJHLn3cdtttXHLJJezatctPz5OkEp177rk8+eST7N27t+mxGirqiPjTiLgvInZFxFBEdDc9syRNYyMjI4yNjTF37tymx5py6SMizgDWAm/PzAMRsRlYCfxL07NL0jRyeI0aIDPZuHEjXV1dTY/b6Br1DGBWRBwCZgOPNj2zJFWpgdPpWm1sbKyScacs6sz8RUR8BXgYOABcn5nXT7xdRKwB1gD09fW1Omd7TDzvsgMPtCRNNOUadUScCnwUGADmAa+LiE9NvF1mDmbmssxc1tPT0/qkknSCauTFxA8AP8/MvZl5CPge8N5qY0mSDmukqB8G3hMRs6N2MuCFwHC1sSRJh01Z1Jl5O7AFuAvYWb/PYMW5JEl1DZ31kZlfAL5QcRZJ0iR8Z6Iktcjjjz/OypUrOeuss1i6dCkXXXQRDzzwQNPj+lkfkqalRRsXtXS8nat3HvP6zGTFihWsXr2aTZs2AXDPPfewZ88e5s+f39TcFrUktcC2bduYOXMml1566Uv7Fi9e3JKxXfqQpBbYtWsXS5curWRsi1qSCmdRS1ILLFy4kO3bt1cytkUtSS1wwQUX8NxzzzE4+Ou3mdx7773cfPPNTY9tUUtSC0QEV111FTfccANnnXUWCxcuZP369bzpTW9qemzP+pA0LU11Ol0V5s2bx+bNm1s+rkfUklQ4i1qSCmdRS1LhLGpJKpxFLUmFs6glqXAWtSS1SFdXF0uWLGHhwoUsXryYr371q7z44otNj+t51JKmpeGzF7R0vAUjU/8FwlmzZrFjxw4AnnjiCS6++GL279/PFVdc0dTcFvVxmPjAN/LANWviZ+q27ST+DXMmbD/dnnk1OR+PV53TTz+dwcFB3vnOd7JhwwZqf3L2lXHpQ5IqcuaZZzI2NsYTTzzR1DgWtSQVzqKWpIo8+OCDdHV1cfrppzc1jkUtSRXYu3cvl156KZdddllT69Pgi4mS1DIHDhxgyZIlHDp0iBkzZrBq1So+97nPNT2uRS1pWmrHWVkTjY2NVTKuSx+SVDiLWpIKZ1FLUuEsaknTRmZ2OsKUXklGi1rStNDd3c2+ffuKLuvMZN++fXR3dx/X/TzrQ9K00Nvby+joKHv37q1+sl9O8pbwpxs7y6S7u5ve3t7jms6iljQtzJw5k4GBgfZMtuE9k+yr7oOyXPqQpMJZ1JJUOItakgpnUUtS4SxqSSqcRS1JhWuoqCPiDRGxJSJGImI4Is6tOpgkqabR86i/BvwgMz8REa8BZleYSZJ0hCmLOiLmAL8N/AFAZj4PPF9tLEnSYY0cUQ8Ae4FvRsRiYDtweWY+e+SNImINsAagr6/v+FJsmDNuc9HA0fffuXrn8Y2pV78Jz4sq3/klHUv/umvHbe8+vo/qaFoja9QzgHOAf87MdwDPAusm3igzBzNzWWYu6+npaXFMSTpxNVLUo8BoZt5e395CrbglSW0wZVFn5uPAIxHxtvquC4H7K00lSXpJo2d9/Anw7foZHw8Cn64ukiTpSA0VdWbuAJZVnEWSNAnfmShJhbOoJalwFrUkFc6ilqTCWdSSVDiLWpIKZ1FLUuEsakkqnEUtSYWzqCWpcBa1JBXOopakwlnUklQ4i1qSCmdRS1LhLGpJKpxFLUmFa/RPcWka61937VH7dnd3IIheseGzFxy1b8HIcAeSqAoeUUtS4SxqSSqcRS1JhbOoJalwFrUkFc6ilqTCWdSSVDiLWpIKZ1FLUuEsakkqnEUtSYWzqCWpcBa1JBXOopakwlnUklQ4i1qSCmdRS1LhLGpJKpxFLUmFa7ioI6IrIu6OiP+oMpAkabzjOaK+HPCvZUpSmzVU1BHRC3wI+Hq1cSRJE81o8Hb/CPwFcMrL3SAi1gBrAPr6+ppPVoBFGxeN297coRwniv51147b3t3doSBq2FHfI198Ydz2gpH2/xI+fPaCo/Z1IkcrTXlEHREfBp7IzO3Hul1mDmbmssxc1tPT07KAknSia2Tp4zzgIxGxG9gEXBAR36o0lSTpJVMWdWauz8zezOwHVgJbM/NTlSeTJAGeRy1JxWv0xUQAMvNG4MZKkkiSJuURtSQVzqKWpMJZ1JJUOItakgpnUUtS4SxqSSqcRS1JhbOoJalwFrUkFc6ilqTCWdSSVDiLWpIKZ1FLUuEsakkqnEUtSYWzqCWpcBa1JBXuuP7CS6v0r7t23Pbu7k6kkPSqtGHOhO2nO5NjgkUbF43b3vzFF8ZtLxgZfsVje0QtSYWzqCWpcBa1JBXOopakwlnUklQ4i1qSCmdRS1LhLGpJKpxFLUmFs6glqXAWtSQVzqKWpMJZ1JJUOItakgpnUUtS4SxqSSqcRS1JhbOoJalwFrUkFW7Koo6It0TEtoi4PyLui4jL2xFMklTTyB+3fQH4s8y8KyJOAbZHxA8z8/6Ks0mSaOCIOjMfy8y76pf/DxgGzqg6mCSpppEj6pdERD/wDuD2Sa5bA6wB6Ovra0E0abxFGxeN297coRzt0L/u2nHbu7s7FORV4ER4XjT8YmJEnAz8G/DZzNw/8frMHMzMZZm5rKenp5UZJemE1lBRR8RMaiX97cz8XrWRJElHauSsjwCuBIYz8++rjyRJOlIjR9TnAauACyJiR/2/iyrOJUmqm/LFxMy8BYg2ZJEkTcJ3JkpS4SxqSSqcRS1JhbOoJalwFrUkFc6ilqTCWdSSVDiLWpIKZ1FLUuEsakkqnEUtSYWzqCWpcBa1JBXOopakwlnUklQ4i1qSCmdRS1LhpvwLLyrL8NkLjtq3YGS44zk6kaEUfi1UNY+oJalwFrUkFc6ilqTCWdSSVDiLWpIKZ1FLUuEsakkqnEUtSYWzqCWpcBa1JBXOopakwlnUklQ4i1qSCmdRS1LhLGpJKpxFLUmFs6glqXAWtSQVzqKWpMI1VNQRsTwifhwRP42IdVWHkiT92pRFHRFdwD8Bvw+8HfhkRLy96mCSpJpGjqjfBfw0Mx/MzOeBTcBHq40lSTosMvPYN4j4BLA8Mz9T314FvDszL5twuzXAmvrm24AfN5HrNODJJu7fKiXkKCEDlJGjhAxQRo4SMkAZOUrIAM3neGtm9kx2xYwmBh0nMweBwVaMFRF3ZuayVoz1as9RQoZScpSQoZQcJWQoJUcJGarO0cjSxy+Atxyx3VvfJ0lqg0aK+g7gNyNiICJeA6wErqk2liTpsCmXPjLzhYi4DLgO6AK+kZn3VZyrJUsoLVBCjhIyQBk5SsgAZeQoIQOUkaOEDFBhjilfTJQkdZbvTJSkwlnUklQ4i1qSCtey86ibERFnU3u34xn1Xb8ArsnM4c6l6oz61+IM4PbMfOaI/csz8wdtyvAuIDPzjvrHBSwHRjLzP9sx/zFy/WtmXtLhDOdTe7fursy8vk1zvhsYzsz9ETELWAecA9wP/G1mPt2GDGuBqzLzkarnmiLH4TPPHs3MGyLiYuC9wDAwmJmH2pTjTOBj1E5dHgMeAL6Tmfsrma/TLyZGxF8Cn6T21vTR+u5eag/Gpsz8UqeyHRYRn87Mb7ZhnrXAH1N70i0BLs/Mq+vX3ZWZ57Qhwxeofa7LDOCHwLuBbcDvAtdl5t9UnaGeY+IpoAH8DrAVIDM/0qYcP8rMd9Uv/yG1x+cq4IPAv7fj+RkR9wGL62dgDQK/ArYAF9b3f6wNGZ4GngV+BgwB383MvVXPO0mOb1N7bs4GfgmcDHyP2tciMnN1GzKsBT4M/DdwEXB3PcsK4I8y88aWT5qZHf2P2k+imZPsfw3wk07nq2d5uE3z7AROrl/uB+6kVtYAd7cxQxe1b4T9wOvr+2cB97bxa34X8C3g/cD76v8+Vr/8vjbmuPuIy3cAPfXLrwN2tinD8JFflwnX7WjX14HaUukHgSuBvcAPgNXAKW18PO6t/zsD2AN01bejXc/Pw98j9cuzgRvrl/uq+j4tYenjRWAe8NCE/W+uX9cWEXHvy10FvLFNMU7K+nJHZu6OiPcDWyLirfUc7fBCZo4Bv4qIn2X9V7nMPBARbXs8gGXA5cDngT/PzB0RcSAzb2pjBoCTIuJUaiUVWT+KzMxnI+KFNmXYdcRvdfdExLLMvDMi5gNt+VWf2lLYi8D1wPURMZPab16fBL4CTPoZFRU4qb788TpqJTkHeAp4LTCzTRmg9oNirD7vyQCZ+XD961LJZJ32WeC/IuInwOH1rz7gN4DLXvZerfdG4PeA/52wP4Bb25RhT0QsycwdAJn5TER8GPgGsKhNGZ6PiNmZ+Stg6eGdETGHNv7grJfCP0TEd+v/7qEzz9c5wHZqz4OMiDdn5mMRcTLt++H5GeBrEfHX1D7057aIeITa98tn2pRh3P9r1taCrwGuiYjZbcoAtaP5EWq/9X0e+G5EPAi8h9ryaTt8HbgjIm4Hfgv4O4CI6KH2Q6PlOr5GDRARJ1F7gebIFxPvqB/ZtSvDlcA3M/OWSa77TmZe3IYMvdSOaB+f5LrzMvN/2pDhtZn53CT7TwPenJk7q84wmYj4EHBeZv5VJ+afqF5Ob8zMn7dxztcDA9R+YI1m5p42zj0/Mx9o13zHEhHzADLz0Yh4A/ABasuTP2pjhoXAAmovKo9UPl8JRS1JenmeRy1JhbOoJalwFrUkFc6ilqTCWdSSVLj/BxwK0qa+fLy2AAAAAElFTkSuQmCC\n",
+            "image/png": "iVBORw0KGgoAAAANSUhEUgAAAWoAAAD1CAYAAAB5n7/BAAAABHNCSVQICAgIfAhkiAAAAAlwSFlzAAALEgAACxIB0t1+/AAAADh0RVh0U29mdHdhcmUAbWF0cGxvdGxpYiB2ZXJzaW9uMy4yLjIsIGh0dHA6Ly9tYXRwbG90bGliLm9yZy+WH4yJAAAQfUlEQVR4nO3df5DcdX3H8eebS/QSwciEQw3neQdtJGYyiST+QGi1YG2Kjk7UPyJjSJ2xGaalwdppm9TOGP5otaO29Y9OZ25Em456mZiK0NIRpAkUCoMQCCRwJyoGOIEQQiUFEwjHu3/sBnOXI7dh97v74fJ8zDDZ73d3P58Xt3uv+95nv7sXmYkkqVwndTqAJOnYLGpJKpxFLUmFs6glqXAWtSQVzqKWpMLNqGLQ0047Lfv7+6sYWpKmpe3btz+ZmT2TXVdJUff393PnnXdWMbQkTUsR8dDLXefShyQVzqKWpMJZ1JJUuErWqCWp3Q4dOsTo6CgHDx7sdJRj6u7upre3l5kzZzZ8H4ta0rQwOjrKKaecQn9/PxHR6TiTykz27dvH6OgoAwMDDd/PpQ9J08LBgweZO3dusSUNEBHMnTv3uI/6LWpJ00bJJX3YK8loUUtSC33/+98nIhgZGWnZmCfsGnX/umuP2rf7Sx/qQBK9UsNnLzhq34KR4abGnPR50X3xuO1FA33jtneu3tnUnDq2iY9Jo9+nkz2WzRg376N3H32Dee8AYGhoiPPPP5+hoSGuuOKKlsztEbUktcgzzzzDLbfcwpVXXsmmTZtaNq5FLUktcvXVV7N8+XLmz5/P3Llz2b59e0vGtaglqUWGhoZYuXIlACtXrmRoaKgl456wa9SS1EpPPfUUW7duZefOnUQEY2NjRARf/vKXmz4bxSNqSWqBLVu2sGrVKh566CF2797NI488wsDAADfffHPTY1vUktQCQ0NDrFixYty+j3/84y1Z/nDpQ9K01O7Tbbdt23bUvrVr17ZkbI+oJalwFrUkFc6ilqTCWdSSVDiLWpIKZ1FLUuEsaklqka6uLpYsWcLixYs555xzuPXWW1syrudRS5qeNsxp8XhPT3mTWbNmsWPHDgCuu+461q9fz0033dT01B5RS1IF9u/fz6mnntqSsTyilqQWOXDgAEuWLOHgwYM89thjbN26tSXjWtSS1CJHLn3cdtttXHLJJezatctPz5OkEp177rk8+eST7N27t+mxGirqiPjTiLgvInZFxFBEdDc9syRNYyMjI4yNjTF37tymx5py6SMizgDWAm/PzAMRsRlYCfxL07NL0jRyeI0aIDPZuHEjXV1dTY/b6Br1DGBWRBwCZgOPNj2zJFWpgdPpWm1sbKyScacs6sz8RUR8BXgYOABcn5nXT7xdRKwB1gD09fW1Omd7TDzvsgMPtCRNNOUadUScCnwUGADmAa+LiE9NvF1mDmbmssxc1tPT0/qkknSCauTFxA8AP8/MvZl5CPge8N5qY0mSDmukqB8G3hMRs6N2MuCFwHC1sSRJh01Z1Jl5O7AFuAvYWb/PYMW5JEl1DZ31kZlfAL5QcRZJ0iR8Z6Iktcjjjz/OypUrOeuss1i6dCkXXXQRDzzwQNPj+lkfkqalRRsXtXS8nat3HvP6zGTFihWsXr2aTZs2AXDPPfewZ88e5s+f39TcFrUktcC2bduYOXMml1566Uv7Fi9e3JKxXfqQpBbYtWsXS5curWRsi1qSCmdRS1ILLFy4kO3bt1cytkUtSS1wwQUX8NxzzzE4+Ou3mdx7773cfPPNTY9tUUtSC0QEV111FTfccANnnXUWCxcuZP369bzpTW9qemzP+pA0LU11Ol0V5s2bx+bNm1s+rkfUklQ4i1qSCmdRS1LhLGpJKpxFLUmFs6glqXAWtSS1SFdXF0uWLGHhwoUsXryYr371q7z44otNj+t51JKmpeGzF7R0vAUjU/8FwlmzZrFjxw4AnnjiCS6++GL279/PFVdc0dTcFvVxmPjAN/LANWviZ+q27ST+DXMmbD/dnnk1OR+PV53TTz+dwcFB3vnOd7JhwwZqf3L2lXHpQ5IqcuaZZzI2NsYTTzzR1DgWtSQVzqKWpIo8+OCDdHV1cfrppzc1jkUtSRXYu3cvl156KZdddllT69Pgi4mS1DIHDhxgyZIlHDp0iBkzZrBq1So+97nPNT2uRS1pWmrHWVkTjY2NVTKuSx+SVDiLWpIKZ1FLUuEsaknTRmZ2OsKUXklGi1rStNDd3c2+ffuKLuvMZN++fXR3dx/X/TzrQ9K00Nvby+joKHv37q1+sl9O8pbwpxs7y6S7u5ve3t7jms6iljQtzJw5k4GBgfZMtuE9k+yr7oOyXPqQpMJZ1JJUOItakgpnUUtS4SxqSSqcRS1JhWuoqCPiDRGxJSJGImI4Is6tOpgkqabR86i/BvwgMz8REa8BZleYSZJ0hCmLOiLmAL8N/AFAZj4PPF9tLEnSYY0cUQ8Ae4FvRsRiYDtweWY+e+SNImINsAagr6/v+FJsmDNuc9HA0fffuXrn8Y2pV78Jz4sq3/klHUv/umvHbe8+vo/qaFoja9QzgHOAf87MdwDPAusm3igzBzNzWWYu6+npaXFMSTpxNVLUo8BoZt5e395CrbglSW0wZVFn5uPAIxHxtvquC4H7K00lSXpJo2d9/Anw7foZHw8Cn64ukiTpSA0VdWbuAJZVnEWSNAnfmShJhbOoJalwFrUkFc6ilqTCWdSSVDiLWpIKZ1FLUuEsakkqnEUtSYWzqCWpcBa1JBXOopakwlnUklQ4i1qSCmdRS1LhLGpJKpxFLUmFa/RPcWka61937VH7dnd3IIheseGzFxy1b8HIcAeSqAoeUUtS4SxqSSqcRS1JhbOoJalwFrUkFc6ilqTCWdSSVDiLWpIKZ1FLUuEsakkqnEUtSYWzqCWpcBa1JBXOopakwlnUklQ4i1qSCmdRS1LhLGpJKpxFLUmFa7ioI6IrIu6OiP+oMpAkabzjOaK+HPCvZUpSmzVU1BHRC3wI+Hq1cSRJE81o8Hb/CPwFcMrL3SAi1gBrAPr6+ppPVoBFGxeN297coRwniv51147b3t3doSBq2FHfI198Ydz2gpH2/xI+fPaCo/Z1IkcrTXlEHREfBp7IzO3Hul1mDmbmssxc1tPT07KAknSia2Tp4zzgIxGxG9gEXBAR36o0lSTpJVMWdWauz8zezOwHVgJbM/NTlSeTJAGeRy1JxWv0xUQAMvNG4MZKkkiSJuURtSQVzqKWpMJZ1JJUOItakgpnUUtS4SxqSSqcRS1JhbOoJalwFrUkFc6ilqTCWdSSVDiLWpIKZ1FLUuEsakkqnEUtSYWzqCWpcBa1JBXuuP7CS6v0r7t23Pbu7k6kkPSqtGHOhO2nO5NjgkUbF43b3vzFF8ZtLxgZfsVje0QtSYWzqCWpcBa1JBXOopakwlnUklQ4i1qSCmdRS1LhLGpJKpxFLUmFs6glqXAWtSQVzqKWpMJZ1JJUOItakgpnUUtS4SxqSSqcRS1JhbOoJalwFrUkFW7Koo6It0TEtoi4PyLui4jL2xFMklTTyB+3fQH4s8y8KyJOAbZHxA8z8/6Ks0mSaOCIOjMfy8y76pf/DxgGzqg6mCSpppEj6pdERD/wDuD2Sa5bA6wB6Ovra0E0abxFGxeN297coRzt0L/u2nHbu7s7FORV4ER4XjT8YmJEnAz8G/DZzNw/8frMHMzMZZm5rKenp5UZJemE1lBRR8RMaiX97cz8XrWRJElHauSsjwCuBIYz8++rjyRJOlIjR9TnAauACyJiR/2/iyrOJUmqm/LFxMy8BYg2ZJEkTcJ3JkpS4SxqSSqcRS1JhbOoJalwFrUkFc6ilqTCWdSSVDiLWpIKZ1FLUuEsakkqnEUtSYWzqCWpcBa1JBXOopakwlnUklQ4i1qSCmdRS1LhpvwLLyrL8NkLjtq3YGS44zk6kaEUfi1UNY+oJalwFrUkFc6ilqTCWdSSVDiLWpIKZ1FLUuEsakkqnEUtSYWzqCWpcBa1JBXOopakwlnUklQ4i1qSCmdRS1LhLGpJKpxFLUmFs6glqXAWtSQVzqKWpMI1VNQRsTwifhwRP42IdVWHkiT92pRFHRFdwD8Bvw+8HfhkRLy96mCSpJpGjqjfBfw0Mx/MzOeBTcBHq40lSTosMvPYN4j4BLA8Mz9T314FvDszL5twuzXAmvrm24AfN5HrNODJJu7fKiXkKCEDlJGjhAxQRo4SMkAZOUrIAM3neGtm9kx2xYwmBh0nMweBwVaMFRF3ZuayVoz1as9RQoZScpSQoZQcJWQoJUcJGarO0cjSxy+Atxyx3VvfJ0lqg0aK+g7gNyNiICJeA6wErqk2liTpsCmXPjLzhYi4DLgO6AK+kZn3VZyrJUsoLVBCjhIyQBk5SsgAZeQoIQOUkaOEDFBhjilfTJQkdZbvTJSkwlnUklQ4i1qSCtey86ibERFnU3u34xn1Xb8ArsnM4c6l6oz61+IM4PbMfOaI/csz8wdtyvAuIDPzjvrHBSwHRjLzP9sx/zFy/WtmXtLhDOdTe7fursy8vk1zvhsYzsz9ETELWAecA9wP/G1mPt2GDGuBqzLzkarnmiLH4TPPHs3MGyLiYuC9wDAwmJmH2pTjTOBj1E5dHgMeAL6Tmfsrma/TLyZGxF8Cn6T21vTR+u5eag/Gpsz8UqeyHRYRn87Mb7ZhnrXAH1N70i0BLs/Mq+vX3ZWZ57Qhwxeofa7LDOCHwLuBbcDvAtdl5t9UnaGeY+IpoAH8DrAVIDM/0qYcP8rMd9Uv/yG1x+cq4IPAv7fj+RkR9wGL62dgDQK/ArYAF9b3f6wNGZ4GngV+BgwB383MvVXPO0mOb1N7bs4GfgmcDHyP2tciMnN1GzKsBT4M/DdwEXB3PcsK4I8y88aWT5qZHf2P2k+imZPsfw3wk07nq2d5uE3z7AROrl/uB+6kVtYAd7cxQxe1b4T9wOvr+2cB97bxa34X8C3g/cD76v8+Vr/8vjbmuPuIy3cAPfXLrwN2tinD8JFflwnX7WjX14HaUukHgSuBvcAPgNXAKW18PO6t/zsD2AN01bejXc/Pw98j9cuzgRvrl/uq+j4tYenjRWAe8NCE/W+uX9cWEXHvy10FvLFNMU7K+nJHZu6OiPcDWyLirfUc7fBCZo4Bv4qIn2X9V7nMPBARbXs8gGXA5cDngT/PzB0RcSAzb2pjBoCTIuJUaiUVWT+KzMxnI+KFNmXYdcRvdfdExLLMvDMi5gNt+VWf2lLYi8D1wPURMZPab16fBL4CTPoZFRU4qb788TpqJTkHeAp4LTCzTRmg9oNirD7vyQCZ+XD961LJZJ32WeC/IuInwOH1rz7gN4DLXvZerfdG4PeA/52wP4Bb25RhT0QsycwdAJn5TER8GPgGsKhNGZ6PiNmZ+Stg6eGdETGHNv7grJfCP0TEd+v/7qEzz9c5wHZqz4OMiDdn5mMRcTLt++H5GeBrEfHX1D7057aIeITa98tn2pRh3P9r1taCrwGuiYjZbcoAtaP5EWq/9X0e+G5EPAi8h9ryaTt8HbgjIm4Hfgv4O4CI6KH2Q6PlOr5GDRARJ1F7gebIFxPvqB/ZtSvDlcA3M/OWSa77TmZe3IYMvdSOaB+f5LrzMvN/2pDhtZn53CT7TwPenJk7q84wmYj4EHBeZv5VJ+afqF5Ob8zMn7dxztcDA9R+YI1m5p42zj0/Mx9o13zHEhHzADLz0Yh4A/ABasuTP2pjhoXAAmovKo9UPl8JRS1JenmeRy1JhbOoJalwFrUkFc6ilqTCWdSSVLj/BxwK0qa+fLy2AAAAAElFTkSuQmCC",
             "text/plain": [
               "<Figure size 432x288 with 1 Axes>"
             ]
           },
           "metadata": {
             "needs_background": "light"
-          }
+          },
+          "output_type": "display_data"
         }
+      ],
+      "source": [
+        "df = pd.DataFrame(np.random.randint(10, size=(10,4)), columns=list(\"ABCD\"))\n",
+        "\n",
+        "df.plot.bar()\n",
+        "plt.show()\n"
       ]
     },
     {
@@ -5662,34 +5639,34 @@
     },
     {
       "cell_type": "code",
+      "execution_count": 95,
       "metadata": {
         "colab": {
           "base_uri": "https://localhost:8080/",
           "height": 265
         },
         "id": "jE1viGpO-adQ",
-        "outputId": "efc5c2dc-651f-45e1-b6c1-7e9bc5c4f2b7"
+        "outputId": "b286a826-15d4-4664-9566-9d1007ae55ae"
       },
-      "source": [
-        "df = pd.DataFrame(np.random.randint(10, size=(10,4)), columns=list(\"ABCD\"))\n",
-        "\n",
-        "df.plot.barh()\n",
-        "plt.show()\n"
-      ],
-      "execution_count": 441,
       "outputs": [
         {
-          "output_type": "display_data",
           "data": {
-            "image/png": "iVBORw0KGgoAAAANSUhEUgAAAWoAAAD4CAYAAADFAawfAAAABHNCSVQICAgIfAhkiAAAAAlwSFlzAAALEgAACxIB0t1+/AAAADh0RVh0U29mdHdhcmUAbWF0cGxvdGxpYiB2ZXJzaW9uMy4yLjIsIGh0dHA6Ly9tYXRwbG90bGliLm9yZy+WH4yJAAARiUlEQVR4nO3dfYxc1XnH8e/D2snaBBlkbGTs0F0r4d3CxBvKW1ELTeUElJSmQgTFuFHbCCkEm7RKcP9oTKVKoYkqR0oU1YKkSKHrIgeSKrRAVTsEVIrYJU7WxiYKxsA6gF9oMKQ2OJunf+zaGLMvdz13PGd3vx/JYnfmzplHI/zzmXPPvU9kJpKkcp3Q6gIkSaMzqCWpcAa1JBXOoJakwhnUklS4ac0Y9NRTT82Ojo5mDC1Jk1Jvb++ezJwz3HNNCeqOjg56enqaMbQkTUoR8fxIz7n0IUmFM6glqXAGtSQVrilr1JJ0vB08eJD+/n4OHDjQ6lJG1d7ezoIFC5g+fXrl1zQlqA9s3sLWs89pxtCSdNg527Ye/rm/v5+TTjqJjo4OIqKFVY0sM9m7dy/9/f10dnZWfp1LH5ImhQMHDjB79uxiQxogIpg9e/a4Z/2VgjoiVkTE5ojYEhErj6lCSWqykkP6kGOpccylj4g4H/hL4CLgLeDBiPhhZv5ipNc8Ow+uW+Xy99H6lve1ugRJE1CVND0HeCIz/w8gIh4B/gT4h2YWJkmN6LjtgVrH2/GVqysd9/3vf59rr72WrVu3cvbZZ9fy3lWCejPw9xExG9gPfAx412WHEfFZ4LMAZ8wK+p57oZYCJ5XVs1pdgapa/VqrK9AE1d3dzeWXX053dze33357LWOOuUadmVuBO4CHgQeBTcDAMMetzcyuzOyaM7P8dSJJqtsbb7zBY489xl133cW6detqG7fSycTMvCszl2TmFcD/Aj+vrQJJmiR+8IMfsHTpUs4880xmz55Nb29vLeNWOuMXEXMzc1dEnMHg+vTFox3flwvpOLCmjvo0RVRd/5NK1t3dzYoVKwC4/vrr6e7uZsmSJQ2PW3VrxveG1qgPAp/LzF81/M6SNIm8+uqrbNiwgb6+PiKCgYEBIoKvfvWrDW8brLr08XuZeW5mXpCZ/9XQO0rSJLR+/XqWLVvG888/z44dO3jxxRfp7Ozk0UcfbXjspmx2XjR/Fj1+lZXUQsd7Oa27u5svfelL73jsk5/8JN3d3VxxxRUNje1VKZJUg40bN77rsVtuuaWWsb3XhyQVzqCWpMIZ1JJUOINakgpnUEtS4QxqSSqc2/MkTU51362ywh0V29raWLRoEZlJW1sb3/jGN7j00ksbfmuDWpJqMmPGDDZt2gTAQw89xKpVq3jkkUcaHtelD0lqgn379nHKKafUMpZdyKXCHdlpW2Xbv38/ixcv5sCBA7z00kts2LChlnFd+pCkmhy59PH4449z4403snnz5obvnlf1ftS3An8BJNAHfCYzR+x3bnNbqUZ3L2p1BRPCmnPX8Ns9vz38+3k1j79lz5ZRnz/v1He+4yWXXMKePXvYvXs3c+fObei9x1yjjoj5wC1AV2aeD7QB1zf0rpI0yW3bto2BgQFmz57d8FhVp73TgBkRcRCYCfyy4XeWpCbacvN/H/f3PLRGDZCZ3H333bS1tTU87phBnZk7I+JrwAsMdiF/ODMfPvo4u5BrUrEL+YSzdetWzjm1tZsYBgbe1fe7FlWWPk4BPgF0AqcDJ0bEp48+zi7kktQcVfZR/yHwXGbuzsyDwH1A45faSJIqqbJG/QJwcUTMZHDp4yqgZ7QX2IVcE92OVhcgHWHMGXVmPgGsB55icGveCcDaJtclSRpSaddHZn4Z+HLVQW1uK0n18V4fklQ4Lx+UNCktqvmKzr7lfWMe8/LLL7Ny5UqefPJJTj75ZE477TTWrFnDmWee2dB7G9SSVIPM5Nprr2X58uWsW7cOgJ/+9Ke88sorBrUklWDjxo1Mnz6dm2666fBjF1xwQS1ju0YtSTXYvHkzS5YsacrYBrUkFc6glqQanHfeefT29jZlbINakmpw5ZVX8uabb7J27dvXA/7sZz/j0UcfbXhsTyZKmpSqbKerU0Rw//33s3LlSu644w7a29vp6OhgzZrGb6dhUEtSTU4//XTuvffe2se1ua2kCWuqNP51jVqSCmdQS1Lhxlz6iIizgH894qGFwN9m5ogr5O3nn8c5PaPeslqSVFGVnonPAIsBIqIN2Anc3+S6JElDxrv0cRXwbGY+34xiJEnvNt5dH9cD3cM98Y4u5Gec0WBZktSYuneeVdlh0tbWxqJFizh48CDTpk3jxhtv5NZbb+WEExo7HVg5qCPiPcDHgVXDPZ+Zaxlq0dXV1ZUNVSVJE9CMGTPYtGkTALt27eKGG25g37593H777Q2NO54Z9UeBpzLzlbEO7Nv5Gh23PXDsVUk6bIdt7SakuXPnsnbtWj784Q+zevVqIuKYxxrPfPxTjLDsIUl6t4ULFzIwMMCuXbsaGqdSUEfEicBHgPsaejdJ0rhV7UL+a2B21UHtQi5JsH37dtra2pg7d25D43hloiQ1we7du7npppu4+eabG1qfBu+eJ2mSasUNm/bv38/ixYsPb89btmwZX/jCFxoe16CWpJoMDAw0ZVyXPiSpcAa1JBXOoJY0aWSWf1H0sdRoUEuaFNrb29m7d2/RYZ2Z7N27l/b29nG9zpOJkiaFBQsW0N/fz+7du1tdyqja29tZsGDBuF5jUEuaFKZPn05nZ2ery2gKlz4kqXB2IZc0LlOl83dJnFFLUuGq3j3v5IhYHxHbImJrRFzS7MIkSYOqLn18HXgwM/90qNPLzNEOfnYeXLfK85TSZNTX6gKmoDHTNCJmAVcAfwaQmW8BbzW3LEnSIVWmvZ3AbuA7EXEB0AusGLpH9WFHN7ftW+6/u5JUhypr1NOADwHfyswLgV8Dtx19UGauzcyuzOyaM2dOzWVK0tRVJaj7gf7MfGLo9/UMBrck6TgYc+kjM1+OiBcj4qzMfAa4Cnh6tNfYhXx4dpOWdCyqbs34PHDP0I6P7cBnmleSJOlIVZvbbgK6mlyLJGkYTdnsbBdySaqPl5BLUuEMakkqnEEtSYUzqCWpcAa1JBXOoJakwhnUklQ4g1qSCmdQS1LhDGpJKpxdyKVh2GlbJXFGLUmFqzSjjogdwOvAAPCbzBz1Tnrt55/HOT09jVcnSRrX0scfZOaeplUiSRqWSx+SVLiqM+oEHo6IBP4pM9cefcA7upDPClg9q74qJWk4q19rdQXHRdWgvjwzd0bEXOA/I2JbZv74yAOGwnstQNfpbVlznZI0ZVVa+sjMnUP/3QXcD1zUzKIkSW8bc0YdEScCJ2Tm60M//xHwd6O9pi8X0nFgTU0lSlOb3etVZenjNOD+iDh0/L9k5oNNrUqSdNiYQZ2Z24ELjkMtkqRh2IVckgrnPmpJKpxBLUmFM6glqXAGtSQVzqCWpMIZ1JJUOINakgpnUEtS4QxqSSqcQS1JhbMLuaQJa6p0i3dGLUmFqzyjjog2oAfYmZnXjHbss/PgulVNmaxPaH3L+1pdgqQJaDwz6hXA1PieIUkFqRTUEbEAuBq4s7nlSJKOVnV9Yg3wReCkkQ44ugt533MvNF7dZGNn9oljinS31sQw5ow6Iq4BdmVm72jHZebazOzKzK45M6O2AiVpqquy9HEZ8PGI2AGsA66MiO82tSpJ0mGRmdUPjvh94K/H2vXR1dWVPT09DZYmSVNHRPRmZtdwz7mPWpIKN67Nzpn5I+BHTalEkjQsZ9SSVDiDWpIKZ1BLUuEMakkqnEEtSYUzqCWpcAa1JBXOoJakwhnUklQ4g1qSCmdzW6lwU6WBq0bmjFqSCmdQS1LhxrwfdUS0Az8G3svgUsn6zPzyaK+Z0TkjP7D6A7UVKUml61ve19DrR7sfdZU16jeBKzPzjYiYDjwWEf+Rmf/TUFWSpErGDOocnHK/MfTr9KE/1dvCSJIaUmnXR0S0Ab3AB4BvZuYTwxzzdhfyM85o+GuAJGlQpZOJmTmQmYuBBcBFEXH+MMe83YV8zpy665SkKWu8rbh+FREbgaXA5pGO69v5Gh23PdBobZIKtOMrV7e6hClnzBl1RMyJiJOHfp4BfATY1uzCJEmDqsyo5wF3D61TnwDcm5k/bG5ZkqRDxtxHfSy6urqyp6en9nElabIabR+1VyZKUuEMakkqnEEtSYUzqCWpcAa1JBXOoJakwhnUklQ4g1qSCmdQS1LhDGpJKpxdyKVh2PlbJXFGLUmFq3Kb0/dHxMaIeDoitkTEiuNRmCRpUJUu5POAeZn5VEScxGBLrj/OzKdHeo1dyCVNNc3sQj7mjDozX8rMp4Z+fh3YCsxvqCJJUmXjOpkYER3AhcDozW1nBX3PvVBDeTVY/VqrK5CkhlQ+mRgR7wO+B6zMzH1HP/+O5rYzo84aJWlKqxTUETGdwZC+JzPva25JkqQjVTmZGMDdwKuZubLKoO+d98Gct3xNDeWpmewmLZWj0VZclwHLgCsjYtPQn4/VWqEkaURjnkzMzMcAF50lqUWacgn5ovmz6PFrtSTVwkvIJalwBrUkFc6glqTCGdSSVDiDWpIKZ1BLUuEMakkqnEEtSYUzqCWpcAa1JBXOLuSSxsUO7cefM2pJKtyYM+qI+DZwDbArM8+vMuiz8+C6VU2ZrI9bow0nJanVqsyo/xlY2uQ6JEkjqNKF/MfAq8ehFknSMGpbnyi3C/msVldQLju0SxNCbScT7UIuSc3hrg9JKlxTtmb05UI6DtiFvHi3PdDqCg6zI7o0sjFn1BHRDTwOnBUR/RHx580vS5J0SJUu5J86HoVIkoZnF3JJKpwnEyWpcAa1JBXOoJakwhnUklQ4g1qSCmdQS1LhDGpJKpxBLUmFM6glqXA2t5U0Lja3Pf6cUUtS4QxqSSpcpaWPiFgKfB1oA+7MzK+MdnxJXcilY2H3epWkyv2o24BvAh8FzgU+FRHnNrswSdKgKksfFwG/yMztmfkWsA74RHPLkiQdUmV9Yj7w4hG/9wO/e/RB5XYht9O2pInNLuSSVLgqQb0TeP8Rvy8YekySdBxEZo5+QMQ04OfAVQwG9JPADZm5ZaTXvHfeB3PecruQH81O25JGEhG9mdk13HNVmtv+JiJuBh5icHvet0cLaUlSvcacUR+Lrq6u7OnpqX1cSZqsRptRe2WiJBXOoJakwhnUklQ4g1qSCmdQS1LhmrLrIyJeB56pfeCJ71RgT6uLKJSfzcj8bEY2mT6b38nMOcM90ax7kT4z0jaTqSwievxchudnMzI/m5FNlc/GpQ9JKpxBLUmFa1ZQr23SuBOdn8vI/GxG5mczsinx2TTlZKIkqT4ufUhS4QxqSSpcrUEdEUsj4pmI+EVE3Fbn2BNZRLw/IjZGxNMRsSUiVrS6ptJERFtE/CQiftjqWkoSESdHxPqI2BYRWyPiklbXVIqIuHXo79PmiOiOiPZW19QstQW13cpH9RvgrzLzXOBi4HN+Nu+yAtja6iIK9HXgwcw8G7gAPyMAImI+cAvQlZnnM3iv/OtbW1Xz1Dmjtlv5CDLzpcx8aujn1xn8yza/tVWVIyIWAFcDd7a6lpJExCzgCuAugMx8KzN/1dqqijINmDHUhWom8MsW19M0dQb1cN3KDaOjREQHcCHwRGsrKcoa4IvAb1tdSGE6gd3Ad4aWhe6MiBNbXVQJMnMn8DXgBeAl4LXMfLi1VTWPJxOPo4h4H/A9YGVm7mt1PSWIiGuAXZnZ2+paCjQN+BDwrcy8EPg14LkfICJOYfAbeydwOnBiRHy6tVU1T51BbbfyUUTEdAZD+p7MvK/V9RTkMuDjEbGDweWyKyPiu60tqRj9QH9mHvr2tZ7B4Bb8IfBcZu7OzIPAfcClLa6paeoM6ieBD0ZEZ0S8h8GF/X+rcfwJKyKCwXXGrZn5j62upySZuSozF2RmB4P/z2zIzEk7MxqPzHwZeDEizhp66Crg6RaWVJIXgIsjYubQ36+rmMQnWmu7e57dykd1GbAM6IuITUOP/U1m/nsLa9LE8HngnqHJz3bgMy2upwiZ+URErAeeYnBX1U+YxJeTewm5JBXOk4mSVDiDWpIKZ1BLUuEMakkqnEEtSYUzqCWpcAa1JBXu/wFTwhodu5ebQAAAAABJRU5ErkJggg==\n",
+            "image/png": "iVBORw0KGgoAAAANSUhEUgAAAWoAAAD4CAYAAADFAawfAAAABHNCSVQICAgIfAhkiAAAAAlwSFlzAAALEgAACxIB0t1+/AAAADh0RVh0U29mdHdhcmUAbWF0cGxvdGxpYiB2ZXJzaW9uMy4yLjIsIGh0dHA6Ly9tYXRwbG90bGliLm9yZy+WH4yJAAARiUlEQVR4nO3dfYxc1XnH8e/D2snaBBlkbGTs0F0r4d3CxBvKW1ELTeUElJSmQgTFuFHbCCkEm7RKcP9oTKVKoYkqR0oU1YKkSKHrIgeSKrRAVTsEVIrYJU7WxiYKxsA6gF9oMKQ2OJunf+zaGLMvdz13PGd3vx/JYnfmzplHI/zzmXPPvU9kJpKkcp3Q6gIkSaMzqCWpcAa1JBXOoJakwhnUklS4ac0Y9NRTT82Ojo5mDC1Jk1Jvb++ezJwz3HNNCeqOjg56enqaMbQkTUoR8fxIz7n0IUmFM6glqXAGtSQVrilr1JJ0vB08eJD+/n4OHDjQ6lJG1d7ezoIFC5g+fXrl1zQlqA9s3sLWs89pxtCSdNg527Ye/rm/v5+TTjqJjo4OIqKFVY0sM9m7dy/9/f10dnZWfp1LH5ImhQMHDjB79uxiQxogIpg9e/a4Z/2VgjoiVkTE5ojYEhErj6lCSWqykkP6kGOpccylj4g4H/hL4CLgLeDBiPhhZv5ipNc8Ow+uW+Xy99H6lve1ugRJE1CVND0HeCIz/w8gIh4B/gT4h2YWJkmN6LjtgVrH2/GVqysd9/3vf59rr72WrVu3cvbZZ9fy3lWCejPw9xExG9gPfAx412WHEfFZ4LMAZ8wK+p57oZYCJ5XVs1pdgapa/VqrK9AE1d3dzeWXX053dze33357LWOOuUadmVuBO4CHgQeBTcDAMMetzcyuzOyaM7P8dSJJqtsbb7zBY489xl133cW6detqG7fSycTMvCszl2TmFcD/Aj+vrQJJmiR+8IMfsHTpUs4880xmz55Nb29vLeNWOuMXEXMzc1dEnMHg+vTFox3flwvpOLCmjvo0RVRd/5NK1t3dzYoVKwC4/vrr6e7uZsmSJQ2PW3VrxveG1qgPAp/LzF81/M6SNIm8+uqrbNiwgb6+PiKCgYEBIoKvfvWrDW8brLr08XuZeW5mXpCZ/9XQO0rSJLR+/XqWLVvG888/z44dO3jxxRfp7Ozk0UcfbXjspmx2XjR/Fj1+lZXUQsd7Oa27u5svfelL73jsk5/8JN3d3VxxxRUNje1VKZJUg40bN77rsVtuuaWWsb3XhyQVzqCWpMIZ1JJUOINakgpnUEtS4QxqSSqc2/MkTU51362ywh0V29raWLRoEZlJW1sb3/jGN7j00ksbfmuDWpJqMmPGDDZt2gTAQw89xKpVq3jkkUcaHtelD0lqgn379nHKKafUMpZdyKXCHdlpW2Xbv38/ixcv5sCBA7z00kts2LChlnFd+pCkmhy59PH4449z4403snnz5obvnlf1ftS3An8BJNAHfCYzR+x3bnNbqUZ3L2p1BRPCmnPX8Ns9vz38+3k1j79lz5ZRnz/v1He+4yWXXMKePXvYvXs3c+fObei9x1yjjoj5wC1AV2aeD7QB1zf0rpI0yW3bto2BgQFmz57d8FhVp73TgBkRcRCYCfyy4XeWpCbacvN/H/f3PLRGDZCZ3H333bS1tTU87phBnZk7I+JrwAsMdiF/ODMfPvo4u5BrUrEL+YSzdetWzjm1tZsYBgbe1fe7FlWWPk4BPgF0AqcDJ0bEp48+zi7kktQcVfZR/yHwXGbuzsyDwH1A45faSJIqqbJG/QJwcUTMZHDp4yqgZ7QX2IVcE92OVhcgHWHMGXVmPgGsB55icGveCcDaJtclSRpSaddHZn4Z+HLVQW1uK0n18V4fklQ4Lx+UNCktqvmKzr7lfWMe8/LLL7Ny5UqefPJJTj75ZE477TTWrFnDmWee2dB7G9SSVIPM5Nprr2X58uWsW7cOgJ/+9Ke88sorBrUklWDjxo1Mnz6dm2666fBjF1xwQS1ju0YtSTXYvHkzS5YsacrYBrUkFc6glqQanHfeefT29jZlbINakmpw5ZVX8uabb7J27dvXA/7sZz/j0UcfbXhsTyZKmpSqbKerU0Rw//33s3LlSu644w7a29vp6OhgzZrGb6dhUEtSTU4//XTuvffe2se1ua2kCWuqNP51jVqSCmdQS1Lhxlz6iIizgH894qGFwN9m5ogr5O3nn8c5PaPeslqSVFGVnonPAIsBIqIN2Anc3+S6JElDxrv0cRXwbGY+34xiJEnvNt5dH9cD3cM98Y4u5Gec0WBZktSYuneeVdlh0tbWxqJFizh48CDTpk3jxhtv5NZbb+WEExo7HVg5qCPiPcDHgVXDPZ+Zaxlq0dXV1ZUNVSVJE9CMGTPYtGkTALt27eKGG25g37593H777Q2NO54Z9UeBpzLzlbEO7Nv5Gh23PXDsVUk6bIdt7SakuXPnsnbtWj784Q+zevVqIuKYxxrPfPxTjLDsIUl6t4ULFzIwMMCuXbsaGqdSUEfEicBHgPsaejdJ0rhV7UL+a2B21UHtQi5JsH37dtra2pg7d25D43hloiQ1we7du7npppu4+eabG1qfBu+eJ2mSasUNm/bv38/ixYsPb89btmwZX/jCFxoe16CWpJoMDAw0ZVyXPiSpcAa1JBXOoJY0aWSWf1H0sdRoUEuaFNrb29m7d2/RYZ2Z7N27l/b29nG9zpOJkiaFBQsW0N/fz+7du1tdyqja29tZsGDBuF5jUEuaFKZPn05nZ2ery2gKlz4kqXB2IZc0LlOl83dJnFFLUuGq3j3v5IhYHxHbImJrRFzS7MIkSYOqLn18HXgwM/90qNPLzNEOfnYeXLfK85TSZNTX6gKmoDHTNCJmAVcAfwaQmW8BbzW3LEnSIVWmvZ3AbuA7EXEB0AusGLpH9WFHN7ftW+6/u5JUhypr1NOADwHfyswLgV8Dtx19UGauzcyuzOyaM2dOzWVK0tRVJaj7gf7MfGLo9/UMBrck6TgYc+kjM1+OiBcj4qzMfAa4Cnh6tNfYhXx4dpOWdCyqbs34PHDP0I6P7cBnmleSJOlIVZvbbgK6mlyLJGkYTdnsbBdySaqPl5BLUuEMakkqnEEtSYUzqCWpcAa1JBXOoJakwhnUklQ4g1qSCmdQS1LhDGpJKpxdyKVh2GlbJXFGLUmFqzSjjogdwOvAAPCbzBz1Tnrt55/HOT09jVcnSRrX0scfZOaeplUiSRqWSx+SVLiqM+oEHo6IBP4pM9cefcA7upDPClg9q74qJWk4q19rdQXHRdWgvjwzd0bEXOA/I2JbZv74yAOGwnstQNfpbVlznZI0ZVVa+sjMnUP/3QXcD1zUzKIkSW8bc0YdEScCJ2Tm60M//xHwd6O9pi8X0nFgTU0lSlOb3etVZenjNOD+iDh0/L9k5oNNrUqSdNiYQZ2Z24ELjkMtkqRh2IVckgrnPmpJKpxBLUmFM6glqXAGtSQVzqCWpMIZ1JJUOINakgpnUEtS4QxqSSqcQS1JhbMLuaQJa6p0i3dGLUmFqzyjjog2oAfYmZnXjHbss/PgulVNmaxPaH3L+1pdgqQJaDwz6hXA1PieIUkFqRTUEbEAuBq4s7nlSJKOVnV9Yg3wReCkkQ44ugt533MvNF7dZGNn9oljinS31sQw5ow6Iq4BdmVm72jHZebazOzKzK45M6O2AiVpqquy9HEZ8PGI2AGsA66MiO82tSpJ0mGRmdUPjvh94K/H2vXR1dWVPT09DZYmSVNHRPRmZtdwz7mPWpIKN67Nzpn5I+BHTalEkjQsZ9SSVDiDWpIKZ1BLUuEMakkqnEEtSYUzqCWpcAa1JBXOoJakwhnUklQ4g1qSCmdzW6lwU6WBq0bmjFqSCmdQS1LhxrwfdUS0Az8G3svgUsn6zPzyaK+Z0TkjP7D6A7UVKUml61ve19DrR7sfdZU16jeBKzPzjYiYDjwWEf+Rmf/TUFWSpErGDOocnHK/MfTr9KE/1dvCSJIaUmnXR0S0Ab3AB4BvZuYTwxzzdhfyM85o+GuAJGlQpZOJmTmQmYuBBcBFEXH+MMe83YV8zpy665SkKWu8rbh+FREbgaXA5pGO69v5Gh23PdBobZIKtOMrV7e6hClnzBl1RMyJiJOHfp4BfATY1uzCJEmDqsyo5wF3D61TnwDcm5k/bG5ZkqRDxtxHfSy6urqyp6en9nElabIabR+1VyZKUuEMakkqnEEtSYUzqCWpcAa1JBXOoJakwhnUklQ4g1qSCmdQS1LhDGpJKpxdyKVh2PlbJXFGLUmFq3Kb0/dHxMaIeDoitkTEiuNRmCRpUJUu5POAeZn5VEScxGBLrj/OzKdHeo1dyCVNNc3sQj7mjDozX8rMp4Z+fh3YCsxvqCJJUmXjOpkYER3AhcDozW1nBX3PvVBDeTVY/VqrK5CkhlQ+mRgR7wO+B6zMzH1HP/+O5rYzo84aJWlKqxTUETGdwZC+JzPva25JkqQjVTmZGMDdwKuZubLKoO+d98Gct3xNDeWpmewmLZWj0VZclwHLgCsjYtPQn4/VWqEkaURjnkzMzMcAF50lqUWacgn5ovmz6PFrtSTVwkvIJalwBrUkFc6glqTCGdSSVDiDWpIKZ1BLUuEMakkqnEEtSYUzqCWpcAa1JBXOLuSSxsUO7cefM2pJKtyYM+qI+DZwDbArM8+vMuiz8+C6VU2ZrI9bow0nJanVqsyo/xlY2uQ6JEkjqNKF/MfAq8ehFknSMGpbnyi3C/msVldQLju0SxNCbScT7UIuSc3hrg9JKlxTtmb05UI6DtiFvHi3PdDqCg6zI7o0sjFn1BHRDTwOnBUR/RHx580vS5J0SJUu5J86HoVIkoZnF3JJKpwnEyWpcAa1JBXOoJakwhnUklQ4g1qSCmdQS1LhDGpJKpxBLUmFM6glqXA2t5U0Lja3Pf6cUUtS4QxqSSpcpaWPiFgKfB1oA+7MzK+MdnxJXcilY2H3epWkyv2o24BvAh8FzgU+FRHnNrswSdKgKksfFwG/yMztmfkWsA74RHPLkiQdUmV9Yj7w4hG/9wO/e/RB5XYht9O2pInNLuSSVLgqQb0TeP8Rvy8YekySdBxEZo5+QMQ04OfAVQwG9JPADZm5ZaTXvHfeB3PecruQH81O25JGEhG9mdk13HNVmtv+JiJuBh5icHvet0cLaUlSvcacUR+Lrq6u7OnpqX1cSZqsRptRe2WiJBXOoJakwhnUklQ4g1qSCmdQS1LhmrLrIyJeB56pfeCJ71RgT6uLKJSfzcj8bEY2mT6b38nMOcM90ax7kT4z0jaTqSwievxchudnMzI/m5FNlc/GpQ9JKpxBLUmFa1ZQr23SuBOdn8vI/GxG5mczsinx2TTlZKIkqT4ufUhS4QxqSSpcrUEdEUsj4pmI+EVE3Fbn2BNZRLw/IjZGxNMRsSUiVrS6ptJERFtE/CQiftjqWkoSESdHxPqI2BYRWyPiklbXVIqIuHXo79PmiOiOiPZW19QstQW13cpH9RvgrzLzXOBi4HN+Nu+yAtja6iIK9HXgwcw8G7gAPyMAImI+cAvQlZnnM3iv/OtbW1Xz1Dmjtlv5CDLzpcx8aujn1xn8yza/tVWVIyIWAFcDd7a6lpJExCzgCuAugMx8KzN/1dqqijINmDHUhWom8MsW19M0dQb1cN3KDaOjREQHcCHwRGsrKcoa4IvAb1tdSGE6gd3Ad4aWhe6MiBNbXVQJMnMn8DXgBeAl4LXMfLi1VTWPJxOPo4h4H/A9YGVm7mt1PSWIiGuAXZnZ2+paCjQN+BDwrcy8EPg14LkfICJOYfAbeydwOnBiRHy6tVU1T51BbbfyUUTEdAZD+p7MvK/V9RTkMuDjEbGDweWyKyPiu60tqRj9QH9mHvr2tZ7B4Bb8IfBcZu7OzIPAfcClLa6paeoM6ieBD0ZEZ0S8h8GF/X+rcfwJKyKCwXXGrZn5j62upySZuSozF2RmB4P/z2zIzEk7MxqPzHwZeDEizhp66Crg6RaWVJIXgIsjYubQ36+rmMQnWmu7e57dykd1GbAM6IuITUOP/U1m/nsLa9LE8HngnqHJz3bgMy2upwiZ+URErAeeYnBX1U+YxJeTewm5JBXOk4mSVDiDWpIKZ1BLUuEMakkqnEEtSYUzqCWpcAa1JBXu/wFTwhodu5ebQAAAAABJRU5ErkJggg==",
             "text/plain": [
               "<Figure size 432x288 with 1 Axes>"
             ]
           },
           "metadata": {
             "needs_background": "light"
-          }
+          },
+          "output_type": "display_data"
         }
+      ],
+      "source": [
+        "df = pd.DataFrame(np.random.randint(10, size=(10,4)), columns=list(\"ABCD\"))\n",
+        "\n",
+        "df.plot.barh()\n",
+        "plt.show()\n"
       ]
     },
     {
@@ -5703,34 +5680,34 @@
     },
     {
       "cell_type": "code",
+      "execution_count": 96,
       "metadata": {
         "colab": {
           "base_uri": "https://localhost:8080/",
           "height": 265
         },
         "id": "wA-yL5Un-eLF",
-        "outputId": "9315be28-9042-4d3f-dc51-1b3afa03d90e"
+        "outputId": "6b7f08c6-8f8b-4899-929f-897469f2fb55"
       },
-      "source": [
-        "df = pd.DataFrame(np.random.randint(10, size=(10,4)), columns=list(\"ABCD\"))\n",
-        "\n",
-        "df.plot.box()\n",
-        "plt.show()"
-      ],
-      "execution_count": 442,
       "outputs": [
         {
-          "output_type": "display_data",
           "data": {
-            "image/png": "iVBORw0KGgoAAAANSUhEUgAAAWoAAAD4CAYAAADFAawfAAAABHNCSVQICAgIfAhkiAAAAAlwSFlzAAALEgAACxIB0t1+/AAAADh0RVh0U29mdHdhcmUAbWF0cGxvdGxpYiB2ZXJzaW9uMy4yLjIsIGh0dHA6Ly9tYXRwbG90bGliLm9yZy+WH4yJAAAMNUlEQVR4nO3dfWhddx3H8c/HNGrGYlVaUbdlmeDDldb6cPFh1odsMqcTp7A/VpioFPLX6pShiwYp+yPQgYhSBQlWqdtMxW1/iB1aYRWtyrDZVrC7Kjo7nU+rorVKy7Lx9Y+bdlmXLSfJOTnfc+/7BYXk3svZt4fT9w6/e+49jggBAPJ6Tt0DAACeHaEGgOQINQAkR6gBIDlCDQDJratioxs2bIjR0dEqNg0APWl2dvYfEbFxsecqCfXo6KgOHz5cxaYBoCfZfviZnmPpAwCSI9QAkByhBoDkCDUAJEeoASA5Qg0AyRFqAEiOUANAcpV84KVutkvdXr9/Zzf7szzsS6xET55RR8SSfy6+6fuFXsc/BPZnmYruo6L7E/2hJ0MNAL2EUANAcoQaAJIj1ACQHKEGgOQINQAkR6gBIDlCDQDJEWoASI5QA0ByhBoAkiPUAJAcoQaA5Ag1ACRHqAEgOUINAMkRagBIrlCobX/K9lHbv7I9Y/v5VQ8GAKs1MzOjTZs2aWBgQJs2bdLMzEzdI63IkqG2fYGkT0hqR8QmSQOSrq16MABYjZmZGU1OTmr37t06ffq0du/ercnJyUbGuujSxzpJQ7bXSTpP0l+qGwkAVm9qakp79uzR2NiYBgcHNTY2pj179mhqaqru0ZZtybuQR8SfbX9B0h8lnZJ0ICIOnPs62+OSxiVpZGSk7DnP2nLzAZ04NVfKtkYn9peynfVDgzqy84pStgWgHJ1OR1u3bn3KY1u3blWn06lpopVbMtS2XyTpakmXSPq3pO/avi4iblv4uoiYljQtSe12u7LbI584Nadju66qavMrUlbwAZSn1Wrp0KFDGhsbO/vYoUOH1Gq1apxqZYosfbxH0h8i4nhEzEm6S9Kl1Y4FAKszOTmp7du36+DBg5qbm9PBgwe1fft2TU5O1j3asi15Rq3uksdbbZ+n7tLH5ZIOVzoVAKzStm3bJEk7duxQp9NRq9XS1NTU2cebpMga9b2275B0n6THJd2v+SUOAMhs27ZtjQzzuYqcUSsidkraWfEsAIBFFAo1gKWVeUWSxFVJeBKhBkqS8YokiauSegHf9QEAyRFqAEiOUANAcoQaAJIj1ACQHKEGgOQINQAkR6gBIDlCDQDJEWoASI5QA0ByhBoAkiPUAJAcoQaA5Ag1ACRHqAEgOUINAMkRagBIjlADQHKEGgCSI9QAkByhBoDkCDUAJEeoASA5Qg0AyRFqAEiOUANAcoQaAJIj1ACQHKEGgOQINQAkR6gBIDlCDQDJFQq17RfavsP2r213bL+t6sEAAF3rCr7uy5J+EBHX2H6upPMqnAkAsMCSoba9XtI7JX1MkiLiMUmPVTsWAOCMImfUl0g6LumbtrdImpV0Q0T8b+GLbI9LGpekkZGRsuc8a7g1oc17Jyrb/koMtyTpqrrHWLYtNx/QiVNzpW1vdGJ/KdtZPzSoIzuvKGVbQC8oEup1kt4oaUdE3Gv7y5ImJH1+4YsiYlrStCS12+0oe9AzTnZ26diuXFEsK1Br7cSpuXT7Umru/gSqUuTNxEckPRIR987/foe64QYArIElQx0Rf5P0J9uvnn/ockkPVjoVAOCsold97JB0+/wVHw9J+nh1IwEAFioU6oh4QFK74lkAAIvgk4kAkByhBoDkCDUAJEeoASA5Qg0AyRFqAEiOUANAcoQaAJIj1ACQHKEGgOQINQAkR6gBIDlCDQDJEWoASI5QA0ByhBoAkit6hxcASxhuTWjz3om6x3ia4ZYk5buJMYoj1EBJTnZ2cVd3VIKlDwBIjlADQHKEGgCSI9QAkByhBoDkCDUAJEeoASA5Qg0AyRFqAEiOUANAcoQaAJIj1ACQHKEGgOQINQAkR6gBIDlCDQDJEWoASK5wqG0P2L7f9verHAgA8FTLOaO+QVKnqkEAAIsrFGrbF6p7d8yvVzsOAOBcRW9u+yVJn5E0/EwvsD0uaVySRkZGVj/Zs8h2s871Q4N1j4Aksh2bUm8fn7ZL3V5ElLq9siwZatsfkPRoRMzafvczvS4ipiVNS1K73a7sb1vWXZ5HJ/anvGM0mqvM44njs5iiYW36/iyy9PF2SR+0fUzSPkmX2b6t0qkAAGctGeqI+GxEXBgRo5KulXRPRFxX+WQAAElcRw0A6RV9M1GSFBE/lvTjSiYBACyKM2oASI5QA0ByhBoAkiPUAJAcoQaA5JZ11Qd6y3BrQpv3TtQ9xtMMt6TuV8sAkAh1XzvZ2ZXyY7UZvy8DqBNLHwCQHKEGgOQINQAkR6gBIDlCDQDJEWoASI5QA0ByhBoAkiPUAJAcn0wEkNKWmw/oxKm50rZXxide1w8N6sjOK0qYZnkINYCUTpyaS/cVB3V9vQFLHwCQHKEGgOQINQAkR6gBIDlCDQDJEWoASI5QA0ByhBoAkiPUAJAcn0wEkNJwa0Kb907UPcZTDLckae0/LUmoAaR0srOLj5DPY+kDAJIj1ACQHKEGgORYo+5zda25PZv1Q4N1jwCkQqj7WJlv1IxO7E/3xg/QK1j6AIDklgy17YtsH7T9oO2jtm9Yi8EAAF1Flj4el3RjRNxne1jSrO0fRcSDFc8GAFCBM+qI+GtE3Df/80lJHUkXVD0YAKBrWWvUtkclvUHSvYs8N277sO3Dx48fL2c6AEDxUNs+X9Kdkj4ZEf859/mImI6IdkS0N27cWOaMANDXCoXa9qC6kb49Iu6qdiQAwEJFrvqwpD2SOhHxxepHAgAsVOSM+u2SPiLpMtsPzP95f8VzAQDmLXl5XkQckuQ1mAUAsAg+mQgAyRFqAEiOUANAcoQaAJIj1ACQHKEGgOQINQAkR6gBIDlCDQDJEWoASI5QA0ByhBoAkiPUAJAcoQaA5Ag1ACRHqAEguSVvHNBE3buHFXjdLcW2FxGrmKb52J9AvXoy1ISgXOxPoF4sfQBAcoQaAJIj1ACQHKEGgOQINQAkR6gBIDlCDQDJEWoASI5QA0ByhBoAkiPUAJAcoQaA5Ag1ACRHqAEguZ78mlMAvWF0Yn/dIzzF+qHBWv67hBpASsd2XVXatkYn9pe6vbXG0gcAJFco1LavtP0b27+zPVH1UACAJy0ZatsDkr4q6X2SXitpm+3XVj0YAKCryBn1myX9LiIeiojHJO2TdHW1YwEAzijyZuIFkv604PdHJL3l3BfZHpc0LkkjIyOlDAf0mqJ3dJeK3dW932883C/7s7SrPiJiWtK0JLXb7Zx/W6BmWUPQVP2yP4ssffxZ0kULfr9w/jEAwBooEupfSnql7UtsP1fStZK+V+1YAIAzllz6iIjHbV8v6YeSBiR9IyKOVj4ZAEBSwTXqiLhb0t0VzwIAWASfTASA5Ag1ACRHqAEgOUINAMm5igvGbR+X9HDpGy7XBkn/qHuIHsL+LBf7s1xN2J8XR8TGxZ6oJNRNYPtwRLTrnqNXsD/Lxf4sV9P3J0sfAJAcoQaA5Po51NN1D9Bj2J/lYn+Wq9H7s2/XqAGgKfr5jBoAGoFQA0ByfRlq2x+yHbZfU/csTWf7CdsP2D5i+z7bl9Y9U5PZfqntfbZ/b3vW9t22X1X3XE204Ng8On983mi7kc3ryzVq29+R9HJJ90TEzrrnaTLb/42I8+d/fq+kz0XEu2oeq5Hcva/UzyXtjYivzT+2RdILIuKntQ7XQOccmy+R9G1JP2viv/lG/t9lNWyfL2mrpO3q3gQB5XmBpH/VPUSDjUmaOxNpSYqII0R69SLiUXXv6Xq9l3OjxSRKu2dig1wt6QcR8Vvb/7T9poiYrXuoBhuy/YCk50t6maTLap6nyTZJ4lisSEQ8ZHtA0ksk/b3ueZaj786oJW2TtG/+533zv2PlTkXE6yPiNZKulPStJp6xAJn11Rm17Rere8a32Xaoe2uxsP3p6MfF+pJFxC9sb5C0UdKjdc/TQEclXVP3EL3K9iskPaEGHpv9dkZ9jaRbI+LiiBiNiIsk/UHSO2qeqyfMX0UzIOmfdc/SUPdIep7t8TMP2H6dbY7PVbK9UdLXJH2liSdlfXVGre4yxy3nPHbn/OM/WftxesKZNWpJsqSPRsQTdQ7UVBERtj8s6Uu2b5J0WtIxSZ+sdbDmOnNsDkp6XNKtkr5Y70gr05eX5wFAk/Tb0gcANA6hBoDkCDUAJEeoASA5Qg0AyRFqAEiOUANAcv8H00JLC4Lrl6MAAAAASUVORK5CYII=\n",
+            "image/png": "iVBORw0KGgoAAAANSUhEUgAAAWoAAAD4CAYAAADFAawfAAAABHNCSVQICAgIfAhkiAAAAAlwSFlzAAALEgAACxIB0t1+/AAAADh0RVh0U29mdHdhcmUAbWF0cGxvdGxpYiB2ZXJzaW9uMy4yLjIsIGh0dHA6Ly9tYXRwbG90bGliLm9yZy+WH4yJAAAMLklEQVR4nO3dfYgcdx3H8c/Hy2lTekYlKWrb61XwYUtifFh8aOPDVanVilXoHw0oKoH7q7GVoq4eEvrHQQQRSxTkMEqsehHb/iGm1AiNaFSKuZiA6apoTW3rQ6NojJLSa/n6x23Sa3rtzeVmMt/Zfb+gkNtbpl+m03eG387sOCIEAMjreXUPAAB4boQaAJIj1ACQHKEGgOQINQAkt6qKja5duzbGxsaq2DQA9KXZ2dl/RMS6xX5XSajHxsZ04MCBKjYNAH3J9oPP9juWPgAgOUINAMkRagBIjlADQHKEGgCSI9QAkByhBoDkCDUAJFfJDS91G+vsKXV7R7dfW+r2mob9WR72Jc6Gq3hwQLvdjux3Jo519nCQl4j9WS725+CxPRsR7cV+x9IHACRHqAEgOUINAMkRagBIjlADQHKEGgCSI9QAkByhBoDkCDUAJEeoASA5Qg0AyRFqAEiOUANAcoQaAJIj1ACQHKEGgOQINQAkVyjUtj9p+4jt39iesX1e1YMBwErNzMxo/fr1Ghoa0vr16zUzM1P3SGdlyVDbvkjSJyS1I2K9pCFJN1Q9GACsxMzMjCYnJ7Vjxw499thj2rFjhyYnJxsZ66JLH6skrba9StL5kv5S3UgAsHJTU1PauXOnxsfHNTw8rPHxce3cuVNTU1N1j7ZsSz6FPCIesf1FSX+WdFLS3ojYe+b7bE9ImpCk0dHRsuc8beOte3X85Fwp2yrridBrVg/r8LarS9kWgHJ0u11t2rTpaa9t2rRJ3W63ponO3pKhtv1iSddJukzSvyV93/aHI+LbC98XEdOSpqX5p5BXMKsk6fjJuXRPZy4r+ADK02q1tH//fo2Pj59+bf/+/Wq1WjVOdXaKLH28W9KfIuJYRMxJukvSFdWOBQArMzk5qS1btmjfvn2am5vTvn37tGXLFk1OTtY92rIteUat+SWPt9g+X/NLH++SdKDSqQBghTZv3ixJ2rp1q7rdrlqtlqampk6/3iRF1qjvs32HpIOSnpD0a/WWOAAgs82bNzcyzGcqckatiNgmaVvFswAAFlEo1ACWVuYVSRJXJeEphBooScYrkiSuSuoHfNcHACRHqAEgOUINAMkRagBIjlADQHKEGgCSI9QAkByhBoDkCDUAJEeoASA5Qg0AyRFqAEiOUANAcoQaAJIj1ACQHKEGgOQINQAkR6gBIDlCDQDJEWoASI5QA0ByhBoAkiPUAJAcoQaA5Ag1ACRHqAEgOUINAMkRagBIjlADQHKEGgCSI9QAkByhBoDkCDUAJFco1LZfZPsO27+13bX91qoHAwDMW1XwfbdJuicirrf9fEnnVzgTAGCBJUNte42kt0v6mCRFxOOSHq92LADAKUXOqC+TdEzSN21vlDQr6aaI+N/CN9mekDQhSaOjo2XPedpIq6MNuzqVbf9sjLQk6dq6x1i2jbfu1fGTc6Vtb6yzp5TtrFk9rMPbri5lW0A/KBLqVZLeIGlrRNxn+zZJHUmfX/imiJiWNC1J7XY7yh70lBPd7Tq6PVcUywrUuXb85Fy6fSk1d38CVSnyYeLDkh6OiPt6P9+h+XADAM6BJUMdEX+T9JDtV/deepek+yudCgBwWtGrPrZK+k7vio8HJH28upEAAAsVCnVEHJLUrngWAMAiuDMRAJIj1ACQHKEGgOQINQAkR6gBIDlCDQDJEWoASI5QA0ByhBoAkiPUAJAcoQaA5Ag1ACRHqAEgOUINAMkRagBIjlADQHJFn/ACYAkjrY427OrUPcYzjLQkKd9DjFEcoQZKcqK7nae6oxIsfQBAcoQaAJIj1ACQHKEGgOQINQAkR6gBIDlCDQDJEWoASI5QA0ByhBoAkiPUAJAcoQaA5Ag1ACRHqAEgOUINAMkRagBIjlADQHKFQ217yPavbf+wyoEAAE+3nDPqmyR1qxoEALC4QqG2fbHmn4759WrHAQCcqejDbb8s6dOSRp7tDbYnJE1I0ujo6Monew7ZHta5ZvVw3SMgiWzHptTfx2fZ+zvjw4mlAqG2/X5Jj0bErO13Ptv7ImJa0rQktdvtKG3CM5S1I8c6e9L+R0EzlXk8cXwWU3QfNX1/Fln6uFLSB2wflbRb0lW2v13pVACA05YMdUR8NiIujogxSTdIujciPlz5ZAAASVxHDQDpFf0wUZIUET+R9JNKJgEALIozagBIjlADQHKEGgCSI9QAkByhBoDklnXVB/rLSKujDbs6dY/xDCMtaf6rZQBIhHqgnehuT3lbbcbvywDqxNIHACRHqAEgOUINAMkRagBIjlADQHKEGgCSI9QAkByhBoDkCDUAJMediQBS2njrXh0/OVfa9sq443XN6mEd3nZ1CdMsD6EGkNLxk3PpvuKgrq83YOkDAJIj1ACQHKEGgOQINQAkR6gBIDlCDQDJEWoASI5QA0ByhBoAkuPORAApjbQ62rCrU/cYTzPSkqRzf7ckoQaQ0onudm4h72HpAwCSI9QAkByhBoDkWKMecHWtuT2XNauH6x4BSIVQD7AyP6gZ6+xJ98EP0C9Y+gCA5JYMte1LbO+zfb/tI7ZvOheDAQDmFVn6eELSLRFx0PaIpFnbP46I+yueDQCgAmfUEfHXiDjY+/MJSV1JF1U9GABg3rLWqG2PSXq9pPsW+d2E7QO2Dxw7dqyc6QAAxUNt+wJJd0q6OSL+c+bvI2I6ItoR0V63bl2ZMwLAQCsUatvDmo/0dyLirmpHAgAsVOSqD0vaKakbEV+qfiQAwEJFzqivlPQRSVfZPtT7530VzwUA6Fny8ryI2C/J52AWAMAiuDMRAJIj1ACQHKEGgOQINQAkR6gBIDlCDQDJEWoASI5QA0ByhBoAkiPUAJAcoQaA5Ag1ACRHqAEgOUINAMkRagBIjlADQHJLPjigicY6e0p939Ht165knMZjfwL16stQE4JysT+BerH0AQDJEWoASI5QA0ByhBoAkiPUAJAcoQaA5Ag1ACRHqAEgOUINAMkRagBIjlADQHKEGgCSI9QAkByhBoDk+vJrTgH0h6LfcX6urFk9XMu/l1ADSKnM70Ef6+xp9Peqs/QBAMkVCrXta2z/zvYfbHeqHgoA8JQlQ217SNJXJb1X0uWSNtu+vOrBAADzipxRv0nSHyLigYh4XNJuSddVOxYA4JQiHyZeJOmhBT8/LOnNZ77J9oSkCUkaHR0tZTig3yznKoYi723yB2RlGJT9WdpVHxExLWlaktrtdpS1XaCfZA1BUw3K/iyy9PGIpEsW/Hxx7zUAwDlQJNS/kvRK25fZfr6kGyT9oNqxAACnLLn0ERFP2L5R0o8kDUn6RkQcqXwyAICkgmvUEXG3pLsrngUAsAjuTASA5Ag1ACRHqAEgOUINAMk5ovx7U2wfk/Rg6Rsu11pJ/6h7iD7C/iwX+7NcTdifl0bEusV+UUmom8D2gYho1z1Hv2B/lov9Wa6m70+WPgAgOUINAMkNcqin6x6gz7A/y8X+LFej9+fArlEDQFMM8hk1ADQCoQaA5AYy1LY/aDtsv6buWZrO9pO2D9k+bPug7SvqnqnJbL/U9m7bf7Q9a/tu26+qe64mWnBsHukdn7fYbmTzBnKN2vb3JL1c0r0Rsa3ueZrM9n8j4oLen98j6XMR8Y6ax2ok25b0C0m7IuJrvdc2SnphRPys1uEa6Ixj80JJ35X08yb+P9/Iv11WwvYFkjZJ2qL5hyCgPC+U9K+6h2iwcUlzpyItSRFxmEivXEQ8qvlnut7Y+wuxUUp7ZmKDXCfpnoj4ve1/2n5jRMzWPVSDrbZ9SNJ5kl4m6aqa52my9ZI4FisSEQ/YHpJ0oaS/1z3PcgzcGbWkzZJ29/68u/czzt7JiHhdRLxG0jWSvtXEMxYgs4E6o7b9Es2f8W2wHZp/tFjY/lQM4mJ9ySLil7bXSlon6dG652mgI5Kur3uIfmX7FZKeVAOPzUE7o75e0u0RcWlEjEXEJZL+JOltNc/VF3pX0QxJ+mfdszTUvZJeYHvi1Au2X2ub43OFbK+T9DVJX2niSdlAnVFrfpnjC2e8dmfv9Z+e+3H6wqk1akmypI9GxJN1DtRUERG2PyTpy7Y/I+kxSUcl3VzrYM116tgclvSEpNslfanekc7OQF6eBwBNMmhLHwDQOIQaAJIj1ACQHKEGgOQINQAkR6gBIDlCDQDJ/R/Hgq1fz4P+kAAAAABJRU5ErkJggg==",
             "text/plain": [
               "<Figure size 432x288 with 1 Axes>"
             ]
           },
           "metadata": {
             "needs_background": "light"
-          }
+          },
+          "output_type": "display_data"
         }
+      ],
+      "source": [
+        "df = pd.DataFrame(np.random.randint(10, size=(10,4)), columns=list(\"ABCD\"))\n",
+        "\n",
+        "df.plot.box()\n",
+        "plt.show()"
       ]
     },
     {
@@ -5744,34 +5721,34 @@
     },
     {
       "cell_type": "code",
+      "execution_count": 97,
       "metadata": {
         "colab": {
           "base_uri": "https://localhost:8080/",
           "height": 265
         },
         "id": "sQMB0FwU-h_n",
-        "outputId": "92ae8535-173d-40e1-d67d-c60f6c738f98"
+        "outputId": "bd7f32a5-fb40-40db-8abe-f918cea7b756"
       },
-      "source": [
-        "df = pd.DataFrame(np.random.randint(10, size=(10,4)), columns=list(\"ABCD\"))\n",
-        "\n",
-        "df.plot.density()\n",
-        "plt.show()"
-      ],
-      "execution_count": 443,
       "outputs": [
         {
-          "output_type": "display_data",
           "data": {
-            "image/png": "iVBORw0KGgoAAAANSUhEUgAAAYgAAAD4CAYAAAD2FnFTAAAABHNCSVQICAgIfAhkiAAAAAlwSFlzAAALEgAACxIB0t1+/AAAADh0RVh0U29mdHdhcmUAbWF0cGxvdGxpYiB2ZXJzaW9uMy4yLjIsIGh0dHA6Ly9tYXRwbG90bGliLm9yZy+WH4yJAAAgAElEQVR4nOzdd1yV1R/A8c/hshEQUEQZoijiHuAq995bc2tppmY2bNcv21pmZaU5slzlyL23qeXGrYiCslSGoAgCss7vjwfNQcq4l3vR8369eAHPPc95vrdX8r3POc/5HiGlRFEURVEeZGbsABRFURTTpBKEoiiKkiuVIBRFUZRcqQShKIqi5EolCEVRFCVX5sYOQF9KlSolvb29jR2GoihKsRIYGHhNSlk6t9eemATh7e3NkSNHjB2GoihKsSKECP+v19QQk6IoipIrlSAURVGUXBk0QQghOgghgoUQIUKId3N5vZkQ4qgQIlMI0eeB17yEEFuFEEFCiLNCCG9DxqooiqLcz2BzEEIIHTAdaAtEAYeFEGullGfvaRYBDAfezKWLBcAXUsptQogSQLahYlUURSmojIwMoqKiSEtLM3Yoj2RtbY2HhwcWFhZ5PseQk9QNgBAp5UUAIcQSoDtwN0FIKcNyXrvvj78QohpgLqXcltMu2YBxKoqiFFhUVBT29vZ4e3sjhDB2OLmSUhIfH09UVBQVKlTI83mGHGJyByLv+T0q51he+AI3hBArhRDHhBBTcu5IFEVRTEpaWhouLi4mmxwAhBC4uLjk+y7HVCepzYGmaENP9YGKaENR9xFCjBJCHBFCHImLiyvaCBVFUXKYcnK4oyAxGnKI6TLgec/vHjnH8iIKOH7P8NRqoBEw995GUsrZwGyAgIAAVbf8aZeZDhH7IPo0ZKaCfTnwfhacvI0dmaIUS4ZMEIeBykKICmiJoT8wMB/nlhRClJZSxgGtALUKTsldZjocmg3/fA+3crmT9GkN7T6HMtWKPjZFKSKrV6+mZ8+eBAUF4efnp5c+DTbEJKXMBMYBW4AgYJmU8owQ4lMhRDcAIUR9IUQU0BeYJYQ4k3NuFtrw0g4hxClAAHMMFatSjCVcgl/bwdYPoEx16L8Y3r4EH8bBy4eg5Ydw5SjMbAJ/fw9qgyzlCbV48WKaNGnC4sWL9daneFJ2lAsICJCq1MZT5upJWNQLstKh249QrXvu7VISYP3rcHY11BmstTUz1ek3pbgJCgqiatWqRo0hOTmZKlWqsGvXLrp27UpwcHCu7XKLVQgRKKUMyK39E1OLSXnKXLsA87uCZQkYvhFK+/53W1tn6DsPdn0Je77WkkPXH6AYTCwqxcsn685w9spNvfZZrZwDE7tWf2SbNWvW0KFDB3x9fXFxcSEwMBB/f/9CX1t9jFKKn1vX4Pc+YGYOw9c/OjncIQS0+gCavglHF2jzFYryhFi8eDH9+/cHoH///nobZlJ3EErxkp0NK0ZCUjQMWw/OeV/0A0CrDyEhFLZ/Am41oVIbw8SpPJUe90nfEBISEti5cyenTp1CCEFWVhZCCKZMmVLox2/VHYRSvBz8GS7ugg6TwLN+/s8XArpPB9eqsGqMNj+hKMXY8uXLGTJkCOHh4YSFhREZGUmFChXYu3dvoftWCUIpPuKCYfvHUKUT+D9f8H4s7aDXbEhNgI1v6S08RTGGxYsX07Nnz/uO9e7dWy/DTGqISSkepISNb4KFjX4mmN1qQvN3YNcXULMPVOmonzgVpYjt2rXroWPjx4/XS9/qDkIpHs6sgkt7oNX/oESuuyPmX5PXobQfbH4PMm/rp09FeYKoBKGYvvRbsOUDcKsFAS/or1+dhTaXcf0SHJihv34V5QmhEoRi+g7NhqQr0PErMNNzUV+fVlClM+z5Bm7F67dvRSnmVIJQTFtaolYio1JbKP+MYa7RZiJkpKi1EYryAJUgFNO2fwak3dAWuRlK6SpQsy8cmgPJsYa7jqIUMypBKKYrLRH2T4eqXaFcXcNeq/k7Wk2nv78z7HUUpRhRCUIxXUd+g/QkaFYEaxVcfKB2f+2aai5CKWZ0Oh116tShdu3a1KtXj3379umlX5UgFNOUmQ4HZ0KF5lC2dtFc85nx2kZDR+Y+vq2imBAbGxuOHz/OiRMnmDRpEu+9955e+lUJQjFNp5dD0lV4Vj8LfvLE1Q8qt4eDsyAjf3v3KoqpuHnzJk5OTnrpS62kVkyPlLDvR3Ctru0GV5SeGaeVET+5BPyHF+21leJv07sQfUq/fbrVhI6TH9kkNTWVOnXqkJaWxtWrV9m5c6deLq3uIBTTc2k3xJ7V/lgX9Z4N3k21Ia19P2mVYxWlGLgzxHTu3Dk2b97M0KFD0cdmcAa9gxBCdACmATrgFynl5AdebwZ8D9QC+ksplz/wugNwFlgtpRxnyFgVE3LkV7Bxhuq9iv7aQkCjl2HVKC1R+bQs+hiU4usxn/SLQuPGjbl27RpxcXG4uroWqi+D3UEIIXTAdKAjUA0YIIR4cNf4CGA48Md/dPMZsMdQMSomKCkGzm2AOgPBwto4MVTrriWoI78a5/qKUgjnzp0jKysLFxeXQvdlyDuIBkCIlPIigBBiCdAd7Y4AACllWM5rD93LCyH8gTLAZiDX/VKVJ9CxhZCdWbhy3oVlYQ11B8GBn7WNiezdjBeLouTBnTkIACkl8+fPR6crfFkaQyYIdyDynt+jgIZ5OVEIYQZMBQYD/7nllxBiFDAKwMvLq8CBKiYiOwsC50OFZlCqknFj8X9emyg/trBo1mEoSiFkZWUZpF9TnaQeC2yUUkY9qpGUcraUMkBKGVC6tJ5KQCvGE7oTEiP0W7G1oFx8oGILLWFlG+Yfn6KYOkMmiMuA5z2/e+Qcy4vGwDghRBjwDTBUCGH82R/FsI7OB7vSWnVVU+D/PCRGQsh2Y0eiKEZhyARxGKgshKgghLAE+gNr83KilHKQlNJLSukNvAkskFK+a7hQFaNLSYDgzVCzH5hbGjsajV9nLWEdW2TsSBTFKAyWIKSUmcA4YAsQBCyTUp4RQnwqhOgGIISoL4SIAvoCs4QQZwwVj2LizqyC7Ayo/ZyxI/mXzkKr8np+s5bAFOUpY9B1EFLKjcDGB459dM/Ph9GGnh7VxzxgngHCU0zJiSVQuqq2a5wpqd1f223uzEqoP9LY0ShKkTLVSWrlaRIfClGHtLuHol45/ThutbSSHyeWGDsSRSlyKkEoxndyGSC0+QdTI4R2FxF1GK5dMHY0ipKr6Oho+vfvj4+PD/7+/nTq1Inz588Xul+VIBTjklIrjFehGTi6Gzua3NXqB8JM3UUoJklKSc+ePWnRogWhoaEEBgYyadIkYmJiCt23ShCKcUUehOth2qd0U2XvBj6t4ORSVcBPMTm7du3CwsKC0aNH3z1Wu3ZtmjZtWui+VblvxbhOrwSdFfh1MXYkj1Z7AKwYARH7wLuJsaNRTNRXh77iXMI5vfbp5+zHOw3e+c/XT58+jb+/v16veYe6g1CMJzsbgtZC5bZg7WDsaB6tSkewsNUSmqI8JdQdhGI8kQe1XeOq9TB2JI9naQe+7eHsGuj4NejUPx3lYY/6pG8o1atXZ/ny5Y9vWADqDkIxnjOrtOGlKh2MHUneVO8FKdcgTFWgV0xHq1atuH37NrNnz7577OTJk+zdu7fQfasEoRjHvcNLVvbGjiZvKrcFyxJqmEkxKUIIVq1axfbt2/Hx8aF69eq89957uLkVvky9uk9WjOPO8FL1nsaOJO8sbKBKJwhaB52/NZ2aUcpTr1y5cixbtkzv/ao7CMU47gwv+bY3diT5U6MXpN2Ai38ZOxJFMTiVIJSiVxyHl+7waQXWjnB6hbEjURSDUwlCKXrFcXjpDnMr8Ouq7ZudkWbsaBTFoFSCUIreufVgZgGV2xk7koKp3hPSk+DiLmNHoigGpRKEUrSkhOCNWu0lU18c918qNAMrRwhab+xIFMWgVIJQilZcMCRcBL9Oxo6k4MwttbUbwRsgK9PY0SiKwRg0QQghOgghgoUQIUKIh7YMFUI0E0IcFUJkCiH63HO8jhBivxDijBDipBDChLYZUwoleIP2vUoxThAAVbtC6nUI/8fYkSgKOp2OOnXqUL16dWrXrs3UqVPJ1kNhSYOtgxBC6IDpQFsgCjgshFgrpTx7T7MIYDjavtP3SgGGSikvCCHKAYFCiC1SyhuGilcpIuc2QLl64FDO2JEUjk9rMLfR1kRUbG7saJSnnI2NDcePHwcgNjaWgQMHcvPmTT755JNC9WvIO4gGQIiU8qKUMh1YAnS/t4GUMkxKeRLIfuD4eSnlhZyfrwCxQGkDxqoUhZtX4XJg8R5eusPSFiq30SbcVQlwxYS4uroye/ZsfvrpJ6SUherLkCup3YHIe36PAhrmtxMhRAPAEgjN5bVRwCgALy+vgkWpFJ3zm7TvVTobNw59qdpNu4O4HAie9Y0djWICor/8kttB+i33bVXVD7f338/XORUrViQrK4vY2FjKlClT4GubdKkNIURZYCEwTEr50Mc0KeVsYDZAQEBA4VKlYnjnNoKTN7hWfeil+NR4toRt4UTcCa4kXyGbbNxs3ajmUo1WXq2o4Fih6ON9nMrttMd1g9aqBKE8kQyZIC4Dnvf87pFzLE+EEA7ABuADKeUBPcemFLXbSXBpN9R/UdvnOUdcShwzTsxg1YVVZMksytiWobxDecyEGecSzrE1fCvfH/2exmUbM7bOWOq41jHim3iATUlt/iFoHbT99L73pTyd8vtJ31AuXryITqfD1dW1UP0YMkEcBioLISqgJYb+wMC8nCiEsARWAQuklIYpdK4UrZAdkJV+3/zD9vDtfLTvI1IzU+lXpR/9fPtRyanSfadF34pm/cX1LDq7iCGbhtDPtx8TAiZga2Fb1O8gd1W7wrpXIeYMuNUwdjSKQlxcHKNHj2bcuHGIQn5oMdgktZQyExgHbAGCgGVSyjNCiE+FEN0AhBD1hRBRQF9glhDiTM7p/YBmwHAhxPGcLxP66Kjk27kNYOMMno2QUjLzxExe/+t1vOy9WNVtFe83fP+h5ADgZufGyJoj2dhrI0OqDWH5heUM3DCQS4mXjPAmclGlMyC0uwhFMZLU1NS7j7m2adOGdu3aMXHixEL3Kwo7y20qAgIC5JEjR4wdhpKbrAyY4gNVOiN7zOCbI9+w4OwCulbsyifPfIKFziLPXR28epC3dr9FZnYm09tMp65rXQMGnke/dYLUGzB2n7EjUYwgKCiIqlUfnlczRbnFKoQIlFIG5NZeraRWDC/yEKQlQpUOzD09lwVnFzDQbyCfN/k8X8kBoGHZhizpsgQXGxdGbR3FP5dNYKGaXxeIPaOtEFeUJ4hKEIrhXdgKZuZsMs9i2tFpdKrQiXcavIOZKNj/fuVKlGNeh3l4O3rz6q5XCYwJ1HPA+eSX89iuqs2kPGFUglAML2Q7l7wCmHh4MvVc6/H5s58XODnc4WLjwqy2syhrV5ZxO8ZxLkG/z57ni1N5cKupzbMoT6XiMFRfkBhVglAMK/EyabFnmGCVipXOiq+afZXvYaX/4mztzJx2cyhhWYKXt79MbEqsXvotEL+u2j4XyUaMQTEKa2tr4uPjTTpJSCmJj4/H2to6X+eZ9EI55QkQso3pJR25kH6dGa1n4GZX+I3U7+Vm58b01tMZvHEwr+16jd86/IaVzkqv18gTv87w15daKXP/4UV/fcVoPDw8iIqKIi4uztihPJK1tTUeHh75OkclCMWgzgSvYYGjPb0r9aKpR1ODXMPXyZdJTSbx2l+v8en+T/n82c8L/fx3vpWprq0SD1qvEsRTxsLCggoVTHClvx6oISbFYDLTU5h46xwuZla8UX+CQa/VunxrxtYey9rQtSwLXmbQa+VKCO1ppku7Ie1m0V9fUQxAJQjFYP489A3Blua8V6kfDpaG3z3updov8Wy5Z/n68NcEJwQb/HoP8euirRYP2Vb011YUA1BDTIpBJN5OZMbFNTRIu02bemP11m9qehYno25wPPIGIbHJXE1MI/5WOhlZWi1HO5seSJvTDN8wnhd9plHb3ZWa7iWxNC+Cz0KeDcC2lDbMVKO34a+nKAamEoRiEHNOziExO523rH0Q1vaF6ut2ZhabT0ez8dRVdp+PIy1DSwau9la4O9ngXtIGK3MzJJLEVCsck4cTV+IHvj48ibS1/bC2MMO/vBPNKpemY42yeLkYqI6TmU6rNXV6FWTeBnMjTJYrih6pBKHoXVRSFL8H/U6P5GT8/LsWuJ+ktAx+3XORHVsPUSL2MpWyk/jExRJvF1vcvcri6OWOdTUfzMuUeWBSuhE/HUtj1slZDK/bgbQbtThwMZ5Jm84xadM5arg70L22O739PXC2syz8G76XX1c4ugAu7YHKbfXbt6IUMZUgFL2bc2oOZkhevp5YoD+SGbfTWf/rahJWr6XRlSDaZaQ81CYp5wtAV7oUJZo1w751G0o0eRZhacno2qPZd2Uf6y7/xKruq/jYtjqRCSlsPh3N+lNX+WJjEFO2BNOhhhuDG5WnvreTfp58qtAMLEtoxftUglCKOVWsT9GryKRIuq7qynPCkfcSbsD443neJ0Gmp3Putz9I+OUXnJPiSbEpgXWz5rg3fxZrvypYlCuHmZ0dSEnmjRtkRF0m7exZUo8eJXnvXrKTktCVKkXJPr1xGjiQKKtb9FvXD/8y/vzc5uf7EkBwdBKLD0Ww4mgUSWmZ1PYsyZjmFWlXzQ0zs0Imij+HQ9jfMCFYG3ZSFBP2qGJ9KkEoevXRPx+x8dJGNkZcwbXOIOg0JU/nJR84QPC7/8M2OoqQUuWxH/48zYb0wMwqb+P4Mj2d5H37uLF0Gcl//YWwtMRp4EB2N3fis+Af+F+j/9GvSr+HzktNz2LF0Shm77lIREIKFUvZ8VLzivSq54GFroAT26eWw4oR8MIW8GpUsD4UpYioBKEUicibkXRd3ZUBbs/yzr5FMGj5Y4dZstPSuPz5lyQv/5Orti4c7DKcUW8PwaVEwSd40yMiuDZ9Bonr1mFma8uO9q4s8ItlaffllHcon+s5mVnZbDodzczdoZy5cpPyLra81qYy3Wq7o8vvHUVaInztA41GQ7vPC/w+FKUoqHLfSpGYd2YeZsKM59MtwNwavJs8sn16WBghffqRvPxPVlRqzoXJs3n3kxGFSg4All5elPtqMhXXrcWmdm1arrjIx3NT+fGPV8nMzsz1HHOdGV1rl2P9K02YOywAW0tzXl96gg7f72HTqatkZ+fjg5S1Y85WpOvhCfkApjydDJoghBAdhBDBQogQIcS7ubzeTAhxVAiRKYTo88Brw4QQF3K+hhkyTqXwrqddZ03oGrr6dMX14h7wbgoWNv/ZPuXoMUL79edG5BW+aPoiTb/9jJfaVdNriQwrHx88f5mD+/ff455RguHTgtn+8ShkZu5JAkAIQeuqZdjwShOmD6xHtpSM+f0oXX/6m70X8lFrx68zXL8EsWf18E4UxTgMliCEEDpgOtARqAYMEEJUe6BZBDAc+OOBc52BiUBDoAEwUQjhZKhYlcJbGryU21m3GVquJSSEQuV2/9k2aedOwoc/z1Vpyf/aT+Ctj16guW9pg8QlhMChQ3uqbdrKpfrulF+2n6DnepMeEfHI88zMBJ1rlWXr6835tl9tElMzGDL3EEN/PUTQ1TyU0rizFakqAa4UY4a8g2gAhEgpL0op04ElQPd7G0gpw6SUJ4HsB85tD2yTUiZIKa8D24AOBoxVKYTbWbdZfG4xTdyb4BOdsy/Df8w9JO3cSdQr4wm1d+OLDq8z/c2u1PYsafAYdQ4ONJuzgt/6OpEWGsKl3r1J2rnr8eeZCXrV82DHhOZ82LkqJyJv0OmHvbz15wmiE9P++0T7MuBRX+1VrRRrhkwQ7kDkPb9H5RzT27lCiFFCiCNCiCOmXmr3SbY+dD0JaQkMrz5cq0PkUhmcH65umbx3L1GvvsZFJw8mtR7LzHFtqORaosjidLRypMfob5jwgiDBxYqosWOJnTYNmZX12HOtzHWMbFqRPW+1ZGSTCqw5foUW3+xiypZzJKVl5H5S1S4QfRJuPPpuRVFMVbGepJZSzpZSBkgpA0qXNswQhfJoUkoWnF2An7MfDZxrwKW9ud49pJ46RdQr44l0cOPzZi8x66XmVC5TuBIcBfGM+zO0aTCAl/veIL1jU+J/nknkqJfIunEjT+c72lrwQedq7JjQnHbV3Ji+K5QWU/5iwf6wu/Wg7vLron1Xw0xKMWXIBHEZ8Lznd4+cY4Y+VylCB6MPcjHxIkOqDUGE/w1Ztx9KEBmXLxM5ZiwJVva832gE341sRg13RyNFDG8EvIG7cwUmNA6l5EfvknLoEGHP9Sc9LCzPfXg62/LDgLqsHfcslVxL8NGaM7T/bg9bz0T/u7OYiw+Urqr2qlaKLUMmiMNAZSFEBSGEJdAfWJvHc7cA7YQQTjmT0+1yjikmZlnwMkpalaS9d3u4sBUsbKH8s3dfz0pOJnL0GFKTU3gnYDhvD3iGRhVdjBgx2JjbMKnpJK6lxfOD5zm85v1GVmIiYc/1J+Xw4Xz1VcujJEtGNWLusADMzASjFgYyYM4BTl9O1BpU7QIR++BWvAHeSe4yszMJig9i6bmlfBf4HR/v+5gvDnzBrBOz2BGxg5vpar8KJW8MVotJSpkphBiH9oddB/wqpTwjhPgUOCKlXCuEqA+sApyArkKIT6SU1aWUCUKIz9CSDMCnUsoEQ8WqFExsSiw7I3YypNoQrMwstQRRscXdKqZSSq6+/wFpoaFMbPwinbs8Q78Az0f2WVRqlKrBqFqj+PnEz7Ro3oKWy5YS+dJowl8YQdnPPqVkjx557uvOo7HNfEuz5FAE322/QNef/qZ3PQ/eq9MWFzkFzm+CuoMN+I7gTPwZVl1YxZawLdy4rQ2ZWZhZ4GjlSEZ2Bom3taRlLsxpXK4xQ6oNoVHZRkW/+55SbKiV1EqBzTwxk+nHp7Oh5wa8bqfB9PrQ+VuoPwKAhAULiPlyEr/V7Epcpz7MHVa/8HWO9CgjO4OhG4cSmRzJym4rccmwImr8q6QcPIjLmNGUfuUVhFn+b7ITUzOYsSuE3/4JQ2cGh2xfxcarLuaDlhrgXcDRmKPMPDGT/Vf3Y6WzoqVnS1p4tqCua13K2pW9mwBSMlI4l3COv6L+Yl3oOq6lXiOgTAAfNPyASk6VDBKbYvpUqQ1F7zKzM+mwogMVHSsyu91s2PcTbP0AXjsFJb1IPX6csMFDOF62Kj+2HMWGV5vhpO/S2npwKfES/db1o0apGsxpNwddZjZXP/2UxOUrcOjcmbKTvsTMsmBxR8SnMHlzEPWDvmKA+S42d/yHbvUr6y1JxtyKYcqRKWwJ24KztTPDqg+jr29f7C0fP/mfnpXOygsr+fHYj6RkpPC6/+vaPJK6m3jqqFIbit7tidpDTEoMz1V5TjtwYas2IVvSi6zkZC5PeJNEu5JMrt2Pnwb7m2RyAKjgWIEPG33IkZgjzDg+A2FpSdnPPqP0G29wc8MGIl54gczr1wvUt5eLLTMG+dO48zCsSWfzmt/pNv1vDlws3HyElJLfg36n2+pu/BX5F2PrjGVz7828UOOFPCUHAEudJf39+rO+53qaejRlypEpvLn7TW5n3S5UbMqTRSUIpUCWnV+Gq60rzT2bw+0kCN939+mlmMmTSb9ylU9q9eeV7vWo52Xai+C7V+pOr8q9mHNqDnuj9iKEoNSoF3H/dippJ08R3n8A6eHhBe7fr0F7pI0TH1QMJT45nf6zD/DSwiOEXbuV774Sbycyfud4Jh+aTL0y9VjVfRVjao/Bxvy/y5o8ipO1E9NaTuO1eq+xNXwrL29/mVsZ+Y9LeTKpBKHk29Xkq+y7vI9elXthbmau7Z6WnQGV25K0axeJy1ewskorSjUKYESThxfMmaL3GrxHFacqvPf3e1xNvgqAQ6dO/z7h1H8AKUePFaxznTnCtyOe1/aw87VnebOdL3svXKPtd7v5fP1ZElP+Y6HdA47HHqfPuj78feVv3m3wLjNaz8DTvvCT/kIIRtQcwRdNvuBIzBHGbh9LamZqoftVir88JQghxEohRGchhEooCmtD1yKRdPfJqZxyYStY2pNZogpXP/wfV0t5sLJmB77uU6vYjGlbm1sztcVUsrKzeGXnK6Tk7GJnW68e3ksWY+ZgT8Tw4dzcvLlgF6jaBdISsbmyn3GtKvPXmy3oXc+Duf9covk3u5j3z6WHF9rlyJbZ/Hr6V4ZvHo5O6FjYcSGDqg7S+3/bbj7d+KrZVxyLPcabu98kIztviUt5cuX1D/4MYCBwQQgxWQhRxYAxKSZMSsma0DXUd6uPh72HVs76wjbwaUHM11PJuJHIpzX7MbF3Hco6FmzYw1jKO5RnSvMpXLhxgbf3vE1WtlaCw9LbG+8lS7CuUYPLr71O/C+/kO+HOyq2BHMbOKctmnN1sGZy71pseKUp1cs58PG6s7T/bg/bz8bc13dCWgIv73iZ7wK/o5VXK5Z1XUaNUjX09p4f1N67PR82+pA9UXv46tBXBruOUjzkKUFIKbdLKQcB9YAwYLsQYp8Q4nkhhIUhA1RMS2BMIJFJkfSolLNOIPYs3LxMclplbq5bx1LfllRv4k+32uWMG2gBNXFvwrsN3mV31G6mBk69e9zcyQmv337FoVMnYr+ZSvTEjx9ZNvwhlrZQqbVWdiP73zuFauUcWDSiIXOHBYCAkQuOMHjuQUJikwiMCaTv2r4cvHqQDxp+wNTmU3GwdNDn281Vvyr9eL768ywNXsqqC6sMfj3FdOV5oZwQwgUYDAwBjgG/A02AYUALQwSnmJ7VIauxs7CjjVcb7cCFbWRnQvTCvVwrWYbNtdqzuUeNYjO0lJsBfgMISwxj4dmFOFs7M7LmSADMrKwo980ULDw8iJ89m4wrV3D//jt0JfJYcNCvi3YHceUYePjfPXzvQrvfD4Qzdds5uiz8BMtSW/Eo4cHvnX6nqktVQ7zV/zS+3njOJpzl8wOf4+vkS/VS1Yv0+oppyOscxCpgL2ALdJVSdpNSLpVSvgIUXTlOxahSMlLYGr6V9t7tsbWw1Q5e2Ma1CB8yoggVqTQAACAASURBVC4ztXoP3ulWG2cTfaQ1P96u/zadKnRi2tFpLDy78O5xYWaG6xuv4/bZp9zav5/wQYPJiI7OW6e+7UHo4FzuJcAtdGZ0qWdPQMMVWJTaQnpiLW6EjCMqxlkfbylfzM3MmdJsCs42zryz9527czLK0yWvcxBzpJTVpJSTpJRXAYQQVgD/tcBCefJsDd9Kambqv8NLaYncPnWI+MA09pQPwK5xI3rVy2tFd9OmM9PxRZMvaOPVhq8Pf8280/Pumxtw6tsXz1mzyIiKIqzfc6QFBT2+U1tn8H72P6u7/n35b3qv7c2p+ON81Pgj5neZRglLO15ccISR8w8TmVC0f6SdrJ344tkvCL8ZzreB3xbptRXTkNcEkdvO6/v1GYhi+laHrMbbwZs6pesAIEN2Eh1oT4a5Jb/U7MrnPWoW66GlB5mbmfN1s69pV74dUwOn8vXhr8mW/84flGjyLOX/+APMzAgfNJjk3bsf36lfV7h2HuLO3z2UlpnGlMNTGLN9DM7WzizpvIS+vn1pWNGFDeOb8n4nP/aFxtP++z3M3xeWv/2xC6lB2QYMrTaUpcFL+fvy30V2XcU0PDJBCCHchBD+gI0Qoq4Qol7OVwu04SblKRF5M5LAmEC6V+p+Nwkkr1lMSowVc33bM6xTXSqUsjNylPpnobNgSvMpDK46mEVBixi7fSwJaf/WjbSu4ov30qVYeJcncsxYrs2ajczO/XFVAPw6ad9znmY6ePUgvdb2YsHZBTxX5TkWd158X10kC50Zo5r5sO2N5tT3dmbi2jP0n32ASwVYZFdQ4+uNp6JjRT7b/5kaanrKPO4Ooj3wDdp+DN8CU3O+3gDeN2xoiilZf3E9AkGXitomONlpacSsPkmGgwVBDdszqpmPkSM0HDNhxtv13+Z/jf7H4ejD9F3blz1Re+6+blHGFe+FC3Ho0J64774j6pXxZCUl5d6ZoweUq8vlc2t4d++7jNyqTYD/0u4XPmz0Idbm1rme5l7ShnnP12dKn1oERd+k47Q9/LL3IllFcDdhpbPio8YfceXWFWaemGnw6ymm45EJQko5X0rZEhgupWx5z1c3KeXKIopRMTIpJRsvbSTALQA3OzcArs+YQkaSYHtNf/7XvSaW5k/2GkohBP2q9OP3zr9jZ2nHyzteZvzO8QQnBANgZmdHualTKfP+eyTv3s2lPn1ICz7/UD/hN8P5snRpulrEsz1sGyNrjmRlt5U0LNswTzH0DfBk+xvNaVKpFJ9vCKL/7P1EXTf8p3r/Mv70qqzd6dx5z8qT75HVXIUQg6WUi4QQE4CHGkopTWbmSlVzNZwz187Qf0N/Pm78Mb19e5N57RohrVth55LEd0Nm8+3zD28x+iTLyMpgwdkFzD45m5TMFBqXbUzHCh1p4t6E0ralSQkMJOq118hOSqbMe++R1LERB64eYFv4Ng5cPYC50NHtZiJj6r6C27NvFCgGKSWrjl3mozVnEAK+6FnT4GtPbqTdoNvqbpR3KM+CjgueqPmmp9mjqrk+bh3EnUFl9SjrU2zDpQ2Ym5nTpry29iFu2g/I9Ayu13Lk1W7PGDm6omehs2BEzRH08e3D0uClrDi/go/2fQSAi7ULrrauuIzzoPOC88iJEzn0u2BWRzNKlvFiTO0x9K3ch9K/doTQ3VDABCGEoFc9DwLKO/Pq0mOMX3yM3cFxfNK9OiWsDLMPWEnrkrxa71U+3v/x3cedlSebQfeDEEJ0AKah7Sj3i5Ry8gOvWwELAH8gHnhOShmWszr7F7SV2+bAAinlpEddS91BGEZWdhZtl7elRqka/NDqB26HhBDarTvOPkmEduvLsy9OfXwnTzgpJUEJQQTGBHL++nkS0hJIy0yjhM6OxnuvUXPFScwcHfCY/BX2TZtqJ22bCPt/grdCwKZw1W4zs7L5YccFftoVgqezLdMH1jPYnt9Z2Vn0Xd+XlIwU1vRYg5XOyiDXUYrOo+4gkFI+9gv4GnAALIAdQBww+DHn6IBQoCJgCZwAqj3QZiwwM+fn/sDSnJ8HAktyfrZFK+/h/ajr+fv7S0X/Dlw5IGvMqyE3XdokpZQyYsxYeaJGTZnxbkmZcvGAkaMrHlKDgmRoly7ybBU/efn992Xm9etSRhyScqKDlMcX6+06By/Gy0Zfbpe+H2yUSw9H6K3fB+27vE/WmFdD/nrqV4NdQyk6aFtA5/p3Na8zi+2klDeBLjl/rCsBbz3mnAZAiJTyopQyHVgCdH+gTXdgfs7Py4HWQhvYlICdEMIcsAHSAbXTuhFsuLgBW3NbWni0IOXYMZJ37uSGrx1Z9iWxKV/f2OEVC9Z+fnj/+ScuI0eQuHoNoZ27kHjsKtK+HJzRX62jBhWcWf9KE/zLO/H28pO8t/IUaRlZeuv/jsblGtPMoxmzT87melrBNlNSioe8Jog7g5qdgT+llIl5OMcdiLzn96icY7m2kVJmAomAC1qyuAVcBSKAb6SUCShF6nbWbbaHb6dN+TZY6ayI+eZbEq3tqVUtCku/tlCA/ZqfVmbW1ri++SYVVizHwt2dK2+/Q+QeV9KO7IIU/f2v7VLCigUvNGBMCx8WH4qg3yzDPOX0hv8bpGSm8Nvp3/Tet2I68vovfL0Q4hzaXMEOIURpIM1wYdEAyALKARWACUKIig82EkKMEkIcEUIciYuLM2A4T6e/o/4mKSOJThU6cWvPHtICj/BXldqU1N1EVG5n7PCKJWs/P7wX/0GZDz8k9cotLm1y5uqEMWTExurtGuY6M97p4MfsIf5cirtFt5/+4UiYfj9f+ZT0oXOFziw+t5i4FPVv70mV13Lf7wLPAAFSygy0T/cPDhc96DJw73ZXHjnHcm2TM5zkiDZZPRDYLKXMkFLGAv8AD02iSClnSykDpJQBpUuXzstbUfJhw6UNOFs706BMfa5+8y3RJUrhV98chBn4tDJ2eMWW0OlwHjyISlu34VzLkhu7TxLaoSOx33xD5rVrertOu+purBn3LI42Fgycc5BVx6L01jfAmNpjyMjO4JdTv+i1X8V05GeMwA94TggxFOgDPO4j5GGgshCighDCEm0Seu0DbdailQsnp8+dOZMmEUArACGEHdAIOJePWJVCSkpPYnfkbjp4dyBl42YyL5xnvl972tucBo8GWuE5pVB0Tk6UGTsEn44x2DdtRPyvvxHSug3RX3xJxpUrerlGxdIlWDX2GfzLO/H60hNM3Rqst1pOng6e9KjUgz/P/3l3m1blyZLXct8L0UpuNAHq53w9soprzpzCOGALEAQsk1KeEUJ8KoToltNsLuAihAhBK9/xbs7x6UAJIcQZtETzm5TyZL7emVIoOyJ2kJ6dTievdlz9/gdCS7rj1bERNnEnofLTtTDOoGr2xtI+C/d+vvhs3IBD585cX7yYkDZtiRw3jlv79uV/97oHlLS1ZP4LDXguwJMfd4YwbvFRUtP1M3n9Uq2XAJh9arZe+lNMS57WQQghgtAeUS26MpL5pNZB6NeoraOITIrkDzmC6A//x2fPjGD6yFI4bX0VXtoLZWsZO8Qnx5zWkHUbRmvVUjMuX+b6kqXcWL6crOvXsfT2xrFHDxy6dMbSw6PAl5FS8sveS3y5KQh/LyfmDquPo23hN4T88uCX/Bn8J+t7rce9xJNR7v1p8qh1EHkdYjoNuOkvJMWUXUu9xsHog3T2as/V6TO5UNKDmr074RS1C0q4gVtNY4f4ZKnZF6JPQaw2imrh7o7rhDeo9Ncuyn39FToXF+K+/57QNm0Je64/CQsWkB4Rke/LCCF4sVlFpg+sx8moRPrO2kd0YuGfNXmhxgsgYN7peYXuSzEteU0QpYCzQogtQoi1d74MGZhiPJsvbSZbZtM+2AZx9TKra3ZgbLPyELIDfNuBqsGjX9V7ahP/p/6877CZlRWO3brh/fsiKu3YTukJb5CdmkrMl5MIbdee0I6diJn8Fbf27SM7Je+PsnaqWZZ5z9fnyo00ev+8j5DY5EKF72bnRnef7qy8sJJrqfqbZFeML69DTM1zOy6lzMMOKUVDDTHpz8ANA8nKSOejaTe4mAJRk2cyxisSFvaAAUugSkdjh/jkWdgTroXAqyceu74kPSKC5L92k7x7NymHDiEzMsDcHJsaNbCtXx/bBvWxqVv3sXtln76cyPDfDpOVnc2vw+tT16vgJT/Cb4bTbXU3hlcfzuv+rxe4H6XoFXqIKScRhAEWOT8fBo7qLULFZITfDOfUtVMMifLG7Opl1tfpyLBnvSF4E5hbQ4VcPysohVVnECRGQNiexza19PLCeegQvOb+gu+B/XjOnoXL888DEP/bb0S+OIrzDRpysWcvoj/9jMQNG8i4+vBTRjXcHVkxpjH21hYM+uUg+0PjCxx+eYfytC/fnqXBS0m8nZd1tEpxkKeyj0KIF4FRgDPgg7YCeibQ2nChKcaw8dJGdNngueIooQ7laDi4J7YWOi1BVGwJlmojQYPw6wzWjnBsEVRskefTzOzsKNGsGSWaNQMgOyWF1OPHSQk8Suqxo9xYvZrrf/wBgHnZstjWq4dNvbrY1quHla8v5V3sWD6mMYPmHGT4b4eYMzSAZr4FW1M0ouYINoVtYsm5JbxU+6UC9aGYlrzWBX4ZbXXzQQAp5QUhhKvBolKMQkrJxosbGXS5PJZXQ9nUfCRTG5WH2LPap9tmbxo7xCeXhY02WX1sEaTeAJuSBerGzNYWu2eewe4ZrQy7zMwkLTiY1KPHSDkaSMqRI9zcsEFra2eHTZ062NSry4I6NRl91JyR84/w8+B6tK5aJt/XruJcheYezVkUtIgh1YZga6E+TBR3eU0Qt6WU6Xc2CMlZ9Wyyj7wqBROUEET4jUs03+bIJYeyNB7WC2sLHQRv1Br4qvr/BlVnEBz+BU6vgPoj9NKlMDfHpnp1bKpXx3nIYKSUZF65QkpOwkg9eoxrP00HKZms0xHl7MGhE+URQ3rSsk9bhE6Xr+uNrDmSIZuGsCpkFYOqDtLLe1CMJ68JYrcQ4n3ARgjRFq1M9zrDhaUYw4aLG2h6zgz7mAQWtRzBNw3Kay8EbwZ3f7BXTzobVLm64Fodjv+utwTxICEEFu7uOLq749hV2188KylJG5Y6ehTLI4GUOboPi4l7OD21JKXat8W+fXvsGjfKU7Ko41qHOqXrsOjsIvpX6Y/OLH8JRjEteX3M9V20PSBOAS8BG4EPDRWUUvSysrPYErqJ5/aZc8nBjSbP99X2mU6KgctHwFc9uWRwQkDdQXA5EGLOFtlldfb2lGjaFNdXX8Vn4QK8//6HZZ3H8I+DNwnr1hM5ciQhrdsQO20a6ZGRj+1vaPWhRCVHsStyVxFErxhSXp9iygZWA2OllH2klHNMeVW1kn+BMYH4HIuhdFwqOwK60Ms/p87i+c3ad/Voa9Go9RyYWcDR+Y9vayAOTg68+eVYdvR5hd7tJxL35sdYVa5M/MxZhLZtR+TYl0k5+t8PMbbybIVHCQ/mnzHee1D045EJQmg+FkJcA4KBYCFEnBDio6IJTykqG0LX0+cfCLd3pdnIfpjrcv7XOL8ZHD2hTHXjBvi0sCsF1XvA8T/gduEWsBUqDCtzfh1eHz+vUoy4ZE/IhM+otHMHpcaOJfXoUcIHDiJswECSd+9+qFaUzkzH4GqDOR53nBNxJ4z0DhR9eNwdxOvAs0B9KaWzlNIZaAg8K4RQq2GeEOlZ6VzftBGPa9nsatCVLnVy6v1kpELoLu3uQa2eLjr1X4TbN+HUMqOGYW9twfwXGuDn5sDoRUfZn2RO6fGvUGnnDsp8+CGZsbFEvjSa8CFDSDl27L5ze1bqib2lvbqLKOYelyCGAAOklJfuHJBSXgQGA0MNGZhSdPZG7qbz7ltEOpSk5aj+6MxyksHF3ZCZCr4djBvg08azgVbv6tAvYOSRXEcbCxaOaEDFUna8uOAI+0PjMbO1xXnwIHw2b6LMR/8jPSyc8AEDiXr1NTKiowGwtbCln28/dkTsICpJv/tQKEXncQnCQkr5UHEVKWUcUPgykIpJOLPiV7yuwe4GPWlf655qnMEbwdIevJsYL7inkRDQYBTEnoGI/caOhpK2lvw+siFezraMmH+YwHBtH2phYYHzwIFU2rKZUq+MI/mvv7jYqTMJ8+cjMzMZWHUgZsKMRUGLjPwOlIJ6XIJIL+BrSjGRlHaTKqtPEFXShtZjBnNnrQvZWdrq6UqtwdzKuEE+jWr0AeuScMg09llwKWHF7y82xNXeiud/O8S56Jt3XzOzs6P0yy9Tcf06bAL8iZk0mbD+A3CMTqZThU6svLCSm+k3H9G7YqoelyBqCyFu5vKVBKiaz0+AfUum4RUn+athW1pWK/vvC5EH4VYsVO1qvOCeZpa2UHcwBK2Dm/rZXa6wXO2tWTiiITaWOobOPURE/P0VZC09PfGcNQv3774lIyqKS716MySoFKkZKSw/v9xIUSuF8cgEIaXUSSkdcvmyl1KqIaZiTmZnYz5vFVecdHQY/dq/dw+g/WHSWarV08bU4EVtDuLADGNHcpensy0LRzTkdmY2Q349SGzS/ftJCCFw6NiRCmvXYBsQgJw6m0nrHFgVuJCM7AwjRa0UVH72pM43IUQHIUSwECJECPFuLq9bCSGW5rx+UAjhfc9rtYQQ+4UQZ4QQp4QQ1oaM9WkUtn4l5aJT2dqoFk387lklLaWWIHxagZW98QJ82jl5a3tFHPkNUq8bO5q7fMvY89vz9YlLus3QuYdITH34D7+Fqyuec2ZT5oMPqBh8kwk/R7N7x7yiD1YpFIMlCCGEDm1v6Y5ANWCAEKLaA81GANellJWA74Cvcs41BxYBo6WU1YEWgPr4oUdSSiKmTeOqEzQa/vr9dw9XjkFipBpeMgVNXoP0ZDg819iR3KeelxOzhvgTGpfMiHmHc93jWgiB85DBlF+4EKtsHa6vf8eN1WuMEK1SUIa8g2gAhEgpL0op04ElQPcH2nQH7jwovRxoLbS/VO2Ak1LKEwBSyngppX52WVcAuLZ1O66Xr7G+cWl61q5//4tB60DooEon4wSn/MutJlRqAwdnautSTEjTyqX5/rm6BEZcZ+zvgWRkZefazq5uXa78+AbB5eDqu+8S98MPDy2uU0yTIROEO3Bv4ZaonGO5tpFSZgKJgAvgC8icLU6PCiHezu0CQohRQogjQogjcXFxen8DTyopJSHffEN0SXDp1u/BFyForfZoq62zcQJU7tfkdbgVp5UCNzGda5Xlix412RUcx1t/niA7O/c//J38B/DTMCfOPePOtRk/c+Wdd8hOVw9CmjqDzkEUgjnQBBiU872nEOKhzYmklLOllAFSyoDSpQu2ycnTKG7bDkpGRrCqsY4R9fs88OI5iA9Rw0umpPyz4NkQ/v4OMtIe376IDWzoxZvtfFl9/ApfbTmXaxsbcxt6Ve3Hx81jsRw9nJtr1xE58kWykpKKOFolPwyZIC4Dnvf87pFzLNc2OfMOjkA82t3GHinlNSllClr12HoGjPWpIaXk4jfTiHHUEdu0Dm52D5TwDloHCJUgTIkQ0OpDuHkZjvxq7Ghy9XLLSgxq6MWs3ReZ98+lXNsM8BuAmZmO5c9AuSlfk3LsGBHDhpN53XQm4JX7GTJBHAYqCyEqCCEsgf7A2gfarAWG5fzcB9iZUyV2C1BTCGGbkziaA0VX//gJFrttF44RIax6RtKnRo+HG5xdq5V6UHs/mJYKzbT9wPdONWoRv/8ihODT7jVoW60Mn6w/y6ZTD++B7WrrSgfvDqy8sBKz9i3w/OlHboeEEDF0KBmxsUaIWnkcgyWInDmFcWh/7IOAZVLKM0KIT4UQ3XKazQVchBAhwBto+04gpbwOfIuWZI4DR6WUGwwV69NCu3v4nhh7a/6uZUHb8m3vb5BwEWJOqbsHU9X6I0i5Bgd/NnYkudKZCX7oX5e6niV5delxDoclPNRmSLUhpGSmsPLCSko0b47n7NmkX75C+JAhZFwxjQWByr8MOgchpdwopfSVUvpIKb/IOfaRlHJtzs9pUsq+UspKUsoGOYUA75y7SEpZXUpZQ0qZ6yS1kj8xW3dSMuICa5uY0aR8cxytHO9vcGa19r1qt4dPVozPIwCqdIa/v4ebD39CNwU2ljrmDquPR0kbRs4/Qkjs/XMM1Vyq4V/Gnz+C/iAzOxO7Rg3xmvsLWQnXCR82nIyYGCNFruTGVCepFT2TUnJx6vfE2JVgZ83bdKuUSxI4vQI86oNT+aIPUMmbdp9BVjps/9jYkfwnJztL5r/QAAudGcN+PUzMzfsn1odWG8qVW1fYGbETANu6dXOSRAIRw58n89pD9UEVI1EJ4ilxdcsOnCJC2N68DPa2TjRzb3Z/g9hzEHNaKxKnmC4XH2g8Dk4ugYiDxo7mP3k62zLv+frcSEln2K+HSEr7d51rc4/meNp7suDsgrvHbGrVwnP2LDKio4l4/gU1cW0iVIJ4CkgpuTR1GtG2JdlS6wqdKnTCQvdAKa0zK0GYabuZKaat6QSwLwcbJ0CW6RYYqOHuyM+D/QmJTWb0okDSM7WFdDozHYOqDuJE3AlOxp28297W3x/Pn2eQHhFBxAsjyLqpKsAam0oQT4HLW7bjHBnCwVY1SRMZDw8vSQmnlmuL49TTS6bPqgR0nAzRp7T5CBPWzLc0k3vX4p+QeN5e/u9Cup6VemJvYc/Cswvva2/XqBEeOU83Rb08juzbt40RtpJDJYgnnJSSsKk/EG3rzLHGiVQqWYlqzg+UxLp6AhJCoUZv4wSp5F+17lC9F+z+CqJPGzuaR+rj78Fb7auw+vgVvtkaDGg7zvXx7cO28G1cTb5/wr1E06aUmzSJlMOHufLW28gsVWXHWFSCeMJFbdqOS2QIZ9u25WzyWbr5dLu/MB9ok9Nm5urppeKm0zdgUxJWvWRydZoeNLaFDwMbejHjr1AWHggHYGDVgQD8ce6Ph9o7dumM67vvkLR1KzFffKlqNxmJShBPMCklYd9OI8bWmRudbDETZnSp2OX+RtnZcHol+LRWtZeKGzsX6D5De7hg45vGjuaRhBB82q06rf1cmbjmNNvOxuBm50bb8m1ZcX4FtzJuPXSOy/DhOI94get//EH8LNPYWe9poxLEEyxk3VZKRYUS3rEvf8Vto3G5xpS2faBmVdQhuBkFNdXTS8WSbzto+qZWyC9w/uPbG5G5zowfB9alprsjryw+yrGI6wytNpSkjCRWh6zO9RzXCRNw6NaVuO+/58bKVUUcsaISxBNKSsnl738gxs4ZtyG1ib4VTXefB6utAyeXgbk1VOlY9EEq+tHyfajYEja8ASHbjR3NI9lamjN3eH1c7a0ZMf8I9qIidUrXYdHZRWRl57KnhJkZ5b74ArtnGnN14kRuHTpkhKifXipBPKHOLFtLmSsXie02kF1xW7C3sKelZ8v7G2Xe1uYfqnZVO8cVZ2Y66LcASleFpUMhKtDYET1SqRJWzH+hAVJKhv12iB4V+xOVHMVfUX/l2l5YWOD+/fdYenlx+ZXxpIeFFWm8TzOVIJ5AMiuLhB9+4IqDK43H9WZb2DY6VeyEtfkDu7YGb4K0G1B7gHECVfTH2gEGLwe7UrCgO4T9Y+yIHqlCKTvmDq9PdGIa83fYU9au3EOPvN5L5+CA58yfwcyMyJdGk3XjRhFG+/QyN3YAiv4Fzl1M6fgrnHvpXfbE7iA9O52+vn0fbnj8D23BVcUWRR2iYgj2bvD8JljYAxb1gp4ztT2ti0pWhlbwMe4cxIdCSrz2lZWh3eVY2Gj/vzl6QNna1HP348cBdRm9KJCqJZoReGsJZ+LPUN2leq7dW3p64jH9JyKGDSdq/Kt4/TIHYWlZdO/vKSSelMfHAgIC5JEjR4wdhtFl377N/qZtuGluQ/Od6xm05TmsddYs7rL4/oZJMfBtVXh2PLT52BihKoZyKx4WPwdRh6HBS9D2U7Cwfvx5+ZV6AyIPQvg/EL5f28s8+56V3RZ22pNxOkvIzoSMFG1nvLuv20KF5uyzaMhLx1wwr/IT7Su0YnKzyY+8bOK6dVx5620ce/ei7OefP/zYtpIvQohAKWVAbq+pO4gnzP4ff8X55jVuvPU552+eJeRGCB83/vjhhqeWgcyC2gOLPEbFwOxcYPhG2D4RDsyAC1uhwyTw7aBtPlRQWRla0gndqX1dOQYyG8wsoFxdaDQGytSA0r7gUllb8f2gzHS4EaGdG3kQzm/mmcRNHLW2YvT1ymxiE6/7v04ZuzL/GYZj166kX7rEtRk/Y1WxIi4jRhT8PSmPpO4gniAZybc42rQVsY6udNi+mk8OTGRb+DZ29duFrYXtvw2lhJ+f0T7BvbjDeAErhhe6Cza9DdfOg1staDga/DqBjdPjz81M1/YHiTwEF3dD2F5ITwahA3d/8GkJ3k21ny1tH99fbqSEq8eRR+Zx6dQyerq70CerFP/rNltLNP95muTyG2+QtHkLnjN/pkTz5gW7vqLuIJ4We6fMoGzqTZLf+4y07BS2hG2hi0+X+5MDaKU1Ys9C52+NE6hSdHxawph92jqJgzNhzVhYq9P2lihTA5wrgrWjtpI+PVmbM0i4pO1LHnMaMnNKdTtVgFrP/ZsUbErqJz4hoFxdRLe6uLf8CL/FvdlsHscbPzfGrtEYaPEeWNrlcpqg3JdfEhYezuUJb+K9bClWFSvqJyblLoPeQQghOgDT/t/efYdHUbUNHP49uymQBJJAQgmhN+ktAgoq6AtI0SA1vtIRBARFsGBXioIgKL7Si4AgIFKlC1JUitRQQkkglFASCC0hkHa+P2bhS8ICAbKb3XDu68qV3Zkzs8/M7ubJzGmAGZiilBqeYb07MBOohTEXdXulVGSa9cUwphr9Qik16l6v9bhfQVyLucihFxoTFVCa4JXzmHd4HsO2DWNu87lU8stQ6bf8Xdg1E949nLn/JLWcQSnjFtGRVRD5lzHE9Y955AAAHm9JREFU+80rd5bLW8RIHIWrGYkk8EmjYtkONp/6lz7ru9Esxp8RcTvBpxi8/MNdG1IknTnD8bbtMOfJQ4n58zDnzWuXOHOSbLmCEBEz8CPQCDgN/CsiS5VSaeeW7g5cUkqVEZEQYATQPs360cBKW8WYk2z6fBQlEhMo/oEx5MKCIwuokK8CFfNnGJgvMR5C5xnDeuvk8HgRMeYbL1rbeK6U0cz55jWjEtktj9EfxhYV2plUPzCI8j6VWJkczeUbg/lRZuIysyU8MwAafATm9H+yXAMCCBz7PSe6dCVq4LsUnTAeMZuzKfqcx5b9IGoD4UqpY0qpRGAukLErbzBwa3yABcALYmmSICItgePAARvGmCOcDgun6IZlHK7+LDUa1mZX9C4OXzpM2/JtrQ/Md/MqBHXLnmA1xyFi/JPgU8y4YvDyz9bkYIQkdK/aGeUSw9+uKbRK+ZrEqv+Fzd/CT83h6p3zVnvUqkWhTz8hfvNmor/Vt02zki0TRBHgVJrnpy3LrJZRSiUDV4D8IuIFfAB8ea8XEJGeIrJDRHbExMTcq2iOtufTr0gVE7W+HATAnLA55HXLe+fAfAA7pkGBilC0jp2j1LTMaVS8EUW8ilCqzFYOXkii84VOJLecbNSJTH7eaAGVgW+7dvj+97/ETpvGlSVLsiHqnMlRe1J/AYxRSsXdq5BSapJSKkgpFeTv73+vojnWvjV/U3r/Fo6/0JLi5UtwLv4c606uo1XZVuR2yZ2+cNQu48sV1O3Rmjtqmg25mFzoXqU7x+PCeKNJCluOXeTdQ2VJ7brKqEyf1hQO3pkECn44CI86dTj76WckhIZa2bP2oGyZIKKAommeB1qWWS0jIi6AN0ZldR3gGxGJBPoDH4lIXxvG6pRSU1M58/VwLufKQ8MvBgIw//B8FIqQJ0Lu3GDndKNpa9V2do5U0x5McOlgCnoU5EDCwtuTDY3c6wo91kOhyjC/M/w7Jd02xphNY3Dx9+d0334knY/OpuhzDlsmiH+BsiJSUkTcgBBgaYYyS4HOlsdtgPXK8IxSqoRSqgTwHfCVUup/NozVKW2e+ivFzoZzOaQrPvm8uZlykwVHFvBc4HMU8cpwN+/GVdj3mzFrXC7v7AlY0zLJzexG18pd2Xl+J7UrXOK1OsUYvyGCWfuuQ+dlRqe/5QONuok0LTFdfH0JHDeOlLg4Tvfrp6csfUQ2SxCWOoW+wGogDJivlDogIoNF5NbUZVMx6hzCgQHAIFvFk9PEX4tHJv7AWd8A/vOO0ZN05fGVXLp56fZMXens/hmS4uFJ3etUcw6ty7YmX658TA6dzJcvV+I/FQrw+dIDrDlyBdrPgirtYN1gWPtZuiSRq3w5AkYM50ZoKOc++1zPRvcIbFoHoZRaoZQqp5QqrZQaZln2mVJqqeXxDaVUW6VUGaVUbaXUMSv7uG8fiMfR2s+/xT/uIt7vfYCruxtKKeaEzaG0d2nqFMpQAZ2aAtvGQ7GnjCERNM0J5HLJRZdKXdhydgsHY/cz9tUaVAn04a25u9kVFQevTIQne8A/Y2HVh+mSRN5GjfDr25crS5YQ+5NjT6TkyBy1klq7h4h9Rymx6lciKtWhVqvGAGw7t42w2DA6VOxwZ9PWQ78b49/U7ZMN0Wraw2tXvh3e7t5MCp1kTDbUOYiCeXPx+owdHI9NgGYjoe6bxj9Aaz5JlyT8+vQmT+PGRI8cSdzmv7LxKJyXThBORinFvo8Ho8REra8/v7182r5p+OX246XSL9250ZZx4FMcnmhux0g17dF5unrSsUJHNp7eyP4L+43JhroaHf26TN/OhfhEaDIMaveELf+DdV/eThJiMhHw9Ve4ly1L1MCB3Dx+PDsPxSnpBOFkNs35nfJHdnD+pRAKlysJwMGLB9lydgsdKnTA3eyefoOonXBqqzFIm0n3MNWcT4eKHfB192XsrrEAlPDzZGrnIM5fvUHX6f9y7WYyNP0GanWFv8bAn1/d3tbk6Ungjz8iZjOne/ch5YqVoUW0u9IJwonExSWQ8v23ROf15/nP37m9fPr+6Xi6etK2vJVJgbaMM4ZQqNHBjpFqWtbxdPXk9Sqvs+XsFrafNeakrlHMl3Gv1STs7FVen7GDG8mpxuCTNTrApm/gnx9ub+8WWITA//1AUlQUp9/uj0pKuttLaRnoBOFEVn00gsJXz5PnvQ9wy20MiXDq6inWnFhDu3LtyOuWYaCy2ONwYBHU6mxMSalpTqr9E+0p6FGQ73d/f7tV0vNPFOTbdtXYHhlLn9m7SFLAS2OhYrBRH7Fnzu3tPWrVotCQwVzfupVzQ4bqlk2ZpBOEk9j71x7K/bGAyGr1qNn2/+sSZhycgUlMdKho5Qrh7++M20pPvWnHSDUt67mb3elVrRehMaFsPL3x9vLg6kUY2rIy6w9FM2D+XlIwQavJxuivS/rCoRW3y/q0bEn+nj25PH8+l2bOtP9BOCGdIJxAYlIypz/5hJsu7tQdM/T28nPx51h4dCHBpYMp4FEg/UZXomD3bKjREfIG2DliTct6wWWCKZanGGN3jyVVpd5e/lqd4gxq+gTL9p7hk8X7UWY3aD8bAqrDr10g8u/bZf37v02eRo04P+Ib4jZutPIqWlo6QTiBFcPGUepcBIlvvIVvQKHbyyeHTkah6Fm1550b/TMWUFDvbfsFqmk25GpypW+Nvhy9dJRlEcvSrev1XGn6NCjNL9tPMnzlIZSbJ/z3V/AtDr+EwFljbCYxmQgYMZxcTzxB1ICB3Dh8JDsOxWnoBOHgju4Pp+iCaZwsWZmn+3S6vTwqLoqF4QtpXbY1AV4ZrhDiomHnT1A1xPiCaFoO0aREE6r4VeH7Xd9zPel6unXvNSlPh7rFmLjpGD/+GW7Mzd1xEbjnhZ9bwcUIAEweHgSOH4fJ05PTvXuTfOFCdhyKU9AJwoElJqdwYMAgzCqVqqO/TtcBblLoJEyYeL3K63du+NcYSEmE+u/cuU7TnJhJTLz/5PvEJMQwdf/UdOtEhMEvV+aVGkUYteYI4zdEGDPhdVwEKhVmtYSrZwFwLViQwHHjSI6N5VSv3qTGx2fH4Tg8nSAc2NIvx1L+5AHiuvahcIUyt5efunqKJeFLaFu+LYU8C6Xf6PJJY5TL6q+BXxk0LaepXqA6TUs2ZcaBGZyJSz+BkMkkjGxTlZerBTBi1SEmbowA/3Lw2gK4HmtcSSRcAiB35UoUGTOaGwcPcrr/O7r5qxU6QTioPX/vofTC6ZwqU416A99It27s7rG4mlzpXtnKwHsbhgMCDfS4h1rONaDWAAThu53f3bHOxWxidLtqtKhamK9XHmLypmNQpCaEzIaL4TAnBBKN21N5Gjak0JdfEL95M2c//Uw3f81AJwgHFB+fwNlBg0h2cePJcd+mu7W0N2YvqyJX0aVyF/w9MkySFB0Ge3+B2j3sNsm8pmWHQp6F6FK5CysjV7Lz/M471ruYTXzXvjrNqxRm2Iowpmw+ZjR9bTUZTm2DXztDinHF4Nu2rTGw3+LFxHz3vX0PxMHpBOGAlg0cSomYE8g7H+Bb7P/ndVBKMfLfkfjl9qNrpa53brhuMLh5wTMD7RitpmWPrpW6EuAZwOAtg0lKufP2kIvZxHch1WlWpRBDl4cx9a/jUKkltBgDR9fAkjch1Wgu6/dmH3zatuXixInE/jzb3ofisHSCcDBrflpElQ2LOFn7eYK6pB86Y+2JteyN2Uvf6n3xcPVIv2H4Oji8wqiY9shnx4g1LXt4uHrwcd2POXblGNP2T7NaxtVs4vuQGjStXIghvx80WjcFdYXnP4HQebD6I1AKEaHQ55/h1bAh54cN48ry5XY+GsekE4QDObIvnLyjhxGTP4CG475Jty5VpTJ291jK+JShZZmW6TdMToSVH0C+UrrXtPZYeTbwWZqUaMKk0ElEXom0WsbVbGLsqzVoWT2AkasPG/0k6g80hr/fNh42G9PNiIsLRUZ/S+5aNTnz/gdc++MPOx6JY7JpghCRF0XksIiEi8gdtaYi4i4i8yzrt4lICcvyRiKyU0T2WX4/b8s4HUF8fAJH+r2De2oS5cb/gJuXZ7r1JjEx6rlRfPn0l5gzjsq6bQJcPAovDgeXDKO5aloO98GTH+BudmfI1iF3rWR2NZsY3a46r9UpxoSNEXy69ACpjYZC1fawfijsMK5ATLlzU3TCBHJVrkTUOwOI27zZnoficGyWIETEDPwINAUqAq+KSMUMxboDl5RSZYAxwAjL8gvAS0qpKhhzVs+yVZyOQCnFsjc/pvS5cJLeHkRA1QpWyz2R7wmq+ldNv/DaOdj4DZRtDOWa2CFaTXMs/h7+9K/Vn+3ntvPrkV/vWs5kEoa2rMwbz5Xi560neXfBPpJb/ABlm8DvA+DAYgDMXl4UmzQJtzJlON23H/Fbt9nrUByOLa8gagPhSqljSqlEYC4QnKFMMHBrPsAFwAsiIkqp3UqpWw2cDwC5RSTH/mu8aNh4qm1dyakGLajd49XMb6iU8cFOTTKuHjTtMdWmXBueKvwUo3aM4sTVE3ctJyIMevEJ3mtSnoW7o+g5J5T44ClQtA4s7AHhxm0ls7c3xaZOwbVoIKf69OH6zjtbSj0ObJkgigCn0jw/bVlmtYxSKhm4AuTPUKY1sEspdTPjC4hITxHZISI7YmJisixwe9o4fzVlZo/jVOkq/OeHr+6/QVoHFsLh5dDwI8hf2jYBapoTMImJIfWG4Gpy5aPNH5GcmnzXsiLCmw3LMLRlZTYcjiZkeigxL88Av/Iw9zWIWA+AS758FJ8+HdcCBTj5eg/it2yx1+E4DIeupBaRShi3nd6wtl4pNUkpFaSUCvL397dWxKGF7Qoj19CPueTtT72ZEzG5umZ+4/gLsOI9CKhpzMmraY+5gp4F+aTuJ4ReCGXKvin3Ld+hbnEmdwoiPDqOV6Yd5FizOZC/DPzyKhzbAICLvz/FZ83ELTCQU2/04tqff9r4KByLLRNEFFA0zfNAyzKrZUTEBfAGLlqeBwKLgE5KqQgbxpktTh6L4myvXphQlJ0yAc/8vpnfWClYPgBuXIXgH8HsYrtANc2JNC3ZlGYlmzFh7wR2nd913/IvVCjI3J51uZGUwis/HWJXgxmQr7TR2/qYMRy4i78/xWbOwL1cOU73e4urK1fa+jAchi0TxL9AWREpKSJuQAiwNEOZpRiV0ABtgPVKKSUiPsByYJBS6m9ymJjzsRzs1I188ZfwGjWGgMrlH2wHO6fDwSVGW+6CGev9Ne3x9mndTwnwCmBJxJJMla9W1IeFveuR39ON9j8f4bfK4yBfSZjTHo5vAsDF15diP00nd/VqRA18l0vz59vyEByG2HLsERFpBnwHmIFpSqlhIjIY2KGUWioiuTBaKNUAYoEQpdQxEfkE+BA4mmZ3jZVS0Xd7raCgILVjxw6bHUtWuXY1ng2tOlAy6giJX4ygZvsWD7aD8wdg8vNQ/Gl47TcwOfRdQk3LFtHXo/HL7YdJMv/9uHI9iX5zd7PpSAw9a+ZhUMx7mC5FQtufoHxTAFITEjj99tvEb9pM/jfewP/ttxAn/w6KyE6lVJDVdTllcCpnSBBxV+NZ364LZSP3E/vWR9Tr0/HBdnAzzkgOCZeg99/gVeD+22ialmkpqYpvVh1i4qZjvFDMzATTcFzPhxq3cqsbLQxVcjLnBg/h8vz55G3enMJff4XJzS2bI39490oQzp36nMjVy9f4s01nSkce4FzPAQ+eHFJTYWFPo0Nc68k6OWiaDZhNwofNKvB9SHX+OqNofHEglwvWgcW9YMs4wOhxXejLL/AfOICry5dzsls3ki9ezObIbUMnCDu4cvEym9p0otTJg8T0epeGA3o8+E7WDzaatDb52hiVUtM0mwmuXoSFfZ5G3PNQ98QbHM3fEFZ/CGs+hdQURAS/Hj0I+HYUN/bt53jrNiTs3ZvdYWc5nSBs7OyxU2wPbkeJqCNc7PsBDfp3e/Cd7JljzBJXqwvUsdriV9O0LFYpwJtl/erTrHoJmkR1Z41HC2Ou93kd4OY1ALybN6fEL3MQs5kTHTpyae68HDWnhE4QNnRkWyjhbUPIf/k81z4bzrN9O99/o4zClhnDEpdqAM1GQZq5ITRNsy1PdxdGt6/OyLY16B/Xga/ohjq8CjWtiTF7I5CrYkVK/rYAj7p1OffFF5wd9CEpcTljClOdIGzkn1mLuPZ6Z1xSknD7YRJPvfrSg+8kfB0s6AZFgqD9bDA/QEc6TdOyTOtagSx/61l2F2pLp8T3SYiOJGVig9u9rs0+PhSdMB6/N9/kyrJlHG/Zkuu77t8Pw9HpBJHFUpKSWfHO5/gO+4iLPgUImP0LlRvWefAdHVltdPv3Kw+vzQd3r6wPVtO0TCvp58m8nk/RsFkIrZMHcyzBAzWrFWrdEEhJRsxm/Pv1pfjPxtiiJzp0JHrMd6QmJmZz5A9PJ4gsFB0eydoW7Sm5cj5hNRpQb8VCild6iDGS9s4zuvv7l4dOiyH3A/Sy1jTNZkwmoVv9kox/+1W+LPQD85OfQzaPIm5yc7hsDD3nUbMmJRcvxvuVllycOJHjwS2J3749myN/ODpBZAGlFP+Mn8XJV1pRICqCiC79aTn7RzzzeN5/4/Q7gk2jYFFPoyNc52Xg6WeboDVNe2gl/DyZ9UYD3FuP43NzP+Tsbm6Mrc3VvyaBUpi9PAkYNoyikyehkpI42akzZz78iOTY2OwO/YHojnKP6EL4cXa++xnFDu3gWKHSlBo9kgo1rc/ncE8342BxbwhbCpVbQ/A4cM2V9QFrmpal4m4mM3PFRqrv/pSnTQeIzBtEvvbjyFvEGEInNSGBC+PGc3H6dEy5cpG/Rw/yde6EKZdjfL91T2obSE64weahY8i3+BdSECKahfDS0IHkcn+IHpVndls6wYVDo8HwVF/dWknTnMyJC3FsWzCapmfH4U4Se4t2oGzrz/HxNeaIvxkRQfSob4n7809cChXCv19fvF9+GXmQUZxtQCeILJSamMiuybNJ/GkKvtdi2Vf2SaoM+5QKVcs++M6SE43+DZu+AU9/eGWC7gSnaU4uPOIo0Ys+5Om4tcQoH/4p3puaL/WmqL83APHbtxM9chQ39u3DNSCAfK93x6dVq2y7otAJIguk3LjB3hm/kjBtCvmuRBPhVwJzzz682LEF8jD/7R/9A1YNMobOqNIWmo3UldGaloNE7t2IrBpE8YSDnFQF2FSgI8Wf70698gGIQNzGjVycMJGEPXsw+/nh264tPm3b4lq4sF3j1AniESScO8/OH6bitmIxeRKuEekbyM2O3Wnyehtyuz3EPAxndsOG4XBkFeQrZQydUf7FLI9b0zQHoBSxe5Zy84+vKRwfxmnlxzK3prgGdabJk5UI9M3N9e3/cnHaVOI3bQYRvBo2xKdtG7zq1bPL7SedIB5Q6o0bHFm0grO/LsIvbBcuKpV9RavgFvIqjTq0wNP9Id60k9tg00gIXwu5vKH+AKjbG1xy7FTbmqbdohRJh1dz+Y/R+F/Yxk3lyu+pddnt25RiNRvRtGogBa/HcnnefC7/9hspsbGYfXzI07gxeZs3xyOoFmI22yQ0nSAyITn2Ekd+X8v5NevwDt1O7sQbXMyVl4hq9SnZ+TXqN6iByfQIFcczg+HcPnjqTXiyB+TK+/D70jTNeUWHcW3zBNwPzsct5TrnlQ/LU+qyN29D/Cs8zTOl/KgcdZAbq1dxbf16VEICZm9vPOvVw/PZZ/CqXx8Xv6xr/q4TxD2cCz/Job5v43/iMCaluOTuRUSpang2a86z7Zrg5+2RNQFePgke+cHtAftGaJqWMyVehyOruL5rHu7H12FWSVxWnvyVWoW/qcbVArUpVqQUT104TODh3SRv20LKhQsAuJUpjUeNmuSuUYPcNarjVqLEw9WFko0JQkReBL7HmFFuilJqeIb17sBMoBbGXNTtlVKRlnUfAt2BFOAtpdTqe73WwyaIuLgE1jRry9VyVcjf6Hlqv1iPglmVFDRN0zIj4TIc+5Pkw2tIOfoH7gnG5JkxypudqeWYmNyCM54VecZ0mToxRyh+5iheEWFInDGqbK6qVSk5f95DvfS9EoTNZrsXETPwI9AIOA38KyJLlVIH0xTrDlxSSpURkRBgBNBeRCpizGFdCQgA/hCRckqplKyO08srN8EblmF+lNtHmqZpjyK3D1R6BZdKr+CiFESHwamt5DuxlQaRW0kpU4j1Nwty6Hxull3Pw82SNZASqRS9Fk1Q/GnKFMhDHxuEZbMEAdQGwpVSxwBEZC4QDKRNEMHAF5bHC4D/iXGdFAzMVUrdBI6LSLhlf1tsEahODpqmOQwRKFgRClbEHNQNM9BcKZpbbiGlpCoiL8Zz9HwcJ2Pjibx4nXgP27R2smWCKAKcSvP8NJBxWNPbZZRSySJyBchvWb41w7ZFbBeqpmmaA0tTv2A2CaX9vSjtb/sRnp16sD4R6SkiO0RkR0xMTHaHo2malqPYMkFEAUXTPA+0LLNaRkRcAG+MyurMbItSapJSKkgpFeTv75+FoWuapmm2TBD/AmVFpKSIuGFUOi/NUGYpcGsezjbAemU0q1oKhIiIu4iUBMoCzjmguqZpmpOyWR2EpU6hL7Aao5nrNKXUAREZDOxQSi0FpgKzLJXQsRhJBEu5+RgV2snAm7ZowaRpmqbd3WPfUU7TNO1xdq9+EE5dSa1pmqbZjk4QmqZpmlU6QWiapmlW5Zg6CBGJAU7cZbUfcMGO4TwsZ4kTnCdWHWfWc5ZYdZyZU1wpZbWfQI5JEPciIjvuVgnjSJwlTnCeWHWcWc9ZYtVxPjp9i0nTNE2zSicITdM0zarHJUFMyu4AMslZ4gTniVXHmfWcJVYd5yN6LOogNE3TtAf3uFxBaJqmaQ9IJwhN0zTNqhyZIETkCxGJEpE9lp9mdyn3oogcFpFwERmUDXGOFJFDIhIqIotExOcu5SJFZJ/lWOw64NT9zpFlxN15lvXbRKSEPeOzxFBURP4UkYMickBE3rZSpoGIXEnzmfjM3nFa4rjneymGsZbzGSoiNbMhxvJpztMeEbkqIv0zlMm28yki00QkWkT2p1mWT0TWishRy2/fu2zb2VLmqIh0tlbGxnE6/Hc+HaVUjvvBmMb03fuUMQMRQCnADdgLVLRznI0BF8vjEcCIu5SLBPyy4Tze9xwBfYAJlschwLxsiLMwUNPyOA9wxEqcDYDf7R3bg76XQDNgJSBAXWBbNsdrBs5hdKZyiPMJPAvUBPanWfYNMMjyeJC17xKQDzhm+e1reexr5zgd+juf8SdHXkFk0u05s5VSicCtObPtRim1RimVbHm6FWNiJEeSmXMUDMywPF4AvGCZV9xulFJnlVK7LI+vAWE47xS1wcBMZdgK+IhI4WyM5wUgQil1t1EK7E4ptQljeoC00n4OZwAtrWzaBFirlIpVSl0C1gIv2jNOJ/jOp5OTE0Rfy2XctLtcblqbMzs7/6h0w/jP0RoFrBGRnSLS044xZeYcpZtXHLg1r3i2sNziqgFss7L6KRHZKyIrRaSSXQP7f/d7Lx3tcxkC/HKXdY5wPm8pqJQ6a3l8DihopYyjnVtH/M6nY7MJg2xNRP4ACllZ9TEwHhiCcZKHAN9ivBl2d684lVJLLGU+xpgYafZddlNfKRUlIgWAtSJyyPLfiZaGiHgBvwH9lVJXM6zehXGbJM5SJ7UYY6ZCe3Oa91KMmSBfBj60stpRzucdlFJKRBy6/b6zfOedNkEopf6TmXIiMhn43cqqTM17/ajuF6eIdAFaAC8oy81HK/uIsvyOFpFFGLd+7PFheZB5xU9L+nnF7UpEXDGSw2yl1MKM69MmDKXUChEZJyJ+Sim7DpKWiffSLp/LTGoK7FJKnc+4wlHOZxrnRaSwUuqs5ZZctJUyURh1J7cEAhvsEFs6Dv6dTydH3mLKcM/2FWC/lWKZmTPbpkTkReB94GWl1PW7lPEUkTy3HmNUclk7Hlt4lHnF7cZS5zEVCFNKjb5LmUK36kZEpDbGZ9+uiSyT7+VSoJOlNVNd4EqaWyf29ip3ub3kCOczg7Sfw87AEitlVgONRcTXctu5sWWZ3TjBdz697K4lt8UPMAvYB4RifHAKW5YHACvSlGuG0eIlAuOWj73jDMe4J7rH8jMhY5wYLYj2Wn4O2DtOa+cIGIzxAQfIBfxqOZbtQKlsOI/1MW4nhqY5l82AXkAvS5m+lvO3F6Ny8OlsiNPqe5khTgF+tJzvfUCQveO0xOGJ8QffO80yhzifGEnrLJCEUY/QHaPeax1wFPgDyGcpGwRMSbNtN8tnNRzomg1xOvx3Pu2PHmpD0zRNsypH3mLSNE3THp1OEJqmaZpVOkFomqZpVukEoWmaplmlE4SmaZpmlU4QmqZpmlU6QWiapmlW/R+V0Yr2TSGzugAAAABJRU5ErkJggg==\n",
+            "image/png": "iVBORw0KGgoAAAANSUhEUgAAAYgAAAD4CAYAAAD2FnFTAAAABHNCSVQICAgIfAhkiAAAAAlwSFlzAAALEgAACxIB0t1+/AAAADh0RVh0U29mdHdhcmUAbWF0cGxvdGxpYiB2ZXJzaW9uMy4yLjIsIGh0dHA6Ly9tYXRwbG90bGliLm9yZy+WH4yJAAAgAElEQVR4nOzdd1yV1R/A8c/hshEQUEQZoijiHuAq995bc2tppmY2bNcv21pmZaU5slzlyL23qeXGrYiCslSGoAgCss7vjwfNQcq4l3vR8369eAHPPc95vrdX8r3POc/5HiGlRFEURVEeZGbsABRFURTTpBKEoiiKkiuVIBRFUZRcqQShKIqi5EolCEVRFCVX5sYOQF9KlSolvb29jR2GoihKsRIYGHhNSlk6t9eemATh7e3NkSNHjB2GoihKsSKECP+v19QQk6IoipIrlSAURVGUXBk0QQghOgghgoUQIUKId3N5vZkQ4qgQIlMI0eeB17yEEFuFEEFCiLNCCG9DxqooiqLcz2BzEEIIHTAdaAtEAYeFEGullGfvaRYBDAfezKWLBcAXUsptQogSQLahYlUURSmojIwMoqKiSEtLM3Yoj2RtbY2HhwcWFhZ5PseQk9QNgBAp5UUAIcQSoDtwN0FIKcNyXrvvj78QohpgLqXcltMu2YBxKoqiFFhUVBT29vZ4e3sjhDB2OLmSUhIfH09UVBQVKlTI83mGHGJyByLv+T0q51he+AI3hBArhRDHhBBTcu5IFEVRTEpaWhouLi4mmxwAhBC4uLjk+y7HVCepzYGmaENP9YGKaENR9xFCjBJCHBFCHImLiyvaCBVFUXKYcnK4oyAxGnKI6TLgec/vHjnH8iIKOH7P8NRqoBEw995GUsrZwGyAgIAAVbf8aZeZDhH7IPo0ZKaCfTnwfhacvI0dmaIUS4ZMEIeBykKICmiJoT8wMB/nlhRClJZSxgGtALUKTsldZjocmg3/fA+3crmT9GkN7T6HMtWKPjZFKSKrV6+mZ8+eBAUF4efnp5c+DTbEJKXMBMYBW4AgYJmU8owQ4lMhRDcAIUR9IUQU0BeYJYQ4k3NuFtrw0g4hxClAAHMMFatSjCVcgl/bwdYPoEx16L8Y3r4EH8bBy4eg5Ydw5SjMbAJ/fw9qgyzlCbV48WKaNGnC4sWL9daneFJ2lAsICJCq1MZT5upJWNQLstKh249QrXvu7VISYP3rcHY11BmstTUz1ek3pbgJCgqiatWqRo0hOTmZKlWqsGvXLrp27UpwcHCu7XKLVQgRKKUMyK39E1OLSXnKXLsA87uCZQkYvhFK+/53W1tn6DsPdn0Je77WkkPXH6AYTCwqxcsn685w9spNvfZZrZwDE7tWf2SbNWvW0KFDB3x9fXFxcSEwMBB/f/9CX1t9jFKKn1vX4Pc+YGYOw9c/OjncIQS0+gCavglHF2jzFYryhFi8eDH9+/cHoH///nobZlJ3EErxkp0NK0ZCUjQMWw/OeV/0A0CrDyEhFLZ/Am41oVIbw8SpPJUe90nfEBISEti5cyenTp1CCEFWVhZCCKZMmVLox2/VHYRSvBz8GS7ugg6TwLN+/s8XArpPB9eqsGqMNj+hKMXY8uXLGTJkCOHh4YSFhREZGUmFChXYu3dvoftWCUIpPuKCYfvHUKUT+D9f8H4s7aDXbEhNgI1v6S08RTGGxYsX07Nnz/uO9e7dWy/DTGqISSkepISNb4KFjX4mmN1qQvN3YNcXULMPVOmonzgVpYjt2rXroWPjx4/XS9/qDkIpHs6sgkt7oNX/oESuuyPmX5PXobQfbH4PMm/rp09FeYKoBKGYvvRbsOUDcKsFAS/or1+dhTaXcf0SHJihv34V5QmhEoRi+g7NhqQr0PErMNNzUV+fVlClM+z5Bm7F67dvRSnmVIJQTFtaolYio1JbKP+MYa7RZiJkpKi1EYryAJUgFNO2fwak3dAWuRlK6SpQsy8cmgPJsYa7jqIUMypBKKYrLRH2T4eqXaFcXcNeq/k7Wk2nv78z7HUUpRhRCUIxXUd+g/QkaFYEaxVcfKB2f+2aai5CKWZ0Oh116tShdu3a1KtXj3379umlX5UgFNOUmQ4HZ0KF5lC2dtFc85nx2kZDR+Y+vq2imBAbGxuOHz/OiRMnmDRpEu+9955e+lUJQjFNp5dD0lV4Vj8LfvLE1Q8qt4eDsyAjf3v3KoqpuHnzJk5OTnrpS62kVkyPlLDvR3Ctru0GV5SeGaeVET+5BPyHF+21leJv07sQfUq/fbrVhI6TH9kkNTWVOnXqkJaWxtWrV9m5c6deLq3uIBTTc2k3xJ7V/lgX9Z4N3k21Ia19P2mVYxWlGLgzxHTu3Dk2b97M0KFD0cdmcAa9gxBCdACmATrgFynl5AdebwZ8D9QC+ksplz/wugNwFlgtpRxnyFgVE3LkV7Bxhuq9iv7aQkCjl2HVKC1R+bQs+hiU4usxn/SLQuPGjbl27RpxcXG4uroWqi+D3UEIIXTAdKAjUA0YIIR4cNf4CGA48Md/dPMZsMdQMSomKCkGzm2AOgPBwto4MVTrriWoI78a5/qKUgjnzp0jKysLFxeXQvdlyDuIBkCIlPIigBBiCdAd7Y4AACllWM5rD93LCyH8gTLAZiDX/VKVJ9CxhZCdWbhy3oVlYQ11B8GBn7WNiezdjBeLouTBnTkIACkl8+fPR6crfFkaQyYIdyDynt+jgIZ5OVEIYQZMBQYD/7nllxBiFDAKwMvLq8CBKiYiOwsC50OFZlCqknFj8X9emyg/trBo1mEoSiFkZWUZpF9TnaQeC2yUUkY9qpGUcraUMkBKGVC6tJ5KQCvGE7oTEiP0W7G1oFx8oGILLWFlG+Yfn6KYOkMmiMuA5z2/e+Qcy4vGwDghRBjwDTBUCGH82R/FsI7OB7vSWnVVU+D/PCRGQsh2Y0eiKEZhyARxGKgshKgghLAE+gNr83KilHKQlNJLSukNvAkskFK+a7hQFaNLSYDgzVCzH5hbGjsajV9nLWEdW2TsSBTFKAyWIKSUmcA4YAsQBCyTUp4RQnwqhOgGIISoL4SIAvoCs4QQZwwVj2LizqyC7Ayo/ZyxI/mXzkKr8np+s5bAFOUpY9B1EFLKjcDGB459dM/Ph9GGnh7VxzxgngHCU0zJiSVQuqq2a5wpqd1f223uzEqoP9LY0ShKkTLVSWrlaRIfClGHtLuHol45/ThutbSSHyeWGDsSRSlyKkEoxndyGSC0+QdTI4R2FxF1GK5dMHY0ipKr6Oho+vfvj4+PD/7+/nTq1Inz588Xul+VIBTjklIrjFehGTi6Gzua3NXqB8JM3UUoJklKSc+ePWnRogWhoaEEBgYyadIkYmJiCt23ShCKcUUehOth2qd0U2XvBj6t4ORSVcBPMTm7du3CwsKC0aNH3z1Wu3ZtmjZtWui+VblvxbhOrwSdFfh1MXYkj1Z7AKwYARH7wLuJsaNRTNRXh77iXMI5vfbp5+zHOw3e+c/XT58+jb+/v16veYe6g1CMJzsbgtZC5bZg7WDsaB6tSkewsNUSmqI8JdQdhGI8kQe1XeOq9TB2JI9naQe+7eHsGuj4NejUPx3lYY/6pG8o1atXZ/ny5Y9vWADqDkIxnjOrtOGlKh2MHUneVO8FKdcgTFWgV0xHq1atuH37NrNnz7577OTJk+zdu7fQfasEoRjHvcNLVvbGjiZvKrcFyxJqmEkxKUIIVq1axfbt2/Hx8aF69eq89957uLkVvky9uk9WjOPO8FL1nsaOJO8sbKBKJwhaB52/NZ2aUcpTr1y5cixbtkzv/ao7CMU47gwv+bY3diT5U6MXpN2Ai38ZOxJFMTiVIJSiVxyHl+7waQXWjnB6hbEjURSDUwlCKXrFcXjpDnMr8Ouq7ZudkWbsaBTFoFSCUIreufVgZgGV2xk7koKp3hPSk+DiLmNHoigGpRKEUrSkhOCNWu0lU18c918qNAMrRwhab+xIFMWgVIJQilZcMCRcBL9Oxo6k4MwttbUbwRsgK9PY0SiKwRg0QQghOgghgoUQIUKIh7YMFUI0E0IcFUJkCiH63HO8jhBivxDijBDipBDChLYZUwoleIP2vUoxThAAVbtC6nUI/8fYkSgKOp2OOnXqUL16dWrXrs3UqVPJ1kNhSYOtgxBC6IDpQFsgCjgshFgrpTx7T7MIYDjavtP3SgGGSikvCCHKAYFCiC1SyhuGilcpIuc2QLl64FDO2JEUjk9rMLfR1kRUbG7saJSnnI2NDcePHwcgNjaWgQMHcvPmTT755JNC9WvIO4gGQIiU8qKUMh1YAnS/t4GUMkxKeRLIfuD4eSnlhZyfrwCxQGkDxqoUhZtX4XJg8R5eusPSFiq30SbcVQlwxYS4uroye/ZsfvrpJ6SUherLkCup3YHIe36PAhrmtxMhRAPAEgjN5bVRwCgALy+vgkWpFJ3zm7TvVTobNw59qdpNu4O4HAie9Y0djWICor/8kttB+i33bVXVD7f338/XORUrViQrK4vY2FjKlClT4GubdKkNIURZYCEwTEr50Mc0KeVsYDZAQEBA4VKlYnjnNoKTN7hWfeil+NR4toRt4UTcCa4kXyGbbNxs3ajmUo1WXq2o4Fih6ON9nMrttMd1g9aqBKE8kQyZIC4Dnvf87pFzLE+EEA7ABuADKeUBPcemFLXbSXBpN9R/UdvnOUdcShwzTsxg1YVVZMksytiWobxDecyEGecSzrE1fCvfH/2exmUbM7bOWOq41jHim3iATUlt/iFoHbT99L73pTyd8vtJ31AuXryITqfD1dW1UP0YMkEcBioLISqgJYb+wMC8nCiEsARWAQuklIYpdK4UrZAdkJV+3/zD9vDtfLTvI1IzU+lXpR/9fPtRyanSfadF34pm/cX1LDq7iCGbhtDPtx8TAiZga2Fb1O8gd1W7wrpXIeYMuNUwdjSKQlxcHKNHj2bcuHGIQn5oMdgktZQyExgHbAGCgGVSyjNCiE+FEN0AhBD1hRBRQF9glhDiTM7p/YBmwHAhxPGcLxP66Kjk27kNYOMMno2QUjLzxExe/+t1vOy9WNVtFe83fP+h5ADgZufGyJoj2dhrI0OqDWH5heUM3DCQS4mXjPAmclGlMyC0uwhFMZLU1NS7j7m2adOGdu3aMXHixEL3Kwo7y20qAgIC5JEjR4wdhpKbrAyY4gNVOiN7zOCbI9+w4OwCulbsyifPfIKFziLPXR28epC3dr9FZnYm09tMp65rXQMGnke/dYLUGzB2n7EjUYwgKCiIqlUfnlczRbnFKoQIlFIG5NZeraRWDC/yEKQlQpUOzD09lwVnFzDQbyCfN/k8X8kBoGHZhizpsgQXGxdGbR3FP5dNYKGaXxeIPaOtEFeUJ4hKEIrhXdgKZuZsMs9i2tFpdKrQiXcavIOZKNj/fuVKlGNeh3l4O3rz6q5XCYwJ1HPA+eSX89iuqs2kPGFUglAML2Q7l7wCmHh4MvVc6/H5s58XODnc4WLjwqy2syhrV5ZxO8ZxLkG/z57ni1N5cKupzbMoT6XiMFRfkBhVglAMK/EyabFnmGCVipXOiq+afZXvYaX/4mztzJx2cyhhWYKXt79MbEqsXvotEL+u2j4XyUaMQTEKa2tr4uPjTTpJSCmJj4/H2to6X+eZ9EI55QkQso3pJR25kH6dGa1n4GZX+I3U7+Vm58b01tMZvHEwr+16jd86/IaVzkqv18gTv87w15daKXP/4UV/fcVoPDw8iIqKIi4uztihPJK1tTUeHh75OkclCMWgzgSvYYGjPb0r9aKpR1ODXMPXyZdJTSbx2l+v8en+T/n82c8L/fx3vpWprq0SD1qvEsRTxsLCggoVTHClvx6oISbFYDLTU5h46xwuZla8UX+CQa/VunxrxtYey9rQtSwLXmbQa+VKCO1ppku7Ie1m0V9fUQxAJQjFYP489A3Blua8V6kfDpaG3z3updov8Wy5Z/n68NcEJwQb/HoP8euirRYP2Vb011YUA1BDTIpBJN5OZMbFNTRIu02bemP11m9qehYno25wPPIGIbHJXE1MI/5WOhlZWi1HO5seSJvTDN8wnhd9plHb3ZWa7iWxNC+Cz0KeDcC2lDbMVKO34a+nKAamEoRiEHNOziExO523rH0Q1vaF6ut2ZhabT0ez8dRVdp+PIy1DSwau9la4O9ngXtIGK3MzJJLEVCsck4cTV+IHvj48ibS1/bC2MMO/vBPNKpemY42yeLkYqI6TmU6rNXV6FWTeBnMjTJYrih6pBKHoXVRSFL8H/U6P5GT8/LsWuJ+ktAx+3XORHVsPUSL2MpWyk/jExRJvF1vcvcri6OWOdTUfzMuUeWBSuhE/HUtj1slZDK/bgbQbtThwMZ5Jm84xadM5arg70L22O739PXC2syz8G76XX1c4ugAu7YHKbfXbt6IUMZUgFL2bc2oOZkhevp5YoD+SGbfTWf/rahJWr6XRlSDaZaQ81CYp5wtAV7oUJZo1w751G0o0eRZhacno2qPZd2Uf6y7/xKruq/jYtjqRCSlsPh3N+lNX+WJjEFO2BNOhhhuDG5WnvreTfp58qtAMLEtoxftUglCKOVWsT9GryKRIuq7qynPCkfcSbsD443neJ0Gmp3Putz9I+OUXnJPiSbEpgXWz5rg3fxZrvypYlCuHmZ0dSEnmjRtkRF0m7exZUo8eJXnvXrKTktCVKkXJPr1xGjiQKKtb9FvXD/8y/vzc5uf7EkBwdBKLD0Ww4mgUSWmZ1PYsyZjmFWlXzQ0zs0Imij+HQ9jfMCFYG3ZSFBP2qGJ9KkEoevXRPx+x8dJGNkZcwbXOIOg0JU/nJR84QPC7/8M2OoqQUuWxH/48zYb0wMwqb+P4Mj2d5H37uLF0Gcl//YWwtMRp4EB2N3fis+Af+F+j/9GvSr+HzktNz2LF0Shm77lIREIKFUvZ8VLzivSq54GFroAT26eWw4oR8MIW8GpUsD4UpYioBKEUicibkXRd3ZUBbs/yzr5FMGj5Y4dZstPSuPz5lyQv/5Orti4c7DKcUW8PwaVEwSd40yMiuDZ9Bonr1mFma8uO9q4s8ItlaffllHcon+s5mVnZbDodzczdoZy5cpPyLra81qYy3Wq7o8vvHUVaInztA41GQ7vPC/w+FKUoqHLfSpGYd2YeZsKM59MtwNwavJs8sn16WBghffqRvPxPVlRqzoXJs3n3kxGFSg4All5elPtqMhXXrcWmdm1arrjIx3NT+fGPV8nMzsz1HHOdGV1rl2P9K02YOywAW0tzXl96gg7f72HTqatkZ+fjg5S1Y85WpOvhCfkApjydDJoghBAdhBDBQogQIcS7ubzeTAhxVAiRKYTo88Brw4QQF3K+hhkyTqXwrqddZ03oGrr6dMX14h7wbgoWNv/ZPuXoMUL79edG5BW+aPoiTb/9jJfaVdNriQwrHx88f5mD+/ff455RguHTgtn+8ShkZu5JAkAIQeuqZdjwShOmD6xHtpSM+f0oXX/6m70X8lFrx68zXL8EsWf18E4UxTgMliCEEDpgOtARqAYMEEJUe6BZBDAc+OOBc52BiUBDoAEwUQjhZKhYlcJbGryU21m3GVquJSSEQuV2/9k2aedOwoc/z1Vpyf/aT+Ctj16guW9pg8QlhMChQ3uqbdrKpfrulF+2n6DnepMeEfHI88zMBJ1rlWXr6835tl9tElMzGDL3EEN/PUTQ1TyU0rizFakqAa4UY4a8g2gAhEgpL0op04ElQPd7G0gpw6SUJ4HsB85tD2yTUiZIKa8D24AOBoxVKYTbWbdZfG4xTdyb4BOdsy/Df8w9JO3cSdQr4wm1d+OLDq8z/c2u1PYsafAYdQ4ONJuzgt/6OpEWGsKl3r1J2rnr8eeZCXrV82DHhOZ82LkqJyJv0OmHvbz15wmiE9P++0T7MuBRX+1VrRRrhkwQ7kDkPb9H5RzT27lCiFFCiCNCiCOmXmr3SbY+dD0JaQkMrz5cq0PkUhmcH65umbx3L1GvvsZFJw8mtR7LzHFtqORaosjidLRypMfob5jwgiDBxYqosWOJnTYNmZX12HOtzHWMbFqRPW+1ZGSTCqw5foUW3+xiypZzJKVl5H5S1S4QfRJuPPpuRVFMVbGepJZSzpZSBkgpA0qXNswQhfJoUkoWnF2An7MfDZxrwKW9ud49pJ46RdQr44l0cOPzZi8x66XmVC5TuBIcBfGM+zO0aTCAl/veIL1jU+J/nknkqJfIunEjT+c72lrwQedq7JjQnHbV3Ji+K5QWU/5iwf6wu/Wg7vLron1Xw0xKMWXIBHEZ8Lznd4+cY4Y+VylCB6MPcjHxIkOqDUGE/w1Ztx9KEBmXLxM5ZiwJVva832gE341sRg13RyNFDG8EvIG7cwUmNA6l5EfvknLoEGHP9Sc9LCzPfXg62/LDgLqsHfcslVxL8NGaM7T/bg9bz0T/u7OYiw+Urqr2qlaKLUMmiMNAZSFEBSGEJdAfWJvHc7cA7YQQTjmT0+1yjikmZlnwMkpalaS9d3u4sBUsbKH8s3dfz0pOJnL0GFKTU3gnYDhvD3iGRhVdjBgx2JjbMKnpJK6lxfOD5zm85v1GVmIiYc/1J+Xw4Xz1VcujJEtGNWLusADMzASjFgYyYM4BTl9O1BpU7QIR++BWvAHeSe4yszMJig9i6bmlfBf4HR/v+5gvDnzBrBOz2BGxg5vpar8KJW8MVotJSpkphBiH9oddB/wqpTwjhPgUOCKlXCuEqA+sApyArkKIT6SU1aWUCUKIz9CSDMCnUsoEQ8WqFExsSiw7I3YypNoQrMwstQRRscXdKqZSSq6+/wFpoaFMbPwinbs8Q78Az0f2WVRqlKrBqFqj+PnEz7Ro3oKWy5YS+dJowl8YQdnPPqVkjx557uvOo7HNfEuz5FAE322/QNef/qZ3PQ/eq9MWFzkFzm+CuoMN+I7gTPwZVl1YxZawLdy4rQ2ZWZhZ4GjlSEZ2Bom3taRlLsxpXK4xQ6oNoVHZRkW/+55SbKiV1EqBzTwxk+nHp7Oh5wa8bqfB9PrQ+VuoPwKAhAULiPlyEr/V7Epcpz7MHVa/8HWO9CgjO4OhG4cSmRzJym4rccmwImr8q6QcPIjLmNGUfuUVhFn+b7ITUzOYsSuE3/4JQ2cGh2xfxcarLuaDlhrgXcDRmKPMPDGT/Vf3Y6WzoqVnS1p4tqCua13K2pW9mwBSMlI4l3COv6L+Yl3oOq6lXiOgTAAfNPyASk6VDBKbYvpUqQ1F7zKzM+mwogMVHSsyu91s2PcTbP0AXjsFJb1IPX6csMFDOF62Kj+2HMWGV5vhpO/S2npwKfES/db1o0apGsxpNwddZjZXP/2UxOUrcOjcmbKTvsTMsmBxR8SnMHlzEPWDvmKA+S42d/yHbvUr6y1JxtyKYcqRKWwJ24KztTPDqg+jr29f7C0fP/mfnpXOygsr+fHYj6RkpPC6/+vaPJK6m3jqqFIbit7tidpDTEoMz1V5TjtwYas2IVvSi6zkZC5PeJNEu5JMrt2Pnwb7m2RyAKjgWIEPG33IkZgjzDg+A2FpSdnPPqP0G29wc8MGIl54gczr1wvUt5eLLTMG+dO48zCsSWfzmt/pNv1vDlws3HyElJLfg36n2+pu/BX5F2PrjGVz7828UOOFPCUHAEudJf39+rO+53qaejRlypEpvLn7TW5n3S5UbMqTRSUIpUCWnV+Gq60rzT2bw+0kCN939+mlmMmTSb9ylU9q9eeV7vWo52Xai+C7V+pOr8q9mHNqDnuj9iKEoNSoF3H/dippJ08R3n8A6eHhBe7fr0F7pI0TH1QMJT45nf6zD/DSwiOEXbuV774Sbycyfud4Jh+aTL0y9VjVfRVjao/Bxvy/y5o8ipO1E9NaTuO1eq+xNXwrL29/mVsZ+Y9LeTKpBKHk29Xkq+y7vI9elXthbmau7Z6WnQGV25K0axeJy1ewskorSjUKYESThxfMmaL3GrxHFacqvPf3e1xNvgqAQ6dO/z7h1H8AKUePFaxznTnCtyOe1/aw87VnebOdL3svXKPtd7v5fP1ZElP+Y6HdA47HHqfPuj78feVv3m3wLjNaz8DTvvCT/kIIRtQcwRdNvuBIzBHGbh9LamZqoftVir88JQghxEohRGchhEooCmtD1yKRdPfJqZxyYStY2pNZogpXP/wfV0t5sLJmB77uU6vYjGlbm1sztcVUsrKzeGXnK6Tk7GJnW68e3ksWY+ZgT8Tw4dzcvLlgF6jaBdISsbmyn3GtKvPXmy3oXc+Duf9covk3u5j3z6WHF9rlyJbZ/Hr6V4ZvHo5O6FjYcSGDqg7S+3/bbj7d+KrZVxyLPcabu98kIztviUt5cuX1D/4MYCBwQQgxWQhRxYAxKSZMSsma0DXUd6uPh72HVs76wjbwaUHM11PJuJHIpzX7MbF3Hco6FmzYw1jKO5RnSvMpXLhxgbf3vE1WtlaCw9LbG+8lS7CuUYPLr71O/C+/kO+HOyq2BHMbOKctmnN1sGZy71pseKUp1cs58PG6s7T/bg/bz8bc13dCWgIv73iZ7wK/o5VXK5Z1XUaNUjX09p4f1N67PR82+pA9UXv46tBXBruOUjzkKUFIKbdLKQcB9YAwYLsQYp8Q4nkhhIUhA1RMS2BMIJFJkfSolLNOIPYs3LxMclplbq5bx1LfllRv4k+32uWMG2gBNXFvwrsN3mV31G6mBk69e9zcyQmv337FoVMnYr+ZSvTEjx9ZNvwhlrZQqbVWdiP73zuFauUcWDSiIXOHBYCAkQuOMHjuQUJikwiMCaTv2r4cvHqQDxp+wNTmU3GwdNDn281Vvyr9eL768ywNXsqqC6sMfj3FdOV5oZwQwgUYDAwBjgG/A02AYUALQwSnmJ7VIauxs7CjjVcb7cCFbWRnQvTCvVwrWYbNtdqzuUeNYjO0lJsBfgMISwxj4dmFOFs7M7LmSADMrKwo980ULDw8iJ89m4wrV3D//jt0JfJYcNCvi3YHceUYePjfPXzvQrvfD4Qzdds5uiz8BMtSW/Eo4cHvnX6nqktVQ7zV/zS+3njOJpzl8wOf4+vkS/VS1Yv0+oppyOscxCpgL2ALdJVSdpNSLpVSvgIUXTlOxahSMlLYGr6V9t7tsbWw1Q5e2Ma1CB8yoggVqTQAACAASURBVC4ztXoP3ulWG2cTfaQ1P96u/zadKnRi2tFpLDy78O5xYWaG6xuv4/bZp9zav5/wQYPJiI7OW6e+7UHo4FzuJcAtdGZ0qWdPQMMVWJTaQnpiLW6EjCMqxlkfbylfzM3MmdJsCs42zryz9527czLK0yWvcxBzpJTVpJSTpJRXAYQQVgD/tcBCefJsDd9Kambqv8NLaYncPnWI+MA09pQPwK5xI3rVy2tFd9OmM9PxRZMvaOPVhq8Pf8280/Pumxtw6tsXz1mzyIiKIqzfc6QFBT2+U1tn8H72P6u7/n35b3qv7c2p+ON81Pgj5neZRglLO15ccISR8w8TmVC0f6SdrJ344tkvCL8ZzreB3xbptRXTkNcEkdvO6/v1GYhi+laHrMbbwZs6pesAIEN2Eh1oT4a5Jb/U7MrnPWoW66GlB5mbmfN1s69pV74dUwOn8vXhr8mW/84flGjyLOX/+APMzAgfNJjk3bsf36lfV7h2HuLO3z2UlpnGlMNTGLN9DM7WzizpvIS+vn1pWNGFDeOb8n4nP/aFxtP++z3M3xeWv/2xC6lB2QYMrTaUpcFL+fvy30V2XcU0PDJBCCHchBD+gI0Qoq4Qol7OVwu04SblKRF5M5LAmEC6V+p+Nwkkr1lMSowVc33bM6xTXSqUsjNylPpnobNgSvMpDK46mEVBixi7fSwJaf/WjbSu4ov30qVYeJcncsxYrs2ajczO/XFVAPw6ad9znmY6ePUgvdb2YsHZBTxX5TkWd158X10kC50Zo5r5sO2N5tT3dmbi2jP0n32ASwVYZFdQ4+uNp6JjRT7b/5kaanrKPO4Ooj3wDdp+DN8CU3O+3gDeN2xoiilZf3E9AkGXitomONlpacSsPkmGgwVBDdszqpmPkSM0HDNhxtv13+Z/jf7H4ejD9F3blz1Re+6+blHGFe+FC3Ho0J64774j6pXxZCUl5d6ZoweUq8vlc2t4d++7jNyqTYD/0u4XPmz0Idbm1rme5l7ShnnP12dKn1oERd+k47Q9/LL3IllFcDdhpbPio8YfceXWFWaemGnw6ymm45EJQko5X0rZEhgupWx5z1c3KeXKIopRMTIpJRsvbSTALQA3OzcArs+YQkaSYHtNf/7XvSaW5k/2GkohBP2q9OP3zr9jZ2nHyzteZvzO8QQnBANgZmdHualTKfP+eyTv3s2lPn1ICz7/UD/hN8P5snRpulrEsz1sGyNrjmRlt5U0LNswTzH0DfBk+xvNaVKpFJ9vCKL/7P1EXTf8p3r/Mv70qqzd6dx5z8qT75HVXIUQg6WUi4QQE4CHGkopTWbmSlVzNZwz187Qf0N/Pm78Mb19e5N57RohrVth55LEd0Nm8+3zD28x+iTLyMpgwdkFzD45m5TMFBqXbUzHCh1p4t6E0ralSQkMJOq118hOSqbMe++R1LERB64eYFv4Ng5cPYC50NHtZiJj6r6C27NvFCgGKSWrjl3mozVnEAK+6FnT4GtPbqTdoNvqbpR3KM+CjgueqPmmp9mjqrk+bh3EnUFl9SjrU2zDpQ2Ym5nTpry29iFu2g/I9Ayu13Lk1W7PGDm6omehs2BEzRH08e3D0uClrDi/go/2fQSAi7ULrrauuIzzoPOC88iJEzn0u2BWRzNKlvFiTO0x9K3ch9K/doTQ3VDABCGEoFc9DwLKO/Pq0mOMX3yM3cFxfNK9OiWsDLMPWEnrkrxa71U+3v/x3cedlSebQfeDEEJ0AKah7Sj3i5Ry8gOvWwELAH8gHnhOShmWszr7F7SV2+bAAinlpEddS91BGEZWdhZtl7elRqka/NDqB26HhBDarTvOPkmEduvLsy9OfXwnTzgpJUEJQQTGBHL++nkS0hJIy0yjhM6OxnuvUXPFScwcHfCY/BX2TZtqJ22bCPt/grdCwKZw1W4zs7L5YccFftoVgqezLdMH1jPYnt9Z2Vn0Xd+XlIwU1vRYg5XOyiDXUYrOo+4gkFI+9gv4GnAALIAdQBww+DHn6IBQoCJgCZwAqj3QZiwwM+fn/sDSnJ8HAktyfrZFK+/h/ajr+fv7S0X/Dlw5IGvMqyE3XdokpZQyYsxYeaJGTZnxbkmZcvGAkaMrHlKDgmRoly7ybBU/efn992Xm9etSRhyScqKDlMcX6+06By/Gy0Zfbpe+H2yUSw9H6K3fB+27vE/WmFdD/nrqV4NdQyk6aFtA5/p3Na8zi+2klDeBLjl/rCsBbz3mnAZAiJTyopQyHVgCdH+gTXdgfs7Py4HWQhvYlICdEMIcsAHSAbXTuhFsuLgBW3NbWni0IOXYMZJ37uSGrx1Z9iWxKV/f2OEVC9Z+fnj/+ScuI0eQuHoNoZ27kHjsKtK+HJzRX62jBhWcWf9KE/zLO/H28pO8t/IUaRlZeuv/jsblGtPMoxmzT87melrBNlNSioe8Jog7g5qdgT+llIl5OMcdiLzn96icY7m2kVJmAomAC1qyuAVcBSKAb6SUCShF6nbWbbaHb6dN+TZY6ayI+eZbEq3tqVUtCku/tlCA/ZqfVmbW1ri++SYVVizHwt2dK2+/Q+QeV9KO7IIU/f2v7VLCigUvNGBMCx8WH4qg3yzDPOX0hv8bpGSm8Nvp3/Tet2I68vovfL0Q4hzaXMEOIURpIM1wYdEAyALKARWACUKIig82EkKMEkIcEUIciYuLM2A4T6e/o/4mKSOJThU6cWvPHtICj/BXldqU1N1EVG5n7PCKJWs/P7wX/0GZDz8k9cotLm1y5uqEMWTExurtGuY6M97p4MfsIf5cirtFt5/+4UiYfj9f+ZT0oXOFziw+t5i4FPVv70mV13Lf7wLPAAFSygy0T/cPDhc96DJw73ZXHjnHcm2TM5zkiDZZPRDYLKXMkFLGAv8AD02iSClnSykDpJQBpUuXzstbUfJhw6UNOFs706BMfa5+8y3RJUrhV98chBn4tDJ2eMWW0OlwHjyISlu34VzLkhu7TxLaoSOx33xD5rVrertOu+purBn3LI42Fgycc5BVx6L01jfAmNpjyMjO4JdTv+i1X8V05GeMwA94TggxFOgDPO4j5GGgshCighDCEm0Seu0DbdailQsnp8+dOZMmEUArACGEHdAIOJePWJVCSkpPYnfkbjp4dyBl42YyL5xnvl972tucBo8GWuE5pVB0Tk6UGTsEn44x2DdtRPyvvxHSug3RX3xJxpUrerlGxdIlWDX2GfzLO/H60hNM3Rqst1pOng6e9KjUgz/P/3l3m1blyZLXct8L0UpuNAHq53w9soprzpzCOGALEAQsk1KeEUJ8KoToltNsLuAihAhBK9/xbs7x6UAJIcQZtETzm5TyZL7emVIoOyJ2kJ6dTievdlz9/gdCS7rj1bERNnEnofLTtTDOoGr2xtI+C/d+vvhs3IBD585cX7yYkDZtiRw3jlv79uV/97oHlLS1ZP4LDXguwJMfd4YwbvFRUtP1M3n9Uq2XAJh9arZe+lNMS57WQQghgtAeUS26MpL5pNZB6NeoraOITIrkDzmC6A//x2fPjGD6yFI4bX0VXtoLZWsZO8Qnx5zWkHUbRmvVUjMuX+b6kqXcWL6crOvXsfT2xrFHDxy6dMbSw6PAl5FS8sveS3y5KQh/LyfmDquPo23hN4T88uCX/Bn8J+t7rce9xJNR7v1p8qh1EHkdYjoNuOkvJMWUXUu9xsHog3T2as/V6TO5UNKDmr074RS1C0q4gVtNY4f4ZKnZF6JPQaw2imrh7o7rhDeo9Ncuyn39FToXF+K+/57QNm0Je64/CQsWkB4Rke/LCCF4sVlFpg+sx8moRPrO2kd0YuGfNXmhxgsgYN7peYXuSzEteU0QpYCzQogtQoi1d74MGZhiPJsvbSZbZtM+2AZx9TKra3ZgbLPyELIDfNuBqsGjX9V7ahP/p/6877CZlRWO3brh/fsiKu3YTukJb5CdmkrMl5MIbdee0I6diJn8Fbf27SM7Je+PsnaqWZZ5z9fnyo00ev+8j5DY5EKF72bnRnef7qy8sJJrqfqbZFeML69DTM1zOy6lzMMOKUVDDTHpz8ANA8nKSOejaTe4mAJRk2cyxisSFvaAAUugSkdjh/jkWdgTroXAqyceu74kPSKC5L92k7x7NymHDiEzMsDcHJsaNbCtXx/bBvWxqVv3sXtln76cyPDfDpOVnc2vw+tT16vgJT/Cb4bTbXU3hlcfzuv+rxe4H6XoFXqIKScRhAEWOT8fBo7qLULFZITfDOfUtVMMifLG7Opl1tfpyLBnvSF4E5hbQ4VcPysohVVnECRGQNiexza19PLCeegQvOb+gu+B/XjOnoXL888DEP/bb0S+OIrzDRpysWcvoj/9jMQNG8i4+vBTRjXcHVkxpjH21hYM+uUg+0PjCxx+eYfytC/fnqXBS0m8nZd1tEpxkKeyj0KIF4FRgDPgg7YCeibQ2nChKcaw8dJGdNngueIooQ7laDi4J7YWOi1BVGwJlmojQYPw6wzWjnBsEVRskefTzOzsKNGsGSWaNQMgOyWF1OPHSQk8Suqxo9xYvZrrf/wBgHnZstjWq4dNvbrY1quHla8v5V3sWD6mMYPmHGT4b4eYMzSAZr4FW1M0ouYINoVtYsm5JbxU+6UC9aGYlrzWBX4ZbXXzQQAp5QUhhKvBolKMQkrJxosbGXS5PJZXQ9nUfCRTG5WH2LPap9tmbxo7xCeXhY02WX1sEaTeAJuSBerGzNYWu2eewe4ZrQy7zMwkLTiY1KPHSDkaSMqRI9zcsEFra2eHTZ062NSry4I6NRl91JyR84/w8+B6tK5aJt/XruJcheYezVkUtIgh1YZga6E+TBR3eU0Qt6WU6Xc2CMlZ9Wyyj7wqBROUEET4jUs03+bIJYeyNB7WC2sLHQRv1Br4qvr/BlVnEBz+BU6vgPoj9NKlMDfHpnp1bKpXx3nIYKSUZF65QkpOwkg9eoxrP00HKZms0xHl7MGhE+URQ3rSsk9bhE6Xr+uNrDmSIZuGsCpkFYOqDtLLe1CMJ68JYrcQ4n3ARgjRFq1M9zrDhaUYw4aLG2h6zgz7mAQWtRzBNw3Kay8EbwZ3f7BXTzobVLm64Fodjv+utwTxICEEFu7uOLq749hV2188KylJG5Y6ehTLI4GUOboPi4l7OD21JKXat8W+fXvsGjfKU7Ko41qHOqXrsOjsIvpX6Y/OLH8JRjEteX3M9V20PSBOAS8BG4EPDRWUUvSysrPYErqJ5/aZc8nBjSbP99X2mU6KgctHwFc9uWRwQkDdQXA5EGLOFtlldfb2lGjaFNdXX8Vn4QK8//6HZZ3H8I+DNwnr1hM5ciQhrdsQO20a6ZGRj+1vaPWhRCVHsStyVxFErxhSXp9iygZWA2OllH2klHNMeVW1kn+BMYH4HIuhdFwqOwK60Ms/p87i+c3ad/Voa9Go9RyYWcDR+Y9vayAOTg68+eVYdvR5hd7tJxL35sdYVa5M/MxZhLZtR+TYl0k5+t8PMbbybIVHCQ/mnzHee1D045EJQmg+FkJcA4KBYCFEnBDio6IJTykqG0LX0+cfCLd3pdnIfpjrcv7XOL8ZHD2hTHXjBvi0sCsF1XvA8T/gduEWsBUqDCtzfh1eHz+vUoy4ZE/IhM+otHMHpcaOJfXoUcIHDiJswECSd+9+qFaUzkzH4GqDOR53nBNxJ4z0DhR9eNwdxOvAs0B9KaWzlNIZaAg8K4RQq2GeEOlZ6VzftBGPa9nsatCVLnVy6v1kpELoLu3uQa2eLjr1X4TbN+HUMqOGYW9twfwXGuDn5sDoRUfZn2RO6fGvUGnnDsp8+CGZsbFEvjSa8CFDSDl27L5ze1bqib2lvbqLKOYelyCGAAOklJfuHJBSXgQGA0MNGZhSdPZG7qbz7ltEOpSk5aj+6MxyksHF3ZCZCr4djBvg08azgVbv6tAvYOSRXEcbCxaOaEDFUna8uOAI+0PjMbO1xXnwIHw2b6LMR/8jPSyc8AEDiXr1NTKiowGwtbCln28/dkTsICpJv/tQKEXncQnCQkr5UHEVKWUcUPgykIpJOLPiV7yuwe4GPWlf655qnMEbwdIevJsYL7inkRDQYBTEnoGI/caOhpK2lvw+siFezraMmH+YwHBtH2phYYHzwIFU2rKZUq+MI/mvv7jYqTMJ8+cjMzMZWHUgZsKMRUGLjPwOlIJ6XIJIL+BrSjGRlHaTKqtPEFXShtZjBnNnrQvZWdrq6UqtwdzKuEE+jWr0AeuScMg09llwKWHF7y82xNXeiud/O8S56Jt3XzOzs6P0yy9Tcf06bAL8iZk0mbD+A3CMTqZThU6svLCSm+k3H9G7YqoelyBqCyFu5vKVBKiaz0+AfUum4RUn+athW1pWK/vvC5EH4VYsVO1qvOCeZpa2UHcwBK2Dm/rZXa6wXO2tWTiiITaWOobOPURE/P0VZC09PfGcNQv3774lIyqKS716MySoFKkZKSw/v9xIUSuF8cgEIaXUSSkdcvmyl1KqIaZiTmZnYz5vFVecdHQY/dq/dw+g/WHSWarV08bU4EVtDuLADGNHcpensy0LRzTkdmY2Q349SGzS/ftJCCFw6NiRCmvXYBsQgJw6m0nrHFgVuJCM7AwjRa0UVH72pM43IUQHIUSwECJECPFuLq9bCSGW5rx+UAjhfc9rtYQQ+4UQZ4QQp4QQ1oaM9WkUtn4l5aJT2dqoFk387lklLaWWIHxagZW98QJ82jl5a3tFHPkNUq8bO5q7fMvY89vz9YlLus3QuYdITH34D7+Fqyuec2ZT5oMPqBh8kwk/R7N7x7yiD1YpFIMlCCGEDm1v6Y5ANWCAEKLaA81GANellJWA74Cvcs41BxYBo6WU1YEWgPr4oUdSSiKmTeOqEzQa/vr9dw9XjkFipBpeMgVNXoP0ZDg819iR3KeelxOzhvgTGpfMiHmHc93jWgiB85DBlF+4EKtsHa6vf8eN1WuMEK1SUIa8g2gAhEgpL0op04ElQPcH2nQH7jwovRxoLbS/VO2Ak1LKEwBSyngppX52WVcAuLZ1O66Xr7G+cWl61q5//4tB60DooEon4wSn/MutJlRqAwdnautSTEjTyqX5/rm6BEZcZ+zvgWRkZefazq5uXa78+AbB5eDqu+8S98MPDy2uU0yTIROEO3Bv4ZaonGO5tpFSZgKJgAvgC8icLU6PCiHezu0CQohRQogjQogjcXFxen8DTyopJSHffEN0SXDp1u/BFyForfZoq62zcQJU7tfkdbgVp5UCNzGda5Xlix412RUcx1t/niA7O/c//J38B/DTMCfOPePOtRk/c+Wdd8hOVw9CmjqDzkEUgjnQBBiU872nEOKhzYmklLOllAFSyoDSpQu2ycnTKG7bDkpGRrCqsY4R9fs88OI5iA9Rw0umpPyz4NkQ/v4OMtIe376IDWzoxZvtfFl9/ApfbTmXaxsbcxt6Ve3Hx81jsRw9nJtr1xE58kWykpKKOFolPwyZIC4Dnvf87pFzLNc2OfMOjkA82t3GHinlNSllClr12HoGjPWpIaXk4jfTiHHUEdu0Dm52D5TwDloHCJUgTIkQ0OpDuHkZjvxq7Ghy9XLLSgxq6MWs3ReZ98+lXNsM8BuAmZmO5c9AuSlfk3LsGBHDhpN53XQm4JX7GTJBHAYqCyEqCCEsgf7A2gfarAWG5fzcB9iZUyV2C1BTCGGbkziaA0VX//gJFrttF44RIax6RtKnRo+HG5xdq5V6UHs/mJYKzbT9wPdONWoRv/8ihODT7jVoW60Mn6w/y6ZTD++B7WrrSgfvDqy8sBKz9i3w/OlHboeEEDF0KBmxsUaIWnkcgyWInDmFcWh/7IOAZVLKM0KIT4UQ3XKazQVchBAhwBto+04gpbwOfIuWZI4DR6WUGwwV69NCu3v4nhh7a/6uZUHb8m3vb5BwEWJOqbsHU9X6I0i5Bgd/NnYkudKZCX7oX5e6niV5delxDoclPNRmSLUhpGSmsPLCSko0b47n7NmkX75C+JAhZFwxjQWByr8MOgchpdwopfSVUvpIKb/IOfaRlHJtzs9pUsq+UspKUsoGOYUA75y7SEpZXUpZQ0qZ6yS1kj8xW3dSMuICa5uY0aR8cxytHO9vcGa19r1qt4dPVozPIwCqdIa/v4ebD39CNwU2ljrmDquPR0kbRs4/Qkjs/XMM1Vyq4V/Gnz+C/iAzOxO7Rg3xmvsLWQnXCR82nIyYGCNFruTGVCepFT2TUnJx6vfE2JVgZ83bdKuUSxI4vQI86oNT+aIPUMmbdp9BVjps/9jYkfwnJztL5r/QAAudGcN+PUzMzfsn1odWG8qVW1fYGbETANu6dXOSRAIRw58n89pD9UEVI1EJ4ilxdcsOnCJC2N68DPa2TjRzb3Z/g9hzEHNaKxKnmC4XH2g8Dk4ugYiDxo7mP3k62zLv+frcSEln2K+HSEr7d51rc4/meNp7suDsgrvHbGrVwnP2LDKio4l4/gU1cW0iVIJ4CkgpuTR1GtG2JdlS6wqdKnTCQvdAKa0zK0GYabuZKaat6QSwLwcbJ0CW6RYYqOHuyM+D/QmJTWb0okDSM7WFdDozHYOqDuJE3AlOxp28297W3x/Pn2eQHhFBxAsjyLqpKsAam0oQT4HLW7bjHBnCwVY1SRMZDw8vSQmnlmuL49TTS6bPqgR0nAzRp7T5CBPWzLc0k3vX4p+QeN5e/u9Cup6VemJvYc/Cswvva2/XqBEeOU83Rb08juzbt40RtpJDJYgnnJSSsKk/EG3rzLHGiVQqWYlqzg+UxLp6AhJCoUZv4wSp5F+17lC9F+z+CqJPGzuaR+rj78Fb7auw+vgVvtkaDGg7zvXx7cO28G1cTb5/wr1E06aUmzSJlMOHufLW28gsVWXHWFSCeMJFbdqOS2QIZ9u25WzyWbr5dLu/MB9ok9Nm5urppeKm0zdgUxJWvWRydZoeNLaFDwMbejHjr1AWHggHYGDVgQD8ce6Ph9o7dumM67vvkLR1KzFffKlqNxmJShBPMCklYd9OI8bWmRudbDETZnSp2OX+RtnZcHol+LRWtZeKGzsX6D5De7hg45vGjuaRhBB82q06rf1cmbjmNNvOxuBm50bb8m1ZcX4FtzJuPXSOy/DhOI94get//EH8LNPYWe9poxLEEyxk3VZKRYUS3rEvf8Vto3G5xpS2faBmVdQhuBkFNdXTS8WSbzto+qZWyC9w/uPbG5G5zowfB9alprsjryw+yrGI6wytNpSkjCRWh6zO9RzXCRNw6NaVuO+/58bKVUUcsaISxBNKSsnl738gxs4ZtyG1ib4VTXefB6utAyeXgbk1VOlY9EEq+tHyfajYEja8ASHbjR3NI9lamjN3eH1c7a0ZMf8I9qIidUrXYdHZRWRl57KnhJkZ5b74ArtnGnN14kRuHTpkhKifXipBPKHOLFtLmSsXie02kF1xW7C3sKelZ8v7G2Xe1uYfqnZVO8cVZ2Y66LcASleFpUMhKtDYET1SqRJWzH+hAVJKhv12iB4V+xOVHMVfUX/l2l5YWOD+/fdYenlx+ZXxpIeFFWm8TzOVIJ5AMiuLhB9+4IqDK43H9WZb2DY6VeyEtfkDu7YGb4K0G1B7gHECVfTH2gEGLwe7UrCgO4T9Y+yIHqlCKTvmDq9PdGIa83fYU9au3EOPvN5L5+CA58yfwcyMyJdGk3XjRhFG+/QyN3YAiv4Fzl1M6fgrnHvpXfbE7iA9O52+vn0fbnj8D23BVcUWRR2iYgj2bvD8JljYAxb1gp4ztT2ti0pWhlbwMe4cxIdCSrz2lZWh3eVY2Gj/vzl6QNna1HP348cBdRm9KJCqJZoReGsJZ+LPUN2leq7dW3p64jH9JyKGDSdq/Kt4/TIHYWlZdO/vKSSelMfHAgIC5JEjR4wdhtFl377N/qZtuGluQ/Od6xm05TmsddYs7rL4/oZJMfBtVXh2PLT52BihKoZyKx4WPwdRh6HBS9D2U7Cwfvx5+ZV6AyIPQvg/EL5f28s8+56V3RZ22pNxOkvIzoSMFG1nvLuv20KF5uyzaMhLx1wwr/IT7Su0YnKzyY+8bOK6dVx5620ce/ei7OefP/zYtpIvQohAKWVAbq+pO4gnzP4ff8X55jVuvPU552+eJeRGCB83/vjhhqeWgcyC2gOLPEbFwOxcYPhG2D4RDsyAC1uhwyTw7aBtPlRQWRla0gndqX1dOQYyG8wsoFxdaDQGytSA0r7gUllb8f2gzHS4EaGdG3kQzm/mmcRNHLW2YvT1ymxiE6/7v04ZuzL/GYZj166kX7rEtRk/Y1WxIi4jRhT8PSmPpO4gniAZybc42rQVsY6udNi+mk8OTGRb+DZ29duFrYXtvw2lhJ+f0T7BvbjDeAErhhe6Cza9DdfOg1staDga/DqBjdPjz81M1/YHiTwEF3dD2F5ITwahA3d/8GkJ3k21ny1tH99fbqSEq8eRR+Zx6dQyerq70CerFP/rNltLNP95muTyG2+QtHkLnjN/pkTz5gW7vqLuIJ4We6fMoGzqTZLf+4y07BS2hG2hi0+X+5MDaKU1Ys9C52+NE6hSdHxawph92jqJgzNhzVhYq9P2lihTA5wrgrWjtpI+PVmbM0i4pO1LHnMaMnNKdTtVgFrP/ZsUbErqJz4hoFxdRLe6uLf8CL/FvdlsHscbPzfGrtEYaPEeWNrlcpqg3JdfEhYezuUJb+K9bClWFSvqJyblLoPeQQghOgDT/t/efYdHUbUNHP49uymQBJJAQgmhN+ktAgoq6AtI0SA1vtIRBARFsGBXioIgKL7Si4AgIFKlC1JUitRQQkkglFASCC0hkHa+P2bhS8ICAbKb3XDu68qV3Zkzs8/M7ubJzGmAGZiilBqeYb07MBOohTEXdXulVGSa9cUwphr9Qik16l6v9bhfQVyLucihFxoTFVCa4JXzmHd4HsO2DWNu87lU8stQ6bf8Xdg1E949nLn/JLWcQSnjFtGRVRD5lzHE9Y955AAAHm9JREFU+80rd5bLW8RIHIWrGYkk8EmjYtkONp/6lz7ru9Esxp8RcTvBpxi8/MNdG1IknTnD8bbtMOfJQ4n58zDnzWuXOHOSbLmCEBEz8CPQCDgN/CsiS5VSaeeW7g5cUkqVEZEQYATQPs360cBKW8WYk2z6fBQlEhMo/oEx5MKCIwuokK8CFfNnGJgvMR5C5xnDeuvk8HgRMeYbL1rbeK6U0cz55jWjEtktj9EfxhYV2plUPzCI8j6VWJkczeUbg/lRZuIysyU8MwAafATm9H+yXAMCCBz7PSe6dCVq4LsUnTAeMZuzKfqcx5b9IGoD4UqpY0qpRGAukLErbzBwa3yABcALYmmSICItgePAARvGmCOcDgun6IZlHK7+LDUa1mZX9C4OXzpM2/JtrQ/Md/MqBHXLnmA1xyFi/JPgU8y4YvDyz9bkYIQkdK/aGeUSw9+uKbRK+ZrEqv+Fzd/CT83h6p3zVnvUqkWhTz8hfvNmor/Vt02zki0TRBHgVJrnpy3LrJZRSiUDV4D8IuIFfAB8ea8XEJGeIrJDRHbExMTcq2iOtufTr0gVE7W+HATAnLA55HXLe+fAfAA7pkGBilC0jp2j1LTMaVS8EUW8ilCqzFYOXkii84VOJLecbNSJTH7eaAGVgW+7dvj+97/ETpvGlSVLsiHqnMlRe1J/AYxRSsXdq5BSapJSKkgpFeTv73+vojnWvjV/U3r/Fo6/0JLi5UtwLv4c606uo1XZVuR2yZ2+cNQu48sV1O3Rmjtqmg25mFzoXqU7x+PCeKNJCluOXeTdQ2VJ7brKqEyf1hQO3pkECn44CI86dTj76WckhIZa2bP2oGyZIKKAommeB1qWWS0jIi6AN0ZldR3gGxGJBPoDH4lIXxvG6pRSU1M58/VwLufKQ8MvBgIw//B8FIqQJ0Lu3GDndKNpa9V2do5U0x5McOlgCnoU5EDCwtuTDY3c6wo91kOhyjC/M/w7Jd02xphNY3Dx9+d0334knY/OpuhzDlsmiH+BsiJSUkTcgBBgaYYyS4HOlsdtgPXK8IxSqoRSqgTwHfCVUup/NozVKW2e+ivFzoZzOaQrPvm8uZlykwVHFvBc4HMU8cpwN+/GVdj3mzFrXC7v7AlY0zLJzexG18pd2Xl+J7UrXOK1OsUYvyGCWfuuQ+dlRqe/5QONuok0LTFdfH0JHDeOlLg4Tvfrp6csfUQ2SxCWOoW+wGogDJivlDogIoNF5NbUZVMx6hzCgQHAIFvFk9PEX4tHJv7AWd8A/vOO0ZN05fGVXLp56fZMXens/hmS4uFJ3etUcw6ty7YmX658TA6dzJcvV+I/FQrw+dIDrDlyBdrPgirtYN1gWPtZuiSRq3w5AkYM50ZoKOc++1zPRvcIbFoHoZRaoZQqp5QqrZQaZln2mVJqqeXxDaVUW6VUGaVUbaXUMSv7uG8fiMfR2s+/xT/uIt7vfYCruxtKKeaEzaG0d2nqFMpQAZ2aAtvGQ7GnjCERNM0J5HLJRZdKXdhydgsHY/cz9tUaVAn04a25u9kVFQevTIQne8A/Y2HVh+mSRN5GjfDr25crS5YQ+5NjT6TkyBy1klq7h4h9Rymx6lciKtWhVqvGAGw7t42w2DA6VOxwZ9PWQ78b49/U7ZMN0Wraw2tXvh3e7t5MCp1kTDbUOYiCeXPx+owdHI9NgGYjoe6bxj9Aaz5JlyT8+vQmT+PGRI8cSdzmv7LxKJyXThBORinFvo8Ho8REra8/v7182r5p+OX246XSL9250ZZx4FMcnmhux0g17dF5unrSsUJHNp7eyP4L+43JhroaHf26TN/OhfhEaDIMaveELf+DdV/eThJiMhHw9Ve4ly1L1MCB3Dx+PDsPxSnpBOFkNs35nfJHdnD+pRAKlysJwMGLB9lydgsdKnTA3eyefoOonXBqqzFIm0n3MNWcT4eKHfB192XsrrEAlPDzZGrnIM5fvUHX6f9y7WYyNP0GanWFv8bAn1/d3tbk6Ungjz8iZjOne/ch5YqVoUW0u9IJwonExSWQ8v23ROf15/nP37m9fPr+6Xi6etK2vJVJgbaMM4ZQqNHBjpFqWtbxdPXk9Sqvs+XsFrafNeakrlHMl3Gv1STs7FVen7GDG8mpxuCTNTrApm/gnx9ub+8WWITA//1AUlQUp9/uj0pKuttLaRnoBOFEVn00gsJXz5PnvQ9wy20MiXDq6inWnFhDu3LtyOuWYaCy2ONwYBHU6mxMSalpTqr9E+0p6FGQ73d/f7tV0vNPFOTbdtXYHhlLn9m7SFLAS2OhYrBRH7Fnzu3tPWrVotCQwVzfupVzQ4bqlk2ZpBOEk9j71x7K/bGAyGr1qNn2/+sSZhycgUlMdKho5Qrh7++M20pPvWnHSDUt67mb3elVrRehMaFsPL3x9vLg6kUY2rIy6w9FM2D+XlIwQavJxuivS/rCoRW3y/q0bEn+nj25PH8+l2bOtP9BOCGdIJxAYlIypz/5hJsu7tQdM/T28nPx51h4dCHBpYMp4FEg/UZXomD3bKjREfIG2DliTct6wWWCKZanGGN3jyVVpd5e/lqd4gxq+gTL9p7hk8X7UWY3aD8bAqrDr10g8u/bZf37v02eRo04P+Ib4jZutPIqWlo6QTiBFcPGUepcBIlvvIVvQKHbyyeHTkah6Fm1550b/TMWUFDvbfsFqmk25GpypW+Nvhy9dJRlEcvSrev1XGn6NCjNL9tPMnzlIZSbJ/z3V/AtDr+EwFljbCYxmQgYMZxcTzxB1ICB3Dh8JDsOxWnoBOHgju4Pp+iCaZwsWZmn+3S6vTwqLoqF4QtpXbY1AV4ZrhDiomHnT1A1xPiCaFoO0aREE6r4VeH7Xd9zPel6unXvNSlPh7rFmLjpGD/+GW7Mzd1xEbjnhZ9bwcUIAEweHgSOH4fJ05PTvXuTfOFCdhyKU9AJwoElJqdwYMAgzCqVqqO/TtcBblLoJEyYeL3K63du+NcYSEmE+u/cuU7TnJhJTLz/5PvEJMQwdf/UdOtEhMEvV+aVGkUYteYI4zdEGDPhdVwEKhVmtYSrZwFwLViQwHHjSI6N5VSv3qTGx2fH4Tg8nSAc2NIvx1L+5AHiuvahcIUyt5efunqKJeFLaFu+LYU8C6Xf6PJJY5TL6q+BXxk0LaepXqA6TUs2ZcaBGZyJSz+BkMkkjGxTlZerBTBi1SEmbowA/3Lw2gK4HmtcSSRcAiB35UoUGTOaGwcPcrr/O7r5qxU6QTioPX/vofTC6ZwqU416A99It27s7rG4mlzpXtnKwHsbhgMCDfS4h1rONaDWAAThu53f3bHOxWxidLtqtKhamK9XHmLypmNQpCaEzIaL4TAnBBKN21N5Gjak0JdfEL95M2c//Uw3f81AJwgHFB+fwNlBg0h2cePJcd+mu7W0N2YvqyJX0aVyF/w9MkySFB0Ge3+B2j3sNsm8pmWHQp6F6FK5CysjV7Lz/M471ruYTXzXvjrNqxRm2Iowpmw+ZjR9bTUZTm2DXztDinHF4Nu2rTGw3+LFxHz3vX0PxMHpBOGAlg0cSomYE8g7H+Bb7P/ndVBKMfLfkfjl9qNrpa53brhuMLh5wTMD7RitpmWPrpW6EuAZwOAtg0lKufP2kIvZxHch1WlWpRBDl4cx9a/jUKkltBgDR9fAkjch1Wgu6/dmH3zatuXixInE/jzb3ofisHSCcDBrflpElQ2LOFn7eYK6pB86Y+2JteyN2Uvf6n3xcPVIv2H4Oji8wqiY9shnx4g1LXt4uHrwcd2POXblGNP2T7NaxtVs4vuQGjStXIghvx80WjcFdYXnP4HQebD6I1AKEaHQ55/h1bAh54cN48ry5XY+GsekE4QDObIvnLyjhxGTP4CG475Jty5VpTJ291jK+JShZZmW6TdMToSVH0C+UrrXtPZYeTbwWZqUaMKk0ElEXom0WsbVbGLsqzVoWT2AkasPG/0k6g80hr/fNh42G9PNiIsLRUZ/S+5aNTnz/gdc++MPOx6JY7JpghCRF0XksIiEi8gdtaYi4i4i8yzrt4lICcvyRiKyU0T2WX4/b8s4HUF8fAJH+r2De2oS5cb/gJuXZ7r1JjEx6rlRfPn0l5gzjsq6bQJcPAovDgeXDKO5aloO98GTH+BudmfI1iF3rWR2NZsY3a46r9UpxoSNEXy69ACpjYZC1fawfijsMK5ATLlzU3TCBHJVrkTUOwOI27zZnoficGyWIETEDPwINAUqAq+KSMUMxboDl5RSZYAxwAjL8gvAS0qpKhhzVs+yVZyOQCnFsjc/pvS5cJLeHkRA1QpWyz2R7wmq+ldNv/DaOdj4DZRtDOWa2CFaTXMs/h7+9K/Vn+3ntvPrkV/vWs5kEoa2rMwbz5Xi560neXfBPpJb/ABlm8DvA+DAYgDMXl4UmzQJtzJlON23H/Fbt9nrUByOLa8gagPhSqljSqlEYC4QnKFMMHBrPsAFwAsiIkqp3UqpWw2cDwC5RSTH/mu8aNh4qm1dyakGLajd49XMb6iU8cFOTTKuHjTtMdWmXBueKvwUo3aM4sTVE3ctJyIMevEJ3mtSnoW7o+g5J5T44ClQtA4s7AHhxm0ls7c3xaZOwbVoIKf69OH6zjtbSj0ObJkgigCn0jw/bVlmtYxSKhm4AuTPUKY1sEspdTPjC4hITxHZISI7YmJisixwe9o4fzVlZo/jVOkq/OeHr+6/QVoHFsLh5dDwI8hf2jYBapoTMImJIfWG4Gpy5aPNH5GcmnzXsiLCmw3LMLRlZTYcjiZkeigxL88Av/Iw9zWIWA+AS758FJ8+HdcCBTj5eg/it2yx1+E4DIeupBaRShi3nd6wtl4pNUkpFaSUCvL397dWxKGF7Qoj19CPueTtT72ZEzG5umZ+4/gLsOI9CKhpzMmraY+5gp4F+aTuJ4ReCGXKvin3Ld+hbnEmdwoiPDqOV6Yd5FizOZC/DPzyKhzbAICLvz/FZ83ELTCQU2/04tqff9r4KByLLRNEFFA0zfNAyzKrZUTEBfAGLlqeBwKLgE5KqQgbxpktTh6L4myvXphQlJ0yAc/8vpnfWClYPgBuXIXgH8HsYrtANc2JNC3ZlGYlmzFh7wR2nd913/IvVCjI3J51uZGUwis/HWJXgxmQr7TR2/qYMRy4i78/xWbOwL1cOU73e4urK1fa+jAchi0TxL9AWREpKSJuQAiwNEOZpRiV0ABtgPVKKSUiPsByYJBS6m9ymJjzsRzs1I188ZfwGjWGgMrlH2wHO6fDwSVGW+6CGev9Ne3x9mndTwnwCmBJxJJMla9W1IeFveuR39ON9j8f4bfK4yBfSZjTHo5vAsDF15diP00nd/VqRA18l0vz59vyEByG2HLsERFpBnwHmIFpSqlhIjIY2KGUWioiuTBaKNUAYoEQpdQxEfkE+BA4mmZ3jZVS0Xd7raCgILVjxw6bHUtWuXY1ng2tOlAy6giJX4ygZvsWD7aD8wdg8vNQ/Gl47TcwOfRdQk3LFtHXo/HL7YdJMv/9uHI9iX5zd7PpSAw9a+ZhUMx7mC5FQtufoHxTAFITEjj99tvEb9pM/jfewP/ttxAn/w6KyE6lVJDVdTllcCpnSBBxV+NZ364LZSP3E/vWR9Tr0/HBdnAzzkgOCZeg99/gVeD+22ialmkpqYpvVh1i4qZjvFDMzATTcFzPhxq3cqsbLQxVcjLnBg/h8vz55G3enMJff4XJzS2bI39490oQzp36nMjVy9f4s01nSkce4FzPAQ+eHFJTYWFPo0Nc68k6OWiaDZhNwofNKvB9SHX+OqNofHEglwvWgcW9YMs4wOhxXejLL/AfOICry5dzsls3ki9ezObIbUMnCDu4cvEym9p0otTJg8T0epeGA3o8+E7WDzaatDb52hiVUtM0mwmuXoSFfZ5G3PNQ98QbHM3fEFZ/CGs+hdQURAS/Hj0I+HYUN/bt53jrNiTs3ZvdYWc5nSBs7OyxU2wPbkeJqCNc7PsBDfp3e/Cd7JljzBJXqwvUsdriV9O0LFYpwJtl/erTrHoJmkR1Z41HC2Ou93kd4OY1ALybN6fEL3MQs5kTHTpyae68HDWnhE4QNnRkWyjhbUPIf/k81z4bzrN9O99/o4zClhnDEpdqAM1GQZq5ITRNsy1PdxdGt6/OyLY16B/Xga/ohjq8CjWtiTF7I5CrYkVK/rYAj7p1OffFF5wd9CEpcTljClOdIGzkn1mLuPZ6Z1xSknD7YRJPvfrSg+8kfB0s6AZFgqD9bDA/QEc6TdOyTOtagSx/61l2F2pLp8T3SYiOJGVig9u9rs0+PhSdMB6/N9/kyrJlHG/Zkuu77t8Pw9HpBJHFUpKSWfHO5/gO+4iLPgUImP0LlRvWefAdHVltdPv3Kw+vzQd3r6wPVtO0TCvp58m8nk/RsFkIrZMHcyzBAzWrFWrdEEhJRsxm/Pv1pfjPxtiiJzp0JHrMd6QmJmZz5A9PJ4gsFB0eydoW7Sm5cj5hNRpQb8VCild6iDGS9s4zuvv7l4dOiyH3A/Sy1jTNZkwmoVv9kox/+1W+LPQD85OfQzaPIm5yc7hsDD3nUbMmJRcvxvuVllycOJHjwS2J3749myN/ODpBZAGlFP+Mn8XJV1pRICqCiC79aTn7RzzzeN5/4/Q7gk2jYFFPoyNc52Xg6WeboDVNe2gl/DyZ9UYD3FuP43NzP+Tsbm6Mrc3VvyaBUpi9PAkYNoyikyehkpI42akzZz78iOTY2OwO/YHojnKP6EL4cXa++xnFDu3gWKHSlBo9kgo1rc/ncE8342BxbwhbCpVbQ/A4cM2V9QFrmpal4m4mM3PFRqrv/pSnTQeIzBtEvvbjyFvEGEInNSGBC+PGc3H6dEy5cpG/Rw/yde6EKZdjfL91T2obSE64weahY8i3+BdSECKahfDS0IHkcn+IHpVndls6wYVDo8HwVF/dWknTnMyJC3FsWzCapmfH4U4Se4t2oGzrz/HxNeaIvxkRQfSob4n7809cChXCv19fvF9+GXmQUZxtQCeILJSamMiuybNJ/GkKvtdi2Vf2SaoM+5QKVcs++M6SE43+DZu+AU9/eGWC7gSnaU4uPOIo0Ys+5Om4tcQoH/4p3puaL/WmqL83APHbtxM9chQ39u3DNSCAfK93x6dVq2y7otAJIguk3LjB3hm/kjBtCvmuRBPhVwJzzz682LEF8jD/7R/9A1YNMobOqNIWmo3UldGaloNE7t2IrBpE8YSDnFQF2FSgI8Wf70698gGIQNzGjVycMJGEPXsw+/nh264tPm3b4lq4sF3j1AniESScO8/OH6bitmIxeRKuEekbyM2O3Wnyehtyuz3EPAxndsOG4XBkFeQrZQydUf7FLI9b0zQHoBSxe5Zy84+vKRwfxmnlxzK3prgGdabJk5UI9M3N9e3/cnHaVOI3bQYRvBo2xKdtG7zq1bPL7SedIB5Q6o0bHFm0grO/LsIvbBcuKpV9RavgFvIqjTq0wNP9Id60k9tg00gIXwu5vKH+AKjbG1xy7FTbmqbdohRJh1dz+Y/R+F/Yxk3lyu+pddnt25RiNRvRtGogBa/HcnnefC7/9hspsbGYfXzI07gxeZs3xyOoFmI22yQ0nSAyITn2Ekd+X8v5NevwDt1O7sQbXMyVl4hq9SnZ+TXqN6iByfQIFcczg+HcPnjqTXiyB+TK+/D70jTNeUWHcW3zBNwPzsct5TrnlQ/LU+qyN29D/Cs8zTOl/KgcdZAbq1dxbf16VEICZm9vPOvVw/PZZ/CqXx8Xv6xr/q4TxD2cCz/Job5v43/iMCaluOTuRUSpang2a86z7Zrg5+2RNQFePgke+cHtAftGaJqWMyVehyOruL5rHu7H12FWSVxWnvyVWoW/qcbVArUpVqQUT104TODh3SRv20LKhQsAuJUpjUeNmuSuUYPcNarjVqLEw9WFko0JQkReBL7HmFFuilJqeIb17sBMoBbGXNTtlVKRlnUfAt2BFOAtpdTqe73WwyaIuLgE1jRry9VyVcjf6Hlqv1iPglmVFDRN0zIj4TIc+5Pkw2tIOfoH7gnG5JkxypudqeWYmNyCM54VecZ0mToxRyh+5iheEWFInDGqbK6qVSk5f95DvfS9EoTNZrsXETPwI9AIOA38KyJLlVIH0xTrDlxSSpURkRBgBNBeRCpizGFdCQgA/hCRckqplKyO08srN8EblmF+lNtHmqZpjyK3D1R6BZdKr+CiFESHwamt5DuxlQaRW0kpU4j1Nwty6Hxull3Pw82SNZASqRS9Fk1Q/GnKFMhDHxuEZbMEAdQGwpVSxwBEZC4QDKRNEMHAF5bHC4D/iXGdFAzMVUrdBI6LSLhlf1tsEahODpqmOQwRKFgRClbEHNQNM9BcKZpbbiGlpCoiL8Zz9HwcJ2Pjibx4nXgP27R2smWCKAKcSvP8NJBxWNPbZZRSySJyBchvWb41w7ZFbBeqpmmaA0tTv2A2CaX9vSjtb/sRnp16sD4R6SkiO0RkR0xMTHaHo2malqPYMkFEAUXTPA+0LLNaRkRcAG+MyurMbItSapJSKkgpFeTv75+FoWuapmm2TBD/AmVFpKSIuGFUOi/NUGYpcGsezjbAemU0q1oKhIiIu4iUBMoCzjmguqZpmpOyWR2EpU6hL7Aao5nrNKXUAREZDOxQSi0FpgKzLJXQsRhJBEu5+RgV2snAm7ZowaRpmqbd3WPfUU7TNO1xdq9+EE5dSa1pmqbZjk4QmqZpmlU6QWiapmlW5Zg6CBGJAU7cZbUfcMGO4TwsZ4kTnCdWHWfWc5ZYdZyZU1wpZbWfQI5JEPciIjvuVgnjSJwlTnCeWHWcWc9ZYtVxPjp9i0nTNE2zSicITdM0zarHJUFMyu4AMslZ4gTniVXHmfWcJVYd5yN6LOogNE3TtAf3uFxBaJqmaQ9IJwhN0zTNqhyZIETkCxGJEpE9lp9mdyn3oogcFpFwERmUDXGOFJFDIhIqIotExOcu5SJFZJ/lWOw64NT9zpFlxN15lvXbRKSEPeOzxFBURP4UkYMickBE3rZSpoGIXEnzmfjM3nFa4rjneymGsZbzGSoiNbMhxvJpztMeEbkqIv0zlMm28yki00QkWkT2p1mWT0TWishRy2/fu2zb2VLmqIh0tlbGxnE6/Hc+HaVUjvvBmMb03fuUMQMRQCnADdgLVLRznI0BF8vjEcCIu5SLBPyy4Tze9xwBfYAJlschwLxsiLMwUNPyOA9wxEqcDYDf7R3bg76XQDNgJSBAXWBbNsdrBs5hdKZyiPMJPAvUBPanWfYNMMjyeJC17xKQDzhm+e1reexr5zgd+juf8SdHXkFk0u05s5VSicCtObPtRim1RimVbHm6FWNiJEeSmXMUDMywPF4AvGCZV9xulFJnlVK7LI+vAWE47xS1wcBMZdgK+IhI4WyM5wUgQil1t1EK7E4ptQljeoC00n4OZwAtrWzaBFirlIpVSl0C1gIv2jNOJ/jOp5OTE0Rfy2XctLtcblqbMzs7/6h0w/jP0RoFrBGRnSLS044xZeYcpZtXHLg1r3i2sNziqgFss7L6KRHZKyIrRaSSXQP7f/d7Lx3tcxkC/HKXdY5wPm8pqJQ6a3l8DihopYyjnVtH/M6nY7MJg2xNRP4ACllZ9TEwHhiCcZKHAN9ivBl2d684lVJLLGU+xpgYafZddlNfKRUlIgWAtSJyyPLfiZaGiHgBvwH9lVJXM6zehXGbJM5SJ7UYY6ZCe3Oa91KMmSBfBj60stpRzucdlFJKRBy6/b6zfOedNkEopf6TmXIiMhn43cqqTM17/ajuF6eIdAFaAC8oy81HK/uIsvyOFpFFGLd+7PFheZB5xU9L+nnF7UpEXDGSw2yl1MKM69MmDKXUChEZJyJ+Sim7DpKWiffSLp/LTGoK7FJKnc+4wlHOZxrnRaSwUuqs5ZZctJUyURh1J7cEAhvsEFs6Dv6dTydH3mLKcM/2FWC/lWKZmTPbpkTkReB94GWl1PW7lPEUkTy3HmNUclk7Hlt4lHnF7cZS5zEVCFNKjb5LmUK36kZEpDbGZ9+uiSyT7+VSoJOlNVNd4EqaWyf29ip3ub3kCOczg7Sfw87AEitlVgONRcTXctu5sWWZ3TjBdz697K4lt8UPMAvYB4RifHAKW5YHACvSlGuG0eIlAuOWj73jDMe4J7rH8jMhY5wYLYj2Wn4O2DtOa+cIGIzxAQfIBfxqOZbtQKlsOI/1MW4nhqY5l82AXkAvS5m+lvO3F6Ny8OlsiNPqe5khTgF+tJzvfUCQveO0xOGJ8QffO80yhzifGEnrLJCEUY/QHaPeax1wFPgDyGcpGwRMSbNtN8tnNRzomg1xOvx3Pu2PHmpD0zRNsypH3mLSNE3THp1OEJqmaZpVOkFomqZpVukEoWmaplmlE4SmaZpmlU4QmqZpmlU6QWiapmlW/R+V0Yr2TSGzugAAAABJRU5ErkJggg==",
             "text/plain": [
               "<Figure size 432x288 with 1 Axes>"
             ]
           },
           "metadata": {
             "needs_background": "light"
-          }
+          },
+          "output_type": "display_data"
         }
+      ],
+      "source": [
+        "df = pd.DataFrame(np.random.randint(10, size=(10,4)), columns=list(\"ABCD\"))\n",
+        "\n",
+        "df.plot.density()\n",
+        "plt.show()"
       ]
     },
     {
@@ -5785,34 +5762,34 @@
     },
     {
       "cell_type": "code",
+      "execution_count": 98,
       "metadata": {
         "colab": {
           "base_uri": "https://localhost:8080/",
           "height": 265
         },
         "id": "vPg1gqna-lTc",
-        "outputId": "1cd9c8db-c902-40b9-e6fc-10a91042f9c8"
+        "outputId": "6d5a058a-95b3-4572-e0d5-795a16e1f2fd"
       },
-      "source": [
-        "df = pd.DataFrame(np.random.randint(10, size=(10,4)), columns=list(\"ABCD\"))\n",
-        "\n",
-        "df.plot.hist()\n",
-        "plt.show()"
-      ],
-      "execution_count": 444,
       "outputs": [
         {
-          "output_type": "display_data",
           "data": {
-            "image/png": "iVBORw0KGgoAAAANSUhEUgAAAYIAAAD4CAYAAADhNOGaAAAABHNCSVQICAgIfAhkiAAAAAlwSFlzAAALEgAACxIB0t1+/AAAADh0RVh0U29mdHdhcmUAbWF0cGxvdGxpYiB2ZXJzaW9uMy4yLjIsIGh0dHA6Ly9tYXRwbG90bGliLm9yZy+WH4yJAAAUa0lEQVR4nO3dfZBddX3H8feXTeoGpWCTgJIlbqwgUSNPEUGsWqxTfCiUYm20BnTaprRSjNopD9NRcKZTGVtFGx9IxRqsXaQRY1pDqU4yFGYskMRAAovTDFJZiCSEloAmQLbf/nEvcVl2sze7+7sne8/7NbPDOeeee88nd0g+e8753d+NzESSVF+HVB1AklQti0CSas4ikKSaswgkqeYsAkmquWlVBzhQs2bNyt7e3qpjSNKUsmHDhkczc/ZIj025Iujt7WX9+vVVx5CkKSUi/nu0x7w0JEk1ZxFIUs1ZBJJUc1PuHsFInnnmGQYGBtizZ0/VUcbU3d1NT08P06dPrzqKJAEdUgQDAwMcdthh9Pb2EhFVxxlVZrJz504GBgaYN29e1XEkCeiQS0N79uxh5syZB3UJAEQEM2fOnBJnLpLqo1gRRER3RNwREXdFxD0RceUI+7wgIr4ZEVsj4vaI6J3A8SYSt22mSk5J9VHyjOAp4MzMPAE4ETgrIk4bts8fAP+Tma8APgtcVTCPJGkExe4RZOOLDp5srk5v/gz/8oNzgCuayyuBZREROcEvSei99LsTefrzPPCpd7a036pVqzj33HPp7+/n+OOPn9QMklRK0ZvFEdEFbABeAXwhM28ftssc4EGAzNwbEY8DM4FHh73OEmAJwNy5c0tGnpC+vj7e+MY30tfXx5VXPu9KWP1ccXhFx328muMy+b+EtKrVX1Y0cf3Hz6/s2PPv6y/yukVvFmfmYGaeCPQAp0bEa8b5Osszc2FmLpw9e8SpMir35JNPctttt3Httddy/fXXVx1HklrWllFDmfm/wDrgrGEPPQQcAxAR04DDgZ3tyDTZvvOd73DWWWdx3HHHMXPmTDZs2FB1JElqSclRQ7Mj4ojm8gzgbcB9w3ZbDVzQXH43sHai9weq0tfXx6JFiwBYtGgRfX19FSeSpNaUvEfwUmBF8z7BIcANmfmvEfFJYH1mrgauBb4eEVuBx4BFBfMU89hjj7F27Vo2b95MRDA4OEhE8OlPf9rhopIOeiVHDd0NnDTC9o8PWd4D/G6pDO2ycuVKFi9ezDXXXLNv25vf/GZuvfVW3vSmN1WYTJLG1hFTTAzX7hEUfX19XHLJJc/Zdt5559HX12cRSDrodWQRtNu6deuet+3iiy+uIIkkHbiOmGtIkjR+FoEk1ZxFIEk1ZxFIUs1ZBJJUcxaBJNVcZw4fnexZL1uYzbKrq4sFCxaQmXR1dbFs2TLe8IY3TG4OSSqgM4ugAjNmzGDTpk0A3HzzzVx22WXccsstFaeSpLF5aaiAXbt28eIXv7jqGJLUEs8IJsnu3bs58cQT2bNnD9u2bWPt2rVVR5KkllgEk2TopaEf/OAHnH/++WzZssXZRyUd9Lw0VMDpp5/Oo48+yo4dO6qOIkljsggKuO+++xgcHGTmzJlVR5GkMXXmpaEKvrz82XsEAJnJihUr6OrqansOSTpQnVkEFRgcHKw6giSNi5eGJKnmLAJJqjmLQJJqziKQpJqzCCSp5iwCSaq5jhw+umDFgkl9vc0XbG5pv5/+9KcsXbqUO++8kyOOOIKjjjqKq6++muOOO25S80jSZOrIIqhCZnLuuedywQUXcP311wNw11138cgjj1gEkg5qxYogIo4BrgOOAhJYnpmfG7bPW4DvAD9ubroxMz9ZKlNJ69atY/r06Vx44YX7tp1wwgkVJpKk1pQ8I9gLfCwzN0bEYcCGiPheZt47bL9bM/NdBXO0xZYtWzjllFOqjiFJB6zYzeLM3JaZG5vLTwD9wJxSx5MkjU9bRg1FRC9wEnD7CA+fHhF3RcRNEfHqUZ6/JCLWR8T6g3Vq51e/+tVs2LCh6hiSdMCKF0FEvAj4FrA0M3cNe3gj8LLMPAH4O2DVSK+Rmcszc2FmLpw9e3bZwON05pln8tRTT7F8+fJ92+6++25uvfXWClNJ0tiKjhqKiOk0SuAbmXnj8MeHFkNmromIL0bErMx8dCLHbXW452SKCL797W+zdOlSrrrqKrq7u+nt7eXqq69uexZJOhAlRw0FcC3Qn5mfGWWflwCPZGZGxKk0zlB2lspU2tFHH80NN9xQdQxJOiAlzwjOABYDmyNiU3Pb5cBcgMz8MvBu4E8iYi+wG1iUmVkwkyRpmGJFkJm3Afv95vbMXAYsK5VBkjQ25xqSpJqzCCSp5iwCSao5i0CSaq4jZx/tP37+pL7e/Pv6x9ynq6uLBQsW8MwzzzBt2jTOP/98PvKRj3DIIXatpINbRxZBFWbMmMGmTY1Rstu3b+d973sfu3bt4sorr6w4mSTtn7+uFnDkkUeyfPlyli1bhh+LkHSwswgKefnLX87g4CDbt2+vOook7ZdFIEk1ZxEUcv/999PV1cWRRx5ZdRRJ2i+LoIAdO3Zw4YUXctFFF9GYe0+SDl4dOWqoleGek2337t2ceOKJ+4aPLl68mI9+9KNtzyFJB6oji6AKg4ODVUeQpHHx0pAk1ZxFIEk11zFFMFU+uDVVckqqj44ogu7ubnbu3HnQ/yObmezcuZPu7u6qo0jSPh1xs7inp4eBgQF27NhRdZQxdXd309PTU3UMSdqnI4pg+vTpzJs3r+oYkjQldcSlIUnS+FkEklRzFoEk1ZxFIEk1ZxFIUs1ZBJJUcxaBJNVcsSKIiGMiYl1E3BsR90TEh0fYJyLi8xGxNSLujoiTS+WRJI2s5AfK9gIfy8yNEXEYsCEivpeZ9w7Z5+3Asc2f1wNfav5XktQmxc4IMnNbZm5sLj8B9ANzhu12DnBdNvwncEREvLRUJknS87VliomI6AVOAm4f9tAc4MEh6wPNbduGPX8JsARg7ty5486xYMWCcT93ojZfsLmS4/Ze+t1Kjgtw06qjKznu/CsqOWylqvp/+4n+T1VyXIAHPvXOyo7daYrfLI6IFwHfApZm5q7xvEZmLs/MhZm5cPbs2ZMbUJJqrmgRRMR0GiXwjcy8cYRdHgKOGbLe09wmSWqTkqOGArgW6M/Mz4yy22rg/OboodOAxzNz2yj7SpIKKHmP4AxgMbA5IjY1t10OzAXIzC8Da4B3AFuBnwMfLJhHkjSCYkWQmbcBMcY+CXyoVAZJ0thaujQUEdUNt5EkFdXqPYIvRsQdEfGnEXF40USSpLZqqQgy89eA36cxwmdDRPxTRLytaDJJUlu0PGooM/8L+EvgEuDNwOcj4r6I+J1S4SRJ5bV6j+C1EfFZGtNEnAn8VmbOby5/tmA+SVJhrY4a+jvgK8Dlmbn72Y2Z+XBE/GWRZJKktmi1CN4J7M7MQYCIOATozsyfZ+bXi6WTJBXX6j2C7wMzhqwf2twmSZriWi2C7sx88tmV5vKhZSJJktqp1SL42dBvD4uIU4Dd+9lfkjRFtHqPYCnwzxHxMI1pI14C/F6xVJKktmmpCDLzzog4Hnhlc9OPMvOZcrEkSe1yIJPOvQ7obT7n5IggM68rkkqS1DYtFUFEfB34VWATMNjcnIBFIElTXKtnBAuBVzWnjZYkdZBWRw1toXGDWJLUYVo9I5gF3BsRdwBPPbsxM88ukkqS1DatFsEVJUNIkqrT6vDRWyLiZcCxmfn9iDgU6CobTZLUDq1OQ/1HwErgmuamOcCqUqEkSe3T6s3iDwFnALtg35fUHFkqlCSpfVotgqcy8+lnVyJiGo3PEUiSprhWi+CWiLgcmNH8ruJ/Bv6lXCxJUru0WgSXAjuAzcAfA2tofH+xJGmKa3XU0P8Bf9/8kSR1kFZHDf04Iu4f/jPGc74aEdsjYssoj78lIh6PiE3Nn4+P5w8gSZqYA5lr6FndwO8CvzLGc74GLGP/E9PdmpnvajGDJKmAls4IMnPnkJ+HMvNqGl9ov7/n/Afw2GSElCSV0+o01CcPWT2ExhnCgXyXwWhOj4i7gIeBP8/Me0Y5/hJgCcDcuXMn4bCSpGe1+o/53w5Z3gs8ALxngsfeCLwsM5+MiHfQ+KTysSPtmJnLgeUACxcu9PMLkjSJWh019OuTfeDM3DVkeU1EfDEiZmXmo5N9LEnS6Fq9NPTR/T2emZ850ANHxEuARzIzI+JUGpecdh7o60iSJuZARg29DljdXP8t4A7gv0Z7QkT0AW8BZkXEAPAJYDpAZn4ZeDfwJxGxF9gNLPIb0CSp/Votgh7g5Mx8AiAirgC+m5nvH+0Jmfne/b1gZi6jMbxUklShVqeYOAp4esj6081tkqQprtUzguuAOyLi28313wZWlIkkSWqnVkcN/VVE3AT8WnPTBzPzh+ViSZLapdVLQwCHArsy83PAQETMK5RJktRGrU469wngEuCy5qbpwD+WCiVJap9WzwjOBc4GfgaQmQ8Dh5UKJUlqn1aL4OnmGP8EiIgXloskSWqnVovghoi4BjgiIv4I+D5+SY0kdYQxRw1FRADfBI4HdgGvBD6emd8rnE2S1AZjFkFzLqA1mbkA8B9/SeowrV4a2hgRryuaRJJUiVY/Wfx64P0R8QCNkUNB42ThtaWCSZLaY79FEBFzM/MnwG+2KY8kqc3GOiNYRWPW0f+OiG9l5nntCCVJap+x7hHEkOWXlwwiSarGWEWQoyxLkjrEWJeGToiIXTTODGY0l+EXN4t/uWg6SVJx+y2CzOxqVxBJUjUOZBpqSVIHsggkqeYsAkmqOYtAkmrOIpCkmrMIJKnmLAJJqjmLQJJqrlgRRMRXI2J7RGwZ5fGIiM9HxNaIuDsiTi6VRZI0upJnBF8DztrP428Hjm3+LAG+VDCLJGkUxYogM/8DeGw/u5wDXJcN/wkcEREvLZVHkjSyVr+hrIQ5wIND1gea27YN3zEiltA4a2Du3LnjPuANf7133M+dqP6/nl/JcW+q5KgVu+Lwyg5906qjKznue+ZX81f5plV/XslxARbMv7SS495QyVHLmhI3izNzeWYuzMyFs2fPrjqOJHWUKovgIeCYIes9zW2SpDaqsghWA+c3Rw+dBjyemc+7LCRJKqvYhcWI6APeAsyKiAHgE8B0gMz8MrAGeAewFfg58MFSWSRJoytWBJn53jEeT+BDpY4vSWrNlLhZLEkqxyKQpJqzCCSp5iwCSao5i0CSas4ikKSaswgkqeYsAkmqOYtAkmrOIpCkmrMIJKnmLAJJqjmLQJJqziKQpJqzCCSp5iwCSao5i0CSas4ikKSaswgkqeYsAkmqOYtAkmrOIpCkmrMIJKnmLAJJqjmLQJJqrmgRRMRZEfGjiNgaEZeO8PgHImJHRGxq/vxhyTySpOebVuqFI6IL+ALwNmAAuDMiVmfmvcN2/WZmXlQqhyRp/0qeEZwKbM3M+zPzaeB64JyCx5MkjUPJIpgDPDhkfaC5bbjzIuLuiFgZEceM9EIRsSQi1kfE+h07dpTIKkm1VfXN4n8BejPztcD3gBUj7ZSZyzNzYWYunD17dlsDSlKnK1kEDwFDf8PvaW7bJzN3ZuZTzdWvAKcUzCNJGkHJIrgTODYi5kXELwGLgNVDd4iIlw5ZPRvoL5hHkjSCYqOGMnNvRFwE3Ax0AV/NzHsi4pPA+sxcDVwcEWcDe4HHgA+UyiNJGlmxIgDIzDXAmmHbPj5k+TLgspIZJEn7V/XNYklSxSwCSao5i0CSas4ikKSaswgkqeYsAkmqOYtAkmrOIpCkmrMIJKnmLAJJqjmLQJJqziKQpJqzCCSp5iwCSao5i0CSas4ikKSaswgkqeYsAkmqOYtAkmrOIpCkmrMIJKnmLAJJqjmLQJJqziKQpJqzCCSp5iwCSaq5okUQEWdFxI8iYmtEXDrC4y+IiG82H789InpL5pEkPV+xIoiILuALwNuBVwHvjYhXDdvtD4D/ycxXAJ8FriqVR5I0spJnBKcCWzPz/sx8GrgeOGfYPucAK5rLK4G3RkQUzCRJGmZawdeeAzw4ZH0AeP1o+2Tm3oh4HJgJPDp0p4hYAixprj4ZET8aZ6ZZw1+75jrz/bhy3M+chPdj18SePl4fmPRXbOm9GH6K31YfaOvR9r0flf6ZJ/Z78stGe6BkEUyazFwOLJ/o60TE+sxcOAmROoLvx3P5fvyC78Vzdfr7UfLS0EPAMUPWe5rbRtwnIqYBhwM7C2aSJA1TsgjuBI6NiHkR8UvAImD1sH1WAxc0l98NrM3MLJhJkjRMsUtDzWv+FwE3A13AVzPznoj4JLA+M1cD1wJfj4itwGM0yqKkCV9e6jC+H8/l+/ELvhfP1dHvR/gLuCTVm58slqSaswgkqeZqUwRjTXdRJxFxTESsi4h7I+KeiPhw1ZmqFhFdEfHDiPjXqrNULSKOiIiVEXFfRPRHxOlVZ6pKRHyk+XdkS0T0RUR31ZlKqEURtDjdRZ3sBT6Wma8CTgM+VPP3A+DDQH/VIQ4SnwP+LTOPB06gpu9LRMwBLgYWZuZraAx6KT2gpRK1KAJam+6iNjJzW2ZubC4/QeMv+pxqU1UnInqAdwJfqTpL1SLicOBNNEb0kZlPZ+b/VpuqUtOAGc3POR0KPFxxniLqUgQjTXdR23/4hmrO+HoScHu1SSp1NfAXwP9VHeQgMA/YAfxD81LZVyLihVWHqkJmPgT8DfATYBvweGb+e7WpyqhLEWgEEfEi4FvA0sysaJKcakXEu4Dtmbmh6iwHiWnAycCXMvMk4GdALe+pRcSLaVw5mAccDbwwIt5fbaoy6lIErUx3USsRMZ1GCXwjM2+sOk+FzgDOjogHaFwyPDMi/rHaSJUaAAYy89kzxJU0iqGOfgP4cWbuyMxngBuBN1ScqYi6FEEr013URnOq72uB/sz8TNV5qpSZl2VmT2b20vj/Ym1mduRvfa3IzJ8CD0bEK5ub3grcW2GkKv0EOC0iDm3+nXkrHXrjfErMPjpRo013UXGsKp0BLAY2R8Sm5rbLM3NNhZl08Pgz4BvNX5ruBz5YcZ5KZObtEbES2EhjpN0P6dCpJpxiQpJqri6XhiRJo7AIJKnmLAJJqjmLQJJqziKQpJqzCCSp5iwCSaq5/wfTUI9XI7SegAAAAABJRU5ErkJggg==\n",
+            "image/png": "iVBORw0KGgoAAAANSUhEUgAAAYIAAAD4CAYAAADhNOGaAAAABHNCSVQICAgIfAhkiAAAAAlwSFlzAAALEgAACxIB0t1+/AAAADh0RVh0U29mdHdhcmUAbWF0cGxvdGxpYiB2ZXJzaW9uMy4yLjIsIGh0dHA6Ly9tYXRwbG90bGliLm9yZy+WH4yJAAAUa0lEQVR4nO3dfZBddX3H8feXTeoGpWCTgJIlbqwgUSNPEUGsWqxTfCiUYm20BnTaprRSjNopD9NRcKZTGVtFGx9IxRqsXaQRY1pDqU4yFGYskMRAAovTDFJZiCSEloAmQLbf/nEvcVl2sze7+7sne8/7NbPDOeeee88nd0g+e8753d+NzESSVF+HVB1AklQti0CSas4ikKSaswgkqeYsAkmquWlVBzhQs2bNyt7e3qpjSNKUsmHDhkczc/ZIj025Iujt7WX9+vVVx5CkKSUi/nu0x7w0JEk1ZxFIUs1ZBJJUc1PuHsFInnnmGQYGBtizZ0/VUcbU3d1NT08P06dPrzqKJAEdUgQDAwMcdthh9Pb2EhFVxxlVZrJz504GBgaYN29e1XEkCeiQS0N79uxh5syZB3UJAEQEM2fOnBJnLpLqo1gRRER3RNwREXdFxD0RceUI+7wgIr4ZEVsj4vaI6J3A8SYSt22mSk5J9VHyjOAp4MzMPAE4ETgrIk4bts8fAP+Tma8APgtcVTCPJGkExe4RZOOLDp5srk5v/gz/8oNzgCuayyuBZREROcEvSei99LsTefrzPPCpd7a036pVqzj33HPp7+/n+OOPn9QMklRK0ZvFEdEFbABeAXwhM28ftssc4EGAzNwbEY8DM4FHh73OEmAJwNy5c0tGnpC+vj7e+MY30tfXx5VXPu9KWP1ccXhFx328muMy+b+EtKrVX1Y0cf3Hz6/s2PPv6y/yukVvFmfmYGaeCPQAp0bEa8b5Osszc2FmLpw9e8SpMir35JNPctttt3Httddy/fXXVx1HklrWllFDmfm/wDrgrGEPPQQcAxAR04DDgZ3tyDTZvvOd73DWWWdx3HHHMXPmTDZs2FB1JElqSclRQ7Mj4ojm8gzgbcB9w3ZbDVzQXH43sHai9weq0tfXx6JFiwBYtGgRfX19FSeSpNaUvEfwUmBF8z7BIcANmfmvEfFJYH1mrgauBb4eEVuBx4BFBfMU89hjj7F27Vo2b95MRDA4OEhE8OlPf9rhopIOeiVHDd0NnDTC9o8PWd4D/G6pDO2ycuVKFi9ezDXXXLNv25vf/GZuvfVW3vSmN1WYTJLG1hFTTAzX7hEUfX19XHLJJc/Zdt5559HX12cRSDrodWQRtNu6deuet+3iiy+uIIkkHbiOmGtIkjR+FoEk1ZxFIEk1ZxFIUs1ZBJJUcxaBJNVcZw4fnexZL1uYzbKrq4sFCxaQmXR1dbFs2TLe8IY3TG4OSSqgM4ugAjNmzGDTpk0A3HzzzVx22WXccsstFaeSpLF5aaiAXbt28eIXv7jqGJLUEs8IJsnu3bs58cQT2bNnD9u2bWPt2rVVR5KkllgEk2TopaEf/OAHnH/++WzZssXZRyUd9Lw0VMDpp5/Oo48+yo4dO6qOIkljsggKuO+++xgcHGTmzJlVR5GkMXXmpaEKvrz82XsEAJnJihUr6OrqansOSTpQnVkEFRgcHKw6giSNi5eGJKnmLAJJqjmLQJJqziKQpJqzCCSp5iwCSaq5jhw+umDFgkl9vc0XbG5pv5/+9KcsXbqUO++8kyOOOIKjjjqKq6++muOOO25S80jSZOrIIqhCZnLuuedywQUXcP311wNw11138cgjj1gEkg5qxYogIo4BrgOOAhJYnpmfG7bPW4DvAD9ubroxMz9ZKlNJ69atY/r06Vx44YX7tp1wwgkVJpKk1pQ8I9gLfCwzN0bEYcCGiPheZt47bL9bM/NdBXO0xZYtWzjllFOqjiFJB6zYzeLM3JaZG5vLTwD9wJxSx5MkjU9bRg1FRC9wEnD7CA+fHhF3RcRNEfHqUZ6/JCLWR8T6g3Vq51e/+tVs2LCh6hiSdMCKF0FEvAj4FrA0M3cNe3gj8LLMPAH4O2DVSK+Rmcszc2FmLpw9e3bZwON05pln8tRTT7F8+fJ92+6++25uvfXWClNJ0tiKjhqKiOk0SuAbmXnj8MeHFkNmromIL0bErMx8dCLHbXW452SKCL797W+zdOlSrrrqKrq7u+nt7eXqq69uexZJOhAlRw0FcC3Qn5mfGWWflwCPZGZGxKk0zlB2lspU2tFHH80NN9xQdQxJOiAlzwjOABYDmyNiU3Pb5cBcgMz8MvBu4E8iYi+wG1iUmVkwkyRpmGJFkJm3Afv95vbMXAYsK5VBkjQ25xqSpJqzCCSp5iwCSao5i0CSaq4jZx/tP37+pL7e/Pv6x9ynq6uLBQsW8MwzzzBt2jTOP/98PvKRj3DIIXatpINbRxZBFWbMmMGmTY1Rstu3b+d973sfu3bt4sorr6w4mSTtn7+uFnDkkUeyfPlyli1bhh+LkHSwswgKefnLX87g4CDbt2+vOook7ZdFIEk1ZxEUcv/999PV1cWRRx5ZdRRJ2i+LoIAdO3Zw4YUXctFFF9GYe0+SDl4dOWqoleGek2337t2ceOKJ+4aPLl68mI9+9KNtzyFJB6oji6AKg4ODVUeQpHHx0pAk1ZxFIEk11zFFMFU+uDVVckqqj44ogu7ubnbu3HnQ/yObmezcuZPu7u6qo0jSPh1xs7inp4eBgQF27NhRdZQxdXd309PTU3UMSdqnI4pg+vTpzJs3r+oYkjQldcSlIUnS+FkEklRzFoEk1ZxFIEk1ZxFIUs1ZBJJUcxaBJNVcsSKIiGMiYl1E3BsR90TEh0fYJyLi8xGxNSLujoiTS+WRJI2s5AfK9gIfy8yNEXEYsCEivpeZ9w7Z5+3Asc2f1wNfav5XktQmxc4IMnNbZm5sLj8B9ANzhu12DnBdNvwncEREvLRUJknS87VliomI6AVOAm4f9tAc4MEh6wPNbduGPX8JsARg7ty5486xYMWCcT93ojZfsLmS4/Ze+t1Kjgtw06qjKznu/CsqOWylqvp/+4n+T1VyXIAHPvXOyo7daYrfLI6IFwHfApZm5q7xvEZmLs/MhZm5cPbs2ZMbUJJqrmgRRMR0GiXwjcy8cYRdHgKOGbLe09wmSWqTkqOGArgW6M/Mz4yy22rg/OboodOAxzNz2yj7SpIKKHmP4AxgMbA5IjY1t10OzAXIzC8Da4B3AFuBnwMfLJhHkjSCYkWQmbcBMcY+CXyoVAZJ0thaujQUEdUNt5EkFdXqPYIvRsQdEfGnEXF40USSpLZqqQgy89eA36cxwmdDRPxTRLytaDJJUlu0PGooM/8L+EvgEuDNwOcj4r6I+J1S4SRJ5bV6j+C1EfFZGtNEnAn8VmbOby5/tmA+SVJhrY4a+jvgK8Dlmbn72Y2Z+XBE/GWRZJKktmi1CN4J7M7MQYCIOATozsyfZ+bXi6WTJBXX6j2C7wMzhqwf2twmSZriWi2C7sx88tmV5vKhZSJJktqp1SL42dBvD4uIU4Dd+9lfkjRFtHqPYCnwzxHxMI1pI14C/F6xVJKktmmpCDLzzog4Hnhlc9OPMvOZcrEkSe1yIJPOvQ7obT7n5IggM68rkkqS1DYtFUFEfB34VWATMNjcnIBFIElTXKtnBAuBVzWnjZYkdZBWRw1toXGDWJLUYVo9I5gF3BsRdwBPPbsxM88ukkqS1DatFsEVJUNIkqrT6vDRWyLiZcCxmfn9iDgU6CobTZLUDq1OQ/1HwErgmuamOcCqUqEkSe3T6s3iDwFnALtg35fUHFkqlCSpfVotgqcy8+lnVyJiGo3PEUiSprhWi+CWiLgcmNH8ruJ/Bv6lXCxJUru0WgSXAjuAzcAfA2tofH+xJGmKa3XU0P8Bf9/8kSR1kFZHDf04Iu4f/jPGc74aEdsjYssoj78lIh6PiE3Nn4+P5w8gSZqYA5lr6FndwO8CvzLGc74GLGP/E9PdmpnvajGDJKmAls4IMnPnkJ+HMvNqGl9ov7/n/Afw2GSElCSV0+o01CcPWT2ExhnCgXyXwWhOj4i7gIeBP8/Me0Y5/hJgCcDcuXMn4bCSpGe1+o/53w5Z3gs8ALxngsfeCLwsM5+MiHfQ+KTysSPtmJnLgeUACxcu9PMLkjSJWh019OuTfeDM3DVkeU1EfDEiZmXmo5N9LEnS6Fq9NPTR/T2emZ850ANHxEuARzIzI+JUGpecdh7o60iSJuZARg29DljdXP8t4A7gv0Z7QkT0AW8BZkXEAPAJYDpAZn4ZeDfwJxGxF9gNLPIb0CSp/Votgh7g5Mx8AiAirgC+m5nvH+0Jmfne/b1gZi6jMbxUklShVqeYOAp4esj6081tkqQprtUzguuAOyLi28313wZWlIkkSWqnVkcN/VVE3AT8WnPTBzPzh+ViSZLapdVLQwCHArsy83PAQETMK5RJktRGrU469wngEuCy5qbpwD+WCiVJap9WzwjOBc4GfgaQmQ8Dh5UKJUlqn1aL4OnmGP8EiIgXloskSWqnVovghoi4BjgiIv4I+D5+SY0kdYQxRw1FRADfBI4HdgGvBD6emd8rnE2S1AZjFkFzLqA1mbkA8B9/SeowrV4a2hgRryuaRJJUiVY/Wfx64P0R8QCNkUNB42ThtaWCSZLaY79FEBFzM/MnwG+2KY8kqc3GOiNYRWPW0f+OiG9l5nntCCVJap+x7hHEkOWXlwwiSarGWEWQoyxLkjrEWJeGToiIXTTODGY0l+EXN4t/uWg6SVJx+y2CzOxqVxBJUjUOZBpqSVIHsggkqeYsAkmqOYtAkmrOIpCkmrMIJKnmLAJJqjmLQJJqrlgRRMRXI2J7RGwZ5fGIiM9HxNaIuDsiTi6VRZI0upJnBF8DztrP428Hjm3+LAG+VDCLJGkUxYogM/8DeGw/u5wDXJcN/wkcEREvLZVHkjSyVr+hrIQ5wIND1gea27YN3zEiltA4a2Du3LnjPuANf7133M+dqP6/nl/JcW+q5KgVu+Lwyg5906qjKznue+ZX81f5plV/XslxARbMv7SS495QyVHLmhI3izNzeWYuzMyFs2fPrjqOJHWUKovgIeCYIes9zW2SpDaqsghWA+c3Rw+dBjyemc+7LCRJKqvYhcWI6APeAsyKiAHgE8B0gMz8MrAGeAewFfg58MFSWSRJoytWBJn53jEeT+BDpY4vSWrNlLhZLEkqxyKQpJqzCCSp5iwCSao5i0CSas4ikKSaswgkqeYsAkmqOYtAkmrOIpCkmrMIJKnmLAJJqjmLQJJqziKQpJqzCCSp5iwCSao5i0CSas4ikKSaswgkqeYsAkmqOYtAkmrOIpCkmrMIJKnmLAJJqjmLQJJqrmgRRMRZEfGjiNgaEZeO8PgHImJHRGxq/vxhyTySpOebVuqFI6IL+ALwNmAAuDMiVmfmvcN2/WZmXlQqhyRp/0qeEZwKbM3M+zPzaeB64JyCx5MkjUPJIpgDPDhkfaC5bbjzIuLuiFgZEceM9EIRsSQi1kfE+h07dpTIKkm1VfXN4n8BejPztcD3gBUj7ZSZyzNzYWYunD17dlsDSlKnK1kEDwFDf8PvaW7bJzN3ZuZTzdWvAKcUzCNJGkHJIrgTODYi5kXELwGLgNVDd4iIlw5ZPRvoL5hHkjSCYqOGMnNvRFwE3Ax0AV/NzHsi4pPA+sxcDVwcEWcDe4HHgA+UyiNJGlmxIgDIzDXAmmHbPj5k+TLgspIZJEn7V/XNYklSxSwCSao5i0CSas4ikKSaswgkqeYsAkmqOYtAkmrOIpCkmrMIJKnmLAJJqjmLQJJqziKQpJqzCCSp5iwCSao5i0CSas4ikKSaswgkqeYsAkmqOYtAkmrOIpCkmrMIJKnmLAJJqjmLQJJqziKQpJqzCCSp5iwCSaq5okUQEWdFxI8iYmtEXDrC4y+IiG82H789InpL5pEkPV+xIoiILuALwNuBVwHvjYhXDdvtD4D/ycxXAJ8FriqVR5I0spJnBKcCWzPz/sx8GrgeOGfYPucAK5rLK4G3RkQUzCRJGmZawdeeAzw4ZH0AeP1o+2Tm3oh4HJgJPDp0p4hYAixprj4ZET8aZ6ZZw1+75jrz/bhy3M+chPdj18SePl4fmPRXbOm9GH6K31YfaOvR9r0flf6ZJ/Z78stGe6BkEUyazFwOLJ/o60TE+sxcOAmROoLvx3P5fvyC78Vzdfr7UfLS0EPAMUPWe5rbRtwnIqYBhwM7C2aSJA1TsgjuBI6NiHkR8UvAImD1sH1WAxc0l98NrM3MLJhJkjRMsUtDzWv+FwE3A13AVzPznoj4JLA+M1cD1wJfj4itwGM0yqKkCV9e6jC+H8/l+/ELvhfP1dHvR/gLuCTVm58slqSaswgkqeZqUwRjTXdRJxFxTESsi4h7I+KeiPhw1ZmqFhFdEfHDiPjXqrNULSKOiIiVEXFfRPRHxOlVZ6pKRHyk+XdkS0T0RUR31ZlKqEURtDjdRZ3sBT6Wma8CTgM+VPP3A+DDQH/VIQ4SnwP+LTOPB06gpu9LRMwBLgYWZuZraAx6KT2gpRK1KAJam+6iNjJzW2ZubC4/QeMv+pxqU1UnInqAdwJfqTpL1SLicOBNNEb0kZlPZ+b/VpuqUtOAGc3POR0KPFxxniLqUgQjTXdR23/4hmrO+HoScHu1SSp1NfAXwP9VHeQgMA/YAfxD81LZVyLihVWHqkJmPgT8DfATYBvweGb+e7WpyqhLEWgEEfEi4FvA0sysaJKcakXEu4Dtmbmh6iwHiWnAycCXMvMk4GdALe+pRcSLaVw5mAccDbwwIt5fbaoy6lIErUx3USsRMZ1GCXwjM2+sOk+FzgDOjogHaFwyPDMi/rHaSJUaAAYy89kzxJU0iqGOfgP4cWbuyMxngBuBN1ScqYi6FEEr013URnOq72uB/sz8TNV5qpSZl2VmT2b20vj/Ym1mduRvfa3IzJ8CD0bEK5ub3grcW2GkKv0EOC0iDm3+nXkrHXrjfErMPjpRo013UXGsKp0BLAY2R8Sm5rbLM3NNhZl08Pgz4BvNX5ruBz5YcZ5KZObtEbES2EhjpN0P6dCpJpxiQpJqri6XhiRJo7AIJKnmLAJJqjmLQJJqziKQpJqzCCSp5iwCSaq5/wfTUI9XI7SegAAAAABJRU5ErkJggg==",
             "text/plain": [
               "<Figure size 432x288 with 1 Axes>"
             ]
           },
           "metadata": {
             "needs_background": "light"
-          }
+          },
+          "output_type": "display_data"
         }
+      ],
+      "source": [
+        "df = pd.DataFrame(np.random.randint(10, size=(10,4)), columns=list(\"ABCD\"))\n",
+        "\n",
+        "df.plot.hist()\n",
+        "plt.show()"
       ]
     },
     {
@@ -5826,34 +5803,34 @@
     },
     {
       "cell_type": "code",
+      "execution_count": 99,
       "metadata": {
         "colab": {
           "base_uri": "https://localhost:8080/",
           "height": 267
         },
         "id": "HPAGPHyS-sCt",
-        "outputId": "0c797968-b2af-49b7-dd61-4472af9015fd"
+        "outputId": "3bccec66-391a-4ae4-a58a-6e8d756da247"
       },
-      "source": [
-        "df = pd.DataFrame(np.random.randint(10, size=(10,4)), columns=list(\"ABCD\"))\n",
-        "\n",
-        "df.plot.kde()\n",
-        "plt.show()"
-      ],
-      "execution_count": 445,
       "outputs": [
         {
-          "output_type": "display_data",
           "data": {
-            "image/png": "iVBORw0KGgoAAAANSUhEUgAAAYgAAAD6CAYAAAC73tBYAAAABHNCSVQICAgIfAhkiAAAAAlwSFlzAAALEgAACxIB0t1+/AAAADh0RVh0U29mdHdhcmUAbWF0cGxvdGxpYiB2ZXJzaW9uMy4yLjIsIGh0dHA6Ly9tYXRwbG90bGliLm9yZy+WH4yJAAAgAElEQVR4nOzdd1zV1f/A8de5l41sBESmK7eIODIHzkwzc+SqTLOt9s3STMs0S22YLW1YmmapOXOlZu6taI6cKSAgshHZ657fHxf7mSJc4F5knOfjwSP4jHPONbjv+znjfYSUEkVRFEW5k+Z+N0BRFEWpmFSAUBRFUQqlAoSiKIpSKBUgFEVRlEKpAKEoiqIUSgUIRVEUpVAmDRBCiF5CiItCiMtCiLcKOd9JCHFCCJEnhBhUyHl7IUSUEGKeKdupKIqi3M3MVAULIbTAfKAHEAUcE0JskFKeu+2yCGAkMOEexbwP7DWkPldXV+nn51fq9iqKolRHx48fT5BS1izsnMkCBNAGuCylDAUQQqwA+gH/BggpZXjBOd2dNwshWgHuwFYgqLjK/Pz8CAkJMUrDFUVRqgshxNV7nTNlF1NtIPK2n6MKjhVLCKEBPuXeTxaKoiiKiVXUQepXgN+llFFFXSSEeEEIESKECImPjy+npimKolQPpuxiugZ43/azV8ExQzwIdBRCvALUACyEEGlSyv8MdEspFwALAIKCglRSKUVRFCMyZYA4BtQXQvijDwxDgeGG3CilfPLW90KIkUDQncFBURSlIsjNzSUqKoqsrKz73ZQiWVlZ4eXlhbm5ucH3mCxASCnzhBBjgW2AFlgkpTwrhJgBhEgpNwghWgPrACegrxDiPSllE1O1SVEUxdiioqKws7PDz88PIcT9bk6hpJQkJiYSFRWFv7+/wfeZ8gkCKeXvwO93HHv3tu+Poe96KqqMxcBiEzRPURSlzLKysip0cAAQQuDi4kJJx2or6iC1oihKpVGRg8MtpWmjSZ8gFEW5P3Lzc/k78W8uJV0iOTsZGzMbvOy8CPIIwt7C/n43T6kkVIBQlCok8mYkS88vZeOVjaTlpt11XiM0BHsFM7rZaJrXbH4fWqiYym+//Ub//v05f/48DRs2NEqZKkAoShWQkZvBd6e/Y+m5pQD09OtJd5/uNHVtiouVCxl5GVy5cYU9UXtYfWk1OyN3MqjBIN5o9QY1LGrc59YrxrB8+XI6dOjA8uXLee+994xSpgoQilLJXUy6yIQ9Ewi/Gc5jdR/jf4H/w83G7T/XOGgdCHQPJNA9kBebv8jXJ79m6fml/BX7F191+wpvO+97lK5UBmlpaezfv59du3bRt29fFSAURYFt4dt4e//b2FvYs7DnQtrUalPsPTbmNkxoPYGOXh15fffrPPX7UyzsuZB6TvXKocVV23sbz3Iu+qZRy2zsac+0vkXP/l+/fj29evWiQYMGuLi4cPz4cVq1alXmutUsJkWppJadX8bEPRNp7NKYVX1XGRQcbte2Vlt+7v0zWqHl+e3Pc/XmPXO2KRXc8uXLGTp0KABDhw5l+fLlRilXSFk1MlQEBQVJlc1VqS4WnlnI5yc+p4t3Fz7u9DFWZlalLiv0Rigjt47E3tKeX3r/goOlgxFbWvWdP3+eRo0a3bf6k5KS8PLyombNmgghyM/PRwjB1atX75raWlhbhRDHpZSFZsxWXUyKYmK5+TrCEtK5EJNKWHw6calZxN7MJj07j9x8Hbk6ia2FFgdrc5xtLfB3taWeWw1aeDniZGtxV3krLqzg8xOf84j/I8zqMAszTdn+jOs41uHzLp8z+o/RTNo7ifnd5qPVaMtUplJ+Vq9ezdNPP813333377HOnTuzb98+OnXqVKayVYBQFCPT6SQno26w/58EDl1J5HhEMjl5/7/libOtBW52lthbmWNhpsFaI0jPziMuNZv41GxSMnMBEAIaetjTqb4rjwV40riWPZtCNzHzyEyCvYOZ2WFmmYPDLYHugUxuM5n3D7/P0nNLGdl0pFHKVUxv+fLlTJo06T/HBg4cyPLly8scIFQXk6IYyYWYm6w5HsXm09eJTslCCGhcy552dVxoWtueB9ztqVPTFivze386l1KSlJ7DP3FphIQncfBKIsfCk8jNl/h7xZBk9xWtPFrxTfevsdRaGrX9UkrG7x7P3qi9rHh0BQ2cGhi1/KrqfncxlURJu5hUgFCUMpBS8uf5OBbtD+NQaCLmWkHH+jXp26IWXR5ww9Hm7i6ikkpOz+Hn43/xw5X/kZtrg2PyG7zZM4B+AZ5GT/GQlJXEgPUDcLV2ZcWjK4z2hFKVVeUAoWYxKUop7f8ngX7zD/D8TyFcTUxnUq+GHJ3SnUUjW9O/pZdRggOAuXkOO5M/pIaVlmlt5uBi48Brv55k8HeH+Cc21Sh13OJs5czUdlO5mHyRFRdWGLVspfJRHw8UpYSup2Qy9bez/Hk+Fk8HKz4e1JwBLWtjpjX+5y0pJe8ceIewlDC+7fEt7WoF8kRzyarjkXy09SJ95+1n6qONGd7Gx2hPE119utKhdgfmnZzHw34PU9Om0P3slWpAPUEoioGklCw7EkGPuXvZfzmetx5pyM4JwQwO8jZJcABYdmEZOyJ2ML7VeNrVageARiMY0tqHra91pLWfM2+v+5tXV5wkKzffKHUKIZjcZjI5+Tl8dvwzo5SpVE4qQCiKAdKy8xi7/C+mrDtDcy8Htr3WiZc61y1ywLms/k74mzkhcwj2CmZE4xF3nXezs2LJqDa82esBNp6KZvj3h0lMyzZK3T72PoxoPIJNoZu4mHTRKGUqlY8KEIpSjPCEdB6bt58tZ64zqVdDfh7dFl8XW5PWeTPnJhP2TKCmdU0+6PDBPbuPNBrBK8H1+PrJQM5G32TQt4eISTHO1pejmo6ihkUNvvrrK6OUp1Q+KkAoShFORt5g4DcHSU7PYdnz7Xg5uC4ajWk3h5FSMv3gdGLTY/m408cGrWzu3awWvzzXlribWQz7/jCxN8seJBwsHXi26bPsidrDX3F/lbk8xXS0Wi0BAQG0aNGCwMBADh48aJRyVYBQlHs4cDmBYQsOY2OpZc3L7WlXx6Vc6l1/ZT3br27n1cBXCXALMPi+ID9nfhrdRh8kFhwmKT2nzG0Z3nA4rtaufHHiizKXpZiOtbU1J0+e5NSpU8yePZvJkycbpVwVIBSlEIdDExm95Bg+zjasebk9dWqWz54J0WnRfHT0I1q5t+KZJs+U+P5Wvs4sfrYNUTcyeeGnkDIPXNuY2/Bcs+c4HnucE7EnylSWUj5u3ryJk5OTUcpS01wV5Q4nIpJ5dvExvJxs+OX5trjWMO6K5XvRSR1TD0xFJ3V88NAHaETpPr+19nPms8EBjFl2gjdWneKroS3L1C02oP4Avjv1HQv/Xkige2Cpy6kWtrwFMWeMW6ZHM3jkwyIvyczMJCAggKysLK5fv87OnTuNUrVJnyCEEL2EEBeFEJeFEG8Vcr6TEOKEECJPCDHotuMBQohDQoizQojTQoghpmynotwSkZjBc0tCqGlnybLnyi84ACy/sJyjMUd5s/WbeNl5lamsPs1rMfmRhmw+fZ1v914pU1nWZtYMbzScvVF71YymCupWF9OFCxfYunUrI0aMwBhZMkz2BCGE0ALzgR5AFHBMCLFBSnnutssigJHAhDtuzwBGSCn/EUJ4AseFENuklDdM1V5FScnIZdTio+ik5MeRrXGzL30K7ZIKTQnls+Of0cmrEwPqDzBKmS90qsPf0TeZs+0iLb2deLBu6cdQhjUcxo9//8iPZ3/kw45Ff5qt1or5pF8eHnzwQRISEoiPj8fNza34G4pgyieINsBlKWWolDIHWAH0u/0CKWW4lPI0oLvj+CUp5T8F30cDcYBazqmYjE4nGbfiLyKSMvjuqVblNuYAkKfL453972BlZsX0B6cbbUW0EIIPBzTD39WWccv/Iq4MM5scLB0Y1GAQW8O2EpMeY5T2KaZx4cIF8vPzcXEp+6QKUwaI2kDkbT9HFRwrESFEG8ACuOs5WQjxghAiRAgREh8fX+qGKsrXuy+z91I80x9rQttymq10y8IzCzmTcIZ32r5j9LQWtpZmfPtUK9Kyc3lr7ZkydTsMbzQcieTXi78asYWKMdwagwgICGDIkCEsWbIErbbsizgr9CC1EKIWsBR4Rkqpu/O8lHIBsAD02VzLuXlKFXHwSgJzt1+iX4Anw9v4lGvd5xPP8+2pb3nE7xF6+fcySR313e14q1dDpm88x6/HIhlaytdYu0ZtOnt1Zs2lNbzU4iWjpxtXSi8/3zhpVu5kyieIa4D3bT97FRwziBDCHtgMvC2lPGzktikKoB93GP/rSfxcbZnVv5nR02cXJTs/myn7p+Bk5cTb7d42aV0jHvSjfV0X3t90jsikjFKXM7zRcJKzk9kattWIrVMqKlMGiGNAfSGEvxDCAhgKbDDkxoLr1wE/SSlXm7CNSjX33qazJKTl8MWQlthalu8D9fy/5nP5xmWmt59u8n2gNRrBJ0+0QCMEE1efKnVXU1uPttRxqMOyC8uMMktGqdhMFiCklHnAWGAbcB5YKaU8K4SYIYR4DEAI0VoIEQU8AXwnhDhbcPtgoBMwUghxsuDL8CWlimKA7ediWXviGmOC69LMy7Rv0Hc6EXuCxWcXM6jBIDp5lW1bSEPVdrTmrd4NORyaxLq/DH6Y/w8hBMMaDuNc4jlOxZ8ycguVisak6yCklL9LKRtIKetKKWcWHHtXSrmh4PtjUkovKaWtlNJFStmk4PjPUkpzKWXAbV8nTdlWpXq5kZHDlHVnaOhhx9iu9cu17ozcDN7e/zaeNTyZEHTnDG/TGtbah5Y+jszcfJ6UjNxSlfFY3cewNbdl1aVVRm6dUtGoVBtKtfTJtoskpecw54kWWJiV75/BnJA5XEu7xswOM7E1N21W2DtpNIIPHm9KckYOH2+7UKoybMxt6OXXi+1Xt5OWk2bkFioViQoQSrVzJiqFZUcjGPGgL01rl2/X0r6ofay6tIoRjUfQyr1VudZ9SxNPB0Y95M+yoxGcjird2tMB9QeQmZfJ1nA1WF2VqQChVCs6nWTq+r9xsbVkfI8G5Vp3SnYK0w5Oo65DXcYFjivXuu/0Wvf6ONtY8MHm86UabG7m2oy6DnVZ9886E7ROKamYmBiGDh1K3bp1adWqFb179+bSpUtlLlcFCKVaWX08ipORN5j8SEPsrczLte6ZR2aSnJXMrI6z7vsaAjsrc17r0YCjYUn8cS62xPcLIehfvz+nE05zOfmyCVqoGEpKSf/+/QkODubKlSscP36c2bNnExtb8v+vd1IBQqk2MnLy+OSPi7TydWJAYIkX9ZfJlrAtbAnbwgstXqCxS+NyrftehrX2pp5bDT7ccoGcvLvWoRarb92+mGnMWHt5rQlapxhq165dmJub89JLL/17rEWLFnTs2LHMZVfoldSKYkyL9ocRn5rNt08FluuCuNj0WN4//D7NXJvxfLPny63e4phpNUzp3ZBnF4fwy5GrjHrIv0T3O1s508W7C5uubGJ84HjMteX7RFYRfXT0Iy4klW7w/14aOjdkUptJ9zz/999/06qVacaz1BOEUi0kpefw3Z5QejR2p5Wvc7nVe2uPhzxdHrM6zMJMU7E+k3V5wI2H6rnw5Y5/SMvOK/H9/ev1Jzk7mb3X9pqgdcr9VrF+WxXFRObvukx6Th5vPvxAuda74sIKDl0/xDtt38HPwa9c6zaEEIKJDzfk8fkHWHIwnDFd6pXo/gc9H8TZypnNoZvp5tPNRK2sPIr6pG8qTZo0YfVq0yScUE8QSpUXlZzB0kNXGdTKi/ruduVWb2hKKHOPz+Wh2g8x+IHB5VZvSQV4O9KtoRsL9oZyM6tki+fMNGb08uvFnsg9pOakmqiFSlG6du1KdnY2CxYs+PfY6dOn2bdvX5nLVgFCqfLm79Jnin+te/lNa83V5TJl3xSszKx4v/375TrmURrjezQgJTOXRfvDSnxvnzp9yNHl8OfVP03QMqU4QgjWrVvHn3/+Sd26dWnSpAmTJ0/Gw8OjzGWrLialSou+kcnq45EMae2Np6N1udW74PQCziaeZW7wXKPv8WAKTWs78HATdxbuC2NUe38cbAwfcG7m2gwfOx82h26mf/3+Jmylci+enp6sXLnS6OWqJwilSvtuzxWkhJc61y23Ok/Hn+b709/Tt05fevj2KLd6y+q17g1Izc7jh/2hJbpPCEGfOn04GnOU2PSyz71XKg4VIJQqKy41i+XHIhkY6IWXk0251JmRm8GU/VNws3FjctvJ5VKnsTSqZU+fZrX48UA4KZklG4voU6cPEqlSb1QxKkAoVdb3e0PJy9fxcnD5PT3MPT6XiJsRzOwwEzuL8hsQN5ZXutQlLTuPnw9fLdF9vva+NHVpyubQzSZqmXI/qAChVEnJ6Tn8fDiCfgG18XMtn4yp+6L28evFXxnReAStPVqXS53G1sTTgc4NavLjgTCycku2jWWfOn04n3SeKzfu2j5eqaRUgFCqpF+OXCUzN7/cnh6Ss5J59+C71HOsd98T8ZXVy8F1SUjLYVVIZInu6+XfC4FgW/g2E7VMKW8qQChVTnZePksOXaVzg5o0KId1D1JK3j/8PjeybzC74+z7noivrNr6O9PSx5HvCrroDOVq7Uor91b8Ef6HCVunlCcVIJQqZ8PJaOJTs3muY8lyC5XWptBNbL+6nbEBY2no3LBc6jQlIQSvBNcjKjmTTaevl+jenn49uZJyRWV4LWdarZaAgACaNGlCixYt+PTTT9HpSp6A8U4qQChVipSShfvDaOhhR4d6riav73radWYdmUWgWyAjm4w0eX3lpVtDN+q71eCb3VfQ6QzfL6KHbw8Egj+uqqeI8mRtbc3Jkyc5e/Ys27dvZ8uWLbz33ntlLlcFCKVKOXA5kQsxqYzu4G/y1cs6qePtA2+jkzpmdpiJVqM1aX3lSaMRvNi5LhdjU9l3OcHg+1Q30/3n5ubGggULmDdvXqk2g7qdSVdSCyF6AV8AWuAHKeWHd5zvBHwONAeGSilX33buGeCdgh8/kFIuMWVblarh+32h1LSz5LEAT5PXtfTcUo7FHGNG+xl42XmZvL7y9lgLTz7aeoFF+8Po3MDw1eA9/Xoy68gsLidfpp5TyZL/VXYxs2aRfd646b4tGzXEY8qUEt1Tp04d8vPziYuLw93dvdR1m+wJQgihBeYDjwCNgWFCiDt3SokARgLL7rjXGZgGtAXaANOEEE6maqtSNVyJT2PPpXhGtPPF0sy0n+b/Sf6HL058QRfvLjxe73GT1nW/WJhpGNHOlz2X4rkcZ3giPtXNVHWY8gmiDXBZShkKIIRYAfQDzt26QEoZXnDuztGUh4HtUsqkgvPbgV7AchO2V6nkfj58FXOtYFhbH5PWk5Ofw+R9k7GzsGPag9MqfCK+shje1oevdl1m0YFwZvVvZtA9t3czvRLwiolbWLGU9JO+qYSGhqLVanFzcytTOaYcg6gN3D6ROqrgmKnvVaqhjJw8Vh+P4pGmtXCtYdpppl+f/JqLyRd5r/17uFi7mLSu+82lhiX9A2qz9kQUyek5Bt+nZjPdP/Hx8bz00kuMHTu2zB9eKvUgtRDiBSFEiBAiJD4+/n43R7mPNp6KJjUrj6cf9DVpPSdiT7Do70UMrD+QYO9gk9ZVUYzq4EdWro5lRyMMvkd1M5WvzMzMf6e5du/enZ49ezJt2rQyl2vKLqZrgPdtP3sVHDP03uA77t1950VSygXAAoCgoKCyDdcrlZaUkp8OXaWhhx1BvqYbqkrPTWfK/il41vBkYuuJpSskJQoij0BUCCT8AymRkBYLeTkg88HSHmycwbku1HwAfNqBb3uwvH95nRp62NOhnis/HQrnhU51MNcW/7myOncz3Q/5+SVLi2IoUwaIY0B9IYQ/+jf8ocBwA+/dBsy6bWC6J1C5UmMq5eZk5A3ORt/kg8ebmnQ8YE7IHKLTolncazG25iXI7xR/Cf5eA+c3QtxZ/TEza3CtDy71wK8jmFmCEJB1E9ITIPEy/LMN9s8FjRn4PAjNB0Pjx8HK3jQvsAjPdvDj2cUh/H7mOv0CDOvt7e7bnQ+PfkhYShj+DuWzaFExLpMFCCllnhBiLPo3ey2wSEp5VggxAwiRUm4QQrQG1gFOQF8hxHtSyiZSyiQhxPvogwzAjFsD1opyp58PR2BroeXxlqYbptobtZfVl1YzqukoAt0Di78hPw8uboaj30P4PkDo3+R7zgS/h8C9KWiL2ZQnN1P/tBG6G85tgA3j4Pc3oeWT0H4cOPkZ4ZUZJriBG/6utiw+GG5wgOjm040Pj37IjogdPNfsORO3UDEFk66DkFL+Dvx+x7F3b/v+GPruo8LuXQQsMmX7lMovOT2HjaejGRLkTQ1L0/w6J2cl8+6Bd6nvVJ+xAWOLvliXD2dWwZ6PICkUHLyh27sQ8BTYlXA+urk11AnWf3Wbpu+WOrEYji+BkB+h+RDo+g44mH7+hkYjeKqdL+9vOsff11JoWtuh2Hs8bD1o4tKEnRE7q3yAkFJW+NlspVk0V6kHqRVlzYkocvJ0PNnONFNbbyXiS8lJYXaH2VhoLe598aVtML8trHsRzG1h8FL43yno+EbJg8OdhADv1tBvPrx2Gtq9rO+2+qoV7Jqtf9owsUGBXliZa0q0V0Q3n26cSThTpXeas7KyIjExscyrlk1JSkliYiJWVlYluk/tSa1UWlJKVoZEEuDtSEMP0/TLbw7bzPar23kt8DUecH6g8IuSQmHrZLi0FVzq6wNDw0dBY6LPX/ae8PBMaPMC7HgP9nyoDxb95oNPW9PUCTjYmNOvRW1+O3mNyb0b4WBd/L7V3Xy68eVfX7IzcifDGg4zWdvuJy8vL6KioqjoMymtrKzw8irZin8VIJRK61RUCpdi05g9wLAFXCUVkx7DrMOzaOnWsvBEfPm5sG8u7JsDWgvo+QG0eRHMinjKMCYnXxi0CFo+DRtehUUPQ7tXoPs0/aC3CTz9oC+/hkSy5ngUz3YofuC5jmMd/Oz92BGxo8oGCHNzc/z9q+YgvOpiUiqtX49FYm2u5dHmtYxetk7qmHpgKnkyj5kPFZKIL/Yc/NANds+CRn1h3HH9wHF5BYfb1e0CrxyEoGfh8Hx9oEgON0lVTWs70NLHkZ8PXzW4S6WbTzdCYkJIyU4xSZsU01EBQqmUMnPy2Xgqmt7NamFnVXxXR0mtuLCCw9cPM7H1RLztb1vOk58H+z6FBZ0h5RoM+Vn/Kd7Ow+htKBFLO3h0Lgz5BRJD4btOcME0+0M/3c6X0IR0DlxONOj67r7dyZf57I7cbZL2KKajAoRSKf1+5jpp2XkMDjJ+FtXI1Eg+P/E5D9V+iEH1B/3/iZvRsORR2DEDHugNY47onx4qkkaPwot7wMkfVgyHvZ+AkQdPezerhbOtBUsPhxt0fROXJrjbuLMjYodR26GYngoQSqX0a0gkfi42tPF3Nmq5UkqmH5yOVmiZ/uD0/5+6ePlP+LYDxJyBAd/D4CVga/oNiUrF2R+e3QbNBsPOD+C3lyEv22jFW5lrGRzkzfZzsVxPKX72lBCCrj5dORh9kIzcDKO1QzE9FSCUSicsIZ2jYUk8EeRt9Lnnqy6t4mjMUd4IegMPWw99l9KO9+HngVDDA17YrV/RXNGZW8GABdDlbTi1HH56HDKMt9b0ybY+SGD5EcPyM3Xz6UZ2fjYHow8arQ2K6akAoVQ6q0Ii0QgY1Mq43UvX064z9/hc2tZqy8D6AyE1Bn7qp5+l1PJpeO5PfXqMykII6PwmDFwI147Dj73hZsn2mL4Xb2cbujzgxrKjkeTmF7/3cSv3VjhYOqhupkpGBQilUsnL17H6eBRdHnDD3b5ki36KIqXkvUPvoZM6fddS6G59l1L0Cej/HfSbBxY2RquvXDUbBE+t1icGXPQwJIUZpdgn2/qQkJbNjvPFL4Iz05jR2asze6L2kJufa5T6FdNTAUKpVPb+E09cajZPBHkXf3EJrL+yngPRB3it5f/wClkKS/uDjQs8vwtaDDVqXfeFfycYsQGyb8KiXvppumXUuUFNajlYsexoZPEXo+9mSs1J5VjMseIvVioEFSCUSmXNiWs421rQtWHZdsq6XVxGHB8f+5hAl2YMPbZcvzK5xTB4fie4NTRaPfedVysYtUX//eLecP10mYoz02oYHOTNvn/iiUwqfvC5vWd7rM2sVTdTJaIChFJp3MzKZfu5WPo2r4WFmXF+daWUfHD4A3Lyspjxz3E0kSH6lBX9vwGLEqT0rizcGsGzW/W5on7qBzF/l6m4wa29EegXLRbHysyKhzwfYmfkTnSy+HEL5f5TAUKpNLacuU5Ono7+gcYbnN559U92Re5iTEI8vub2+qeGlk8ZrfwKydkfntkAZlbw02Nl6m6q7WhN8ANurAwxbLC6q09XEjITOB1ftqcXpXyoAKFUGmtPXKOOqy0tvIpPNW2ItOQwZu2ZyAPZOTzl87B+vMG9sVHKrvBc6sLITaAx1weJuAulLmpYGx/iUrPZeSGu2Gs7eXXCTJixM3JnqetTyo9K1qdUClHJGRwJS+KNHg2Ms/YhdA/ztr1EvLWWzxo/i/lDb+qnhVYnt4LEj71hSV/9+IRrvRIVkRsTQ1D4X4z9ZxvZk34hzCaf/Bs3ABBaLWZubpjXqoVV40ZYt2yJfePGtPZozc6InYwPHF/h91Co7lSAUCqF9SejAcq+a5wuH/Z8zNlDc1nu6cFg35407zDJCC2spFzr/3+QWPq4fgV2MRsQZYeGkbJxA2k7d5F98SIAj2jNiLBxIbexP7Y+PiAEMjeXvLg40g8cIOW33wDQurrydJs6fOIezpUbV6jnVLKApJQvUZE3uSiJoKAgGRIScr+boZiAlJLuc/fgbGvBqpfal76glGuw7kXywvcxvG4j4i2s2NB/I3YWdsZrbGUVfRIWP6rfa2LUFrB1+c9pmZfHzW3buPHrSjKOHgWNBpvAQGp06YJNmzYkunvT8bP9jOtSj9d73r1vRm5MDBnHj5P6x3ZSd++C7BxuNPWm+YQZ2LZrV16vUimEEOK4lDKosHNqDEKp8P4enEAAACAASURBVM5cS+FKfDr9W5ZhcPrMavjmQbh2guXtR3Fel85bbSer4HCLZwAMX6FPE/7LIMhOBUDm5nJj7Tqu9OlD9BsTyL1+nZqvv079Pbvx/XkpLqOfxbpZU7zcHAhuUJNfQyLJK2Sw2tzDA4c+ffD64nMa7N/Pn4/WRhNxnYiRo4gcM5acCMNSdijlSwUIpcJbe+IaFloNfZqVYt+HzGRY/SysGQ2uDxDzzFq+ij9Ix9od6enb0/iNrcz8OsATi+H6KeTy4dzcspkrvftwfcoUtLY18Jr3FXW3bcX1hecxq1nzrtuHtfEh9mY2uy4WvbOa1s4Om2eG8fKLEquxz5F+6BChfR8jaenPSJ2a/lqRmDRACCF6CSEuCiEuCyHeKuS8pRDi14LzR4QQfgXHzYUQS4QQZ4QQ54UQk03ZTqXiys3XsfFUNN0aueFgU8J9H67sgq/bw7n10PUdGLWFWZeWIaXk7XZvqwHSwjTsTVbAVCIWneXa+AlorK3w+uZr/Nasxq57d0QR26h2beiGm50ly48W/zTQ1acruWaCg908qLtlC7bt2hE7cyaRz79AXnKyMV+RUgYmCxBCCC0wH3gEaAwME0LcOYdwNJAspawHfAZ8VHD8CcBSStkMaAW8eCt4KNXLvn/iSUzPoX9JBqczk2H9GP2gq4UtjN4OnSay9/pBdkXu4uWAl6ldo4yD3VWQLiuL2A8/ImzyD2RnOOARdAP/5+piFxxsUDA102oY0tqb3RfjuHaj6DTg/g7+1HGow86InZi7u+H17Td4TJ9OxrFjhA96gqyLl4z1spQyMOUTRBvgspQyVEqZA6wA+t1xTT9gScH3q4FuQv+bKAFbIYQZYA3kADdN2Falglp74hpONuYEP2BAag0p4ew6mNcGTi6HDuPhpX1QO5Cc/Bw+OvoRfvZ+PN3oadM3vJLJPHOGsAEDSVq8GMchg6m7YzdOI0YjTiyCA18YXM7gIG8ksNKAldXdfLpxPPY4N7JuIITAaegQfH/5GZmbS/iwYaTu2lWGV6QYgykDRG3g9t+SqIJjhV4jpcwDUgAX9MEiHbgORABzpJTGS2avVAq3Ums82tyz+NQaNyL0O6itGqmfifPCbug+HcytAfjp3E9EpEYwuc1kzLXG36K0spI5OcR/+SXhQ4ehy8jAZ9FCak2bhtbBAbrPgCYD4M9p+kF+A3g729Cpfk1WhkSSryt6hmRXn67ky3z2RO3595h1s2b4rVqFpb8/UeNeJWWzabZNVQxTUQep2wD5gCfgD7whhKhz50VCiBeEECFCiJD4+KIHxpTKZ+uZGLLzdPQPLKI7KCsFtk+Dr4L0Yw49P4DndkCt5v9eEpsey4LTC+jq3ZX2tcswTbaKybp0ibChQ0n4+hsc+valzob12La/7d9Ho4H+34JvB1j3EoTtNajcYW18uJ6Sxe6LRa+svtdWpObubvgsWYxNQADREyaSvGpViV+bYhwGBQghxFohRB8hREkCyjXg9pzMXgXHCr2moDvJAUgEhgNbpZS5Uso44ABw1zxdKeUCKWWQlDKoZiGzKpTKbe1fUfi72tLS2/Huk/m5cGQBfNkSDnwOTQfAuBBoPw60/13/+enxT8nX5TOh9YRyannFJvPzSfzhB8IHDiIvNg6veV/h+eFstPb2d19sZglDf9avul7xlEF5m7o1cqOmAYPVRW1Fqq1RA+/vF2DboQMxU98lZf36Er1GxTgMfcP/Gv2b9j9CiA+FEHevhLnbMaC+EMJfCGEBDAU23HHNBuCZgu8HATulfuVeBNAVQAhhC7QDSp8sRql0opIzOByaxOMBtf87QColXNgMX7eDLRPBrTG8sEf/Sdfh7nUSITEhbAnbwqimo/C2M+4eEpVRztWrXH3qaeLmfEqN4GDqbNyAXffuRd9k7QRPrtJ31/3yBNyMLvJyc62GwUFe7LwQV+ye1be2Ij0Ufeiucxpra7zmfYVNu3ZET3mb1J0qf1N5MyhASCn/lFI+CQQC4cCfQoiDQohRQohCO3QLxhTGAtuA88BKKeVZIcQMIcRjBZctBFyEEJeB14FbU2HnAzWEEGfRB5ofpZQq/WM1ciu1xn9mL107Dov76McahAaG/QrPbNQv8ipEni6P2UdnU8u2FqObjS6PZldYUkqSli0j9PH+ZF+5gucnH1P7yy8wc3Y2rABHH32QyLqhDxJZRc8ZGdraB52Elceiirwu0D0Qewv7e+4RobG0xGvePKyaNOHaa+PJOKY2GypPBncZCSFcgJHAc8BfwBfoA8b2e90jpfxdStlASllXSjmz4Ni7UsoNBd9nSSmfkFLWk1K2kVKGFhxPKzjeRErZWEr5SalfoVLpSClZf/IarXyd8HGxgeSrsHo0fN8VEi5Bn7nw8iF4oFeRCfZWXVrFpeRLTAiagLWZdTm+gool9/p1Ikc/R+yM97Fp1Yo6G9bj0LdvydeB1GoOg3+C+Auw6hnIz7vnpd7ONnSs78qvxyKKHKw215gT7B3M7qjd5OoK34pUW8MW7+++xbx2baLGvapWXZcjQ8cg1gH7ABugr5TyMSnlr1LKcUANUzZQqX7OX0/lUmwaTzSpAdvfhXmt4cIm6DgBxp2A1qPvGme4U3JWMvP+mkdbj7b08O1RTi2vWKSU3PjtN0If60fGyZN4TJ+G9/cLMPfwKH2h9brBo5/BlZ2w5U19l989DG/jQ3RKFnsvFT2BpKtPV1JzUjkee/ye15g5OeH97TdIKYl8+RXyU1NL/RIUwxn6BPF9wSf52VLK66BfBQ1wryRPilJaG09cZZTZNgYf6gcHvoSmA/WBodtUsCpkILUQX/71Jem56bzV5q1quWI6Lz6eqLHjuP7WZCwbNKDOb+twGjrUOP8WgSPgof9ByEI48u09L+ve2B3XGpYsK2awur1ne6y0Vuy4WvRWpBa+vnh98QU5V69ybfzryLx7P8EoxmFogPigkGN3jyopSllISf65DQwLeYJpZkvQeDSFF/fot/8sJgX17c4mnmXNpTUMazis2qWTllKSsnEToY/2JX3/ftzefBPfn5Zg4eNj3Iq6TYeGj8K2KXBpW6GXmGs1PFEwWB2TknXPoqzNrGnv2d6grUht27XFY+pU0vfvJ37+/LK8AsUARQYIIYSHEKIVYC2EaCmECCz4Ckbf3aQoxnHtBPzYG+3Kp8nWaTj84DcwYgPUalGiYnRSx+wjs3GycuKVgFdM1NiKKS8+nqhx44ieOBELPz/8163D5dlRCK3W+JVpNDBgAXg00ydDjDlT6GVDW3uTr5OsCil6ZXU3327EZcRxNuFssVU7DRmMw4ABJH77HWn79peq+Yphitsw6GH0A9NewNzbjqcCU0zUJqU6uXkddrwHp5aDbU3Wek5gelQgR7roB6DzU1PJPHWa7IsXyImMJDcyirzkJGR6BrqMDDAzQ1iYo7GyxqxmTaKts3gg4wQj2w/GPPw60t8KYV61V05LnY6UtWuJ+2QOusxM3CZOxHnkM6YJDLezsNXPJPu+Kywbot/P2+6/4xu+LrZ0rO/KimORvNKlHlpN4V1cnb06oxVadkbupFnNZsVW7TH1HbLOnCH6zTfxX7e2bOMqyj0ZtGGQEGKglHJNObSn1NSGQZVMbiYcnAf754IuDx4cQ1a7/9Hmk8MMt0vjWa6Stmcv2Zcv/zsQqnV0xNzLCzNXVzQ2NmhsbZD5OmRODrr0dHLiY4m7egH7NB2aW7/W5uZYNWyITWAg1q0CsWnVCjMXl3u3q5LJunCBmOnvkXnyJNatWlHr/RlY1rkr6YBpXT8Fix6Bmg1g5O9g8d/Ohd/PXOeVX06weFTrInNqPbftOeIy49jw+J3LpQqXHRpK2KAnsGrYEN+fliDM1AaZpVHUhkFFBgghxFNSyp+FEG+gT6D3H1LKuYXcdl+oAFGJXNwCv0+ElEho9Bj0mEFefg2Ofr2EnN/W4p6ZDGZm2LQOwqZ1a2wCArBq0kSfH6gIc47N4adzP7GsxxLqpdqQfekfsi9dJPPkKTJPn0ZmZwNg2agRNTp2pEanjlgHBFTKN5a8pCQSvv6G5GXL0Do64jZxIg6P97t/A/IXt8DyYdCoLzyxRN8FVSAnT0f7D3cQ6OPEghH3ntOy7PwyZh+dzfrH11PHwbAgl7JxE9ETJ+I6biw1x4wp88uojooKEMX9ZdgW/FdNZVXKLjVGPzXy3Hr9CuiRm8nR+pIw51tSNmzAKS+Psx4NaD5tEg5duxSe+uEeQm+E8sv5X+hfvz9NPVsCYPXAA8CjgD4pXda5c6QfPUb63r0kLlxI4oIFaOzssG3fnhrBwdTo1LHCP13o0tNJXLKEpIWL0GVl4ThkMG6vvVZs8DS5Bx7R58H6423YOUOfKLGAhZmGQa28+X5fKLE3s3C3tyq0iK4+XZl9dDY7I3ZSp5lhAcKh76Ok7d1LwtffUKNTJ6ybFd89pRhO7UmtmJ6UcPxH2D4d8rIgeBJ59YcTP/8bbqxbh9BosBkwiGeSfAjuEcS0vk1KWLzkxe0v8nfC32zsvxEX6+Lf5PNTU0k/eIi0fXtJ37OXvPh4EAKr5s2wCw6mRnAwlg0bVpgpsvk3b5K84leSliwhPzERux49qDn+tfLvTiqKlLDpNTi+GPrNh5ZP/XsqPCGd4Dm7mdCzAWO71r9nEUM3DUUjNCzrs8zgavNv3iT0sX5orK3xX7sGjXX1XRRZGmXek1oI8bEQwr5gp7cdQoh4IcRTxd+pVHupMfDzQNg0HjwDkC/sJyncnSuPPkbKb7/hNHQodbdv52DvZwizceXxgJJv5LMzYieHrh9iTMsxBgUH0G97af9wTzw/+IB6e/fgt2Y1rmPHgIT4L74krP8ALgd34fq700jduQtdZtE5hUwl5+pVYj/+hMtduhI/dy5WDRvit2I5Xl99WbGCA+hXtfeeA3WCYeNrEHH431N+rrY8VM+F5Ucj0RWxsrqbTzfOJJwhNj3W4Gq19vZ4zp5FTlgYcXM+LcMLUO5k6CD1SSllgBCiP/pn9teBvVLKks1BNCH1BFEBnd8IG17VD0g/PJNsx05ET3qLrHPnsH3oITymvoOFnx8AQxccIu5mNjve6FyiT+1ZeVk8vv5xrM2sWdV3FWaaso8n5MXHk7Z3H2l79pC+fz+6jAyEpSU27drqny46d8bc07PM9dxLfkoKqTt3kbJmDRkhIaDRYN+rFy7Pjcaq8Z2bMlZAmcn6mU3ZqfD8LnDUJ0ncdDqascv+YsmzbejcoPDsy6E3Qum3vh9vt32boQ2HlqjamFmzSP5pKT6Lf8S2Xbsyv4zqoixjEHde1wdYJaVMqSiP3koFlJcD2ybDsR+gVgBywPckbztG3CdPoLG1pfbnn2H38MP/BoLoG5kcDk1ifPcGJe7S+fHsj1xLu8bCnguNEhwAzGrWxHHgABwHDkCXk0NmSAipu3eTtnsPMXtmAGBRpw7WAQFYt2iBdYvmWNarV+rBbl1ODtnnzpFx4i/S9uzRB4X8fCx8fan5+us49OuHubsBO+pVFNZO+umvP3SDFcPg2W1gYUvPxh642Fqw/EjEPQNEHcc6+Nn7sSNiR4kDhNvrr5O2Zw/Xp75LnQ3rVVeTERj6G71JCHEByAReFkLUBO69NFKpvm5Gw8pnIOootB9HfuvxRL/9Lmk7d2LbqSOeM2didsfeHRtO6TO39gso2afya2nXWHhmIT19e9KmVhujvYTbaSwssG3fHtv27ZGTJ5MTFk7a7t1kHD1K2q5dpKxdC4AwN8fc1wdLf3/MfXwwc3FF6+yE1tERoTUDjQAJutSb5KekkBcXT87Vq+SEh5P9zz/InBwALOvXw2X0aOy6dsGqRYsKMwZSYjUbwKBF+syvv70MTywpGKz2YuH+MOJuZuFWxGD1T2d/IiU7BQdLwwffNVZW1JrxPhHPPEP8V/Nwf3OisV5NtWXwILUQwhlIkVLmCyFsAHspZYxJW1cCqoupAgg/oM/ymZsJ/eaTbd2CqDFjyImMxP3NiTg9/XShb3i9Pt+LlbmW38Y8VKLqxu8az4HoA2x4fAMetuW/UEpKSW5kJJknT5J96RLZYeHkhIeTGxGBzC08M+m/hMDc0xMLPz8s69fHOrAl1gEBmLtVoicFQxz4ErZPheApEDyJsIR0uszZzcSHH2BMl8LToJyOP82Tvz/JrA6z6Fu3b4mrvD71XW6sWYPfypVYNy3ZhIfqyBhdTAANAb+Cnd9u+alMLVOqjlO/wvox4OQHIzeTdj6Wa68PRpib47NoIbZtCv+EfyHmJhdiUnnvsZL9IR+8dpA/I/7k1Zav3pfgAPod0Sx8fO7KcySlRJeWRn5SEvkpKcj8/P9f7Gdnh8bBATNHR4SFxf1odvlqPw7izsHuWeDWCP/Gj9G+rgsrjkXwcue6aApZWd3UtSlu1m7sjNhZqgDhNnECabt3c/2dd/BftbLKr6Q3JUNnMS0F5gAdgNYFXyqLq6J/49v7Cax7AXzawXN/cmPfOSJffgVzb2/8V6+6Z3AA+O2vaLQaQZ/mtQyuMjc/l9lHZ+Nj58MzTZ4p/oZyJoRAa2eHha8v1s2bY9OyJTaBgdgEBmJZvz7mbm7VIziAfmbTo5+DV2tY9yLEnGFYGx8ikzLZfzmh0Fs0QkMXny4ciD5AVl7Je7K19va4vzuV7AsXSFz0Y1lfQbVmaDbXIOAhKeUrUspxBV+vmrJhSiWQnwcb/wc7P4DmQ+CptSQuW8P1KVOwbdsG36VLMa9972mrOp1kw8lrdKzvimsNS4Or/fn8z4TfDGdSm0lYaKvJG21lZm4FQ34GK0dYPoyefhqcbS2K3LO6q09XMvMyORh9sFRV2vfogV3PniR8/TU5kUUnClTuzdAA8TegsmEp/y8/F9Y+DyeWQMc3kI9/S9znXxL3yRzsez+C17ffoq1hW2QRx8KTiE7JKtHah7iMOL499S3BXsF08upU1lehlBc7Dxj6C6THY7lmFINburP9XCxxqYU/IbT2aI29hT1/Xv2z1FW6T5kMWi2xs2aXuozqztAA4QqcE0JsE0JsuPVlyoYpFVheDqwaCWfXQo/3kV2nEvfppyT+sBDHYUPx/OQTNAZ0ofx2MhobCy09m7gbXPXc43PJ0+XxZus3y/AClPuidqB+hXXEQV7J+IY8nY7Vxwvfs9pcY043n27sitxFdn52qaoz9/Cg5pgxpO3aRerOXWVpebVlaICYDjwOzAI+ve1LqW7ysmHl0/otQHt9hGw/jvjPPidp4SKchg/D4913DUoznZ2Xz+bT0fRs7I6NhWFzJUJiQtgcupmRTUfibe9d1lei3A/NBkHHN7A/t4xp7gdYUcTK6of9HiYtN42D10rXzQTgPOJpLOrVJXbWLHRZamZ+SRkUIKSUe4BwwLzg+2PACRO2S6mI8nP1Tw6XtkKfudDuJRK++orEBQtwHDIE93feMXje/u6L8dzMyqNfS8O6l/J0ecw+OptatrV4rtlzZXgRyn3X5R1o8AjP3FyAe/IJDl5JLPSyNrXa4GDpwLarhe9YZwhhbo7HO1PJjYoiccH3pS6nujJ0FtPzwGrgu4JDtYHfDLivlxDiohDishDirULOWwohfi04f0QI4XfbueZCiENCiLNCiDNCiMJX1SjlQ6eD9WPh4u/6fDutR5O46EcSvv4Gh0ED8Zj2LkJj6AMprD95DRdbCzrWczXo+pUXV3Ip+RITW0/E2kytkK3UNBoY8B04+fGt5RdsPlj4+iVzjTndfbqzO3J3qbuZQL9NqX2fPiT+8AM5V6+WupzqyNC/6DHAQ8BNACnlP0CRK3qEEFpgPvAI0BgYJoS4M5HMaCBZSlkP+Az4qOBeM+Bn4CUpZRMgGChm5ZFiMlLqU2ecXqH/9NfmeVI2biTu44+x69WLWu+9V6LgkJKRy5/n4ujbwhMzbfH3JWQmMO/kPNrVakd3n+5leSVKRWHlgGboL9TQ5DLkytvEJKYUellP356k56Zz4NqBMlXn9uabCHNzYmbOpKpksC4Phv5VZ0spc279UPAGXty/chvgspQytODeFUC/O67pBywp+H410E3o+yh6AqellKcApJSJUsp8A9uqGNuej+HIt9BuDHSaQNqBA0RPeRubNm3w/OjDEm9tufF0NDn5Oga18jLo+k+OfUJWXhaT206uvKknlLu5NeTmw18QoLlM3MrCZ823rtUaR0tHtoWXvpsJwNzdDddxY0nfu4+0XbvLVFZ1YmiA2COEmAJYCyF6AKuAjcXcUxu4fQJyVMGxQq+RUuYBKYAL0ACQBbOmTggh1JSV++Xkcv0q2BbDoecHZJ47x7Vxr2JZpw5e8+ehsTR8/cIta09E0cC9Bk08i98Q6GD0QX4P+53RzUYbvMuYUnnUbDuYTfZDaR77G3lH717Udms20+7I3aVaNHc75yefxMLfn7iPPvo395VSNEMDxFtAPHAGeBH4HXjHVI1CnwKkA/BkwX/7CyG63XmREOIFIUSIECIkPj7ehM2ppq4ehA3jwK8j9P2C3Lg4Il96CY2jA94LFqC1sytxkaHxaZyIuMHAQK9inway87OZeXgmvva+amC6CrN9ZDp78psjtk6EqLvHIx72e5iMvIwydzMJc3Pc35pEztWrJP1i+IZE1Zmhs5h06AelX5FSDpJSfi+L78i7Btw+F9Gr4Fih1xR0WzkAieifNvZKKROklBnoA1JgIe1aIKUMklIG1axZePpgpZQSr8CKJ8HJF4YsRZebT9QrY5AZmfh8912p00+v++saGgGPGzB76fvT3xORGsHbbd/GUlvyJxWlcuj8gAef2E0kQbjAr09DWtx/zrf2aI2TpVOZu5kAanTujG3HjiR8/TV5SUllLq+qKzJACL3pQogE4CJwsWA3uXcNKPsYUF8I4S+EsACGAncurtsA3EqmMwjYWRB4tgHNhBA2BYGjM3DO8JellElmMiwbAkgYvhJp5Uj0lClknT+P55xPsKx/7y0ji6LTSdaeuEaH+jXvuS/xLaEpoSz8eyF96vThQc8HS1WfUjloNIJ+7ZoyMuN/6DKT9Oni8/9/ToqZxoxuvt3YHVX2biYA97cmocvIIP6LL8tcVlVX3BPEePSzl1pLKZ2llM5AW+AhIcT4om4sGFMYi/7N/jywUkp5VggxQwjxWMFlCwEXIcRl9LvUvVVwbzIwF32QOQmckFJuLtUrVEpGp4M1z0FyOAz5BVzqkvDNN6Ru2YrbG69j16VLqYs+EpbEtRuZDAws+ulBSsn7h97H2syaCUETSl2fUnk8EeRFqNaflbXehIiD8Md/e7Af9nuYzLxM9l/bX+a6LOvWxWnYMG6sWkXWxYtlLq8qKy5APA0Mk1KG3TogpQwFngJGFFe4lPJ3KWUDKWVdKeXMgmPvSik3FHyfJaV8QkpZT0rZpqDsW/f+LKVsIqVsKqVUg9TlZc9HcPlP6P0x+D3EzT/+IOHLr3Do9xjOo0eXqeg1J6KoYWlGz8ZFp/XacGUDIbEhjG81Hldrw9ZJKJWbo40F/QI8eS+8CdlBL+pnzZ369d/zQe5BOFs5syVsi1Hqqzl2DFo7O2Jnf6imvRahuABhLqW8KyevlDIeUEnWq5pL22DPhxDwJLQaRXZoKNffmoxVi+Z4zJhRpimmGTl5bDlznT7NamFtce9psfEZ8Xx07CNaurVkYP2Bpa5PqXxGPOhHZm4+v9g/B74dYNNrEKvvWTbTmNHDtwd7ovaQlpNW5rq0jo64jhtHxuHDpO3YUebyqqriAkRRc8HUPLGqJClMn53Voxn0+RRdRgZRr76KsLLC68svSzWd9XbbzsaQnpPPgCK6l6SUfHD4A3Lyc5jRfgYaYfjiO6Xya1rbgUAfR5YejUY3cCFY2sHKEZCdCsCjdR4lOz+bHRHGeUN3GjpEn6fp40/QqWmvhSruL7CFEOJmIV+pQLPyaKBSDnIz9Qn4AAYvRZpZcX3adHJCw6j96RzM3Q3Ptnova45fw9vZmtZ+zve8Zlv4NnZG7mRMwBj8HPzKXKdS+Yx40I+whHT2x2j1e1onXdFPtZaSFjVbULtGbTaHGmc4UpiZ4T7pLXIjIkheutQoZVY1RQYIKaVWSmlfyJedlFJ1MVUVW9+CmDMw4Adw9id5+XJubtpEzVfHYftg2WcQXU/J5MCVBPq39Cp0i0mApKwkZh2ZRTPXZoxoXOzwllJFPdLMAxdbC346FA5+HaDbu3B2HRz9HiEEfer04UjMERIyC9+NrqRqdOxAjc6dSfj6G/ISjFNmVaKe4au7s7/B8cXQYTw06Enm6dPEzv4Q286dcHnhBaNUse6va0hJkbOXZh+ZTVpuGjPaz0CrKVnqDqXqsDTTMqyNDzsuxBGZlAHt/wcNHoFtUyAqhD51+qCTOqMNVgO4TZqELjub+C+/MlqZVYUKENXZjQjY+CrUbgVd3iYvOZmo117DvGZNan/0UYkS8N2LlJLVIVG09nPC16XwHeb+vPonW8O38lKLl6jnVK/MdSqV25PtfNAKweKD4frMr/2/AftasPIZ6pg70si5kdG6mQAs6/jjNHwYN1avVtNe76ACRHWVnwdrntevexi4ECm0RL/1FvnxCdT+4gu0jo5GqeZYeDKhCekMae1T6Pn4jHjeO/QejZwbMarpKKPUqVRutRys6d2sFr8eiyQ1KxesnWDwT5AeB2uf51H/PpxNPEtYSljxhRmo5iuvoLGzI/ZDNe31dipAVFd7P4HIw/DoZ/pxh6VLSd+zF7dJk7Bu1tRo1aw4FkENSzN6N7t77YOUkqkHp5KVl8WHnT7EXKOGtRS90R38ScvOY2VIwZakni3hEf0anUdiw9EIjVGfIrSOjtQcO5aMQ4dVttfbqABRHV09CHs/hhbDoPkTZJ49S+ycT6nRtStOTw43WjU3s3L5/cx1HgvwLHRb0RUXV3Dg2gHeCHpDZWpV/qOFtyNBvk78X3vnHR5VsQXwnNedtwAAIABJREFU32x675AeWkjoAqEXKYKIPpEnAvoURBCVJr3IExCkC6gUFcUHiiIgKAhIUxGUIkV6JySkk5Ded5N5f+yiCQZI2Q1JmN/37ZebuTPnnL1bzt45M+esPnidvNslSZsPgsb98DiwhJZOgWwP3W7UX/su/fthWauWyvZaAOUgHjaykvVTSy41oOdC8jMyiB43HnNXV7xmv2vUegtbT0aTrc2nf4t/1o8OTQ5l0bFFtPdpT7+gfkbTqag6DG5fk4jELPacj9U3CKG/4/UI5snw00SmR3Iq/pTR9AkLC6pPmkhueDhJ69YZTW5lRjmIh41db0FaDDz7GVg5EDt7Drnh4XgvWIC5i4tRVa0/GkGwpwONfJwKtWvztEw+MBlbc1tmtZuligApiqR7A098XWxY9VuBWIOlHfT9gsfSM7CWgq1X71v5uETYdeyIXfv2xC9fgS4pyaiyKyPKQTxMXNoJJ7/SL2n1aU7Ktu2kbN6M2+uvYdeqpVFVnYtO4UxUCv1b+P3DAXz454dcSLzAjLYzVK4lxV0x0whebluDo2FJnI5M/vuER13sn1xMt/R0fry6lSxdltF0CiGoPmki+RkZJCxdZjS5lRXlIB4WMhPhhzehWgN4dCK5ERHEzpiBzSOP4DF8uNHVbTgagaW55h91H/ZF7GP1udX0C+pHF/8uRterqFr0a+GHvZV54bsIgCb96O3ZhnSp5aejxt2/YBUYiEu/viStX0/O1atGlV3ZUA7iYWHnZMhMgGdWIKWGqPHjQQi833sPYf7PAHJZyNbm8d2fUfRo4ImzreVf7dHp0Uz9bSr1XOsxocUEo+pUVE0crC3oG+LH9tMxxKYUrgXR/F8f45sv+P7sakiLM6pe95Ej0djaEjd/gVHlVjaUg3gYuLANTq+HDuPB+xHily4j+9RpvGbNxNL3/pXdSsquc7GkZusKBae1eVrG/zqefJnPokcXqQpximIzqF0N8qVkzaGwQu0aKwd6BT3HEUszojYPhPw8o+k0d3HBfdgwMg4cIH3/fqPJrWwoB1HVybilT5vs2Qg6jCPj8GFuffopzs/1wbFHD5OoXPfHDfxcbWhdy+2vtsXHF3Mm4Qwz283Ez/Gfq5oUirvh52rL4w08+epwOOk5ukLnejUeggC2JJ2HA4uMqtf1Py9gEeBP3PwFSK32/gOqIMpBVHV+nKBf2vrMx+jSMoieNBnLGjWoPmWKSdRdiUvjcGgi/2kV8Fdivr3he1l7YS0vBL9At4BuJtGrqNq89mhtUrN1rDtyo1C7l70Xrb3asMW1Gvn75kJY2SvO3UZYWlJ94kRyr10jacMGo8mtTCgHUZU59z2c3QSdJiGrNyB2+gx0iYl4v7cQja2tSVSuPRyOpbmGviH6u4QrSVd467e3aOzemHEh40yiU1H1ecTPmTa13Pjst1BydIWnknoH9iZa5vCHRw34djBkGC8rq32XLti2akXCh0vJS0kxmtzKgnIQVZX0eNg+FrwegXZjSNm0ibTdu6k2+k1sGjQwicqMHB2bTkTxVCMvXO0sSclJYdTPo7C3sGdJ5yVYmlneX4hCcRfe6FSbuNQcvv8zqlB7F/8uOFg6sLl2S8hKgs1D9TnGjIAQgupTJpOXmkrCio+MIrMyoRxEVURKvXPISYPeH5NzI4LY2XOwbd0a10GmS4j3/cko0nN0/Kd1ALp8HeN/HU9cZhxLOi+hmm01k+lVPBx0CHSngbcjn+wP/Tv9BmBlZsW/av2LvTePkvjY23DtJzj4gdH0WgcH49znWRK/+oqc68ZLEFgZMKmDEEL0EEJcEkJcFUJMLuK8lRBiveH8ESFEjTvO+wsh0oUQ401pZ5Xj7Ca4sBU6v4V0qUP0hIkIS0u85801SgrvopBS8uWhcOp7OdLM35klx5dwOOYwb7d+myYeTUyiU/FwIYTgjU61CY3P+Dv9hoG+QX3R5mv5zt4W6j8DP82CG4eNptvjzTfRWFlxc+F7RpNZGTCZgxBCmAHLgSeA+sDzQoj6d3QbDCRJKesAS4D5d5xfDBivMsjDQFoc7BgPPiHQZiTxy5aTffYsXjNnYuH5z4yqxuJ4eBIXY9N4qU0A20K38cX5L3g++Hl6B/Y2mU7Fw8cTDb0IcLPlo33XCiXqq+1cm5DqIWy8vJG8p5aAs58+HpGZaBS95u7uuL3+Guk//0zGoUNGkVkZMOUdREvgqpQyVEqZC3wD9LqjTy9gjeH4W6CrMORlEEI8A1wHzpnQxqqFlLBtDORmwjMfkXniT26tXIlTn2dxfLy7SVV/eTgcBytz/L1jmH5wOi08W6jNcAqjY6YRDO1Yi1ORKRwKvVXoXL/gfkSlR/F74lno8z9Ij4Pvh+k/F0bAdcAALHx8iJs7D5lnvD0XFRlTOggfIKLA/5GGtiL7SCl1QArgJoSwByYB75jQvqrH6Q1waTt0fZs8K0+iJk7Cwt8PTxMtab1NQnoOO87E0P0RDRMPjMXXwZclnZao+g4Kk/BsM1/c7a34aN+1Qu1d/briZu3GhksbwKcZdH8XLv8Ih1cYRa/GyopqEyaQc/kyyd9uMorMik5FDVLPAJZIKdPv1UkIMVQIcUwIcSw+Pr58LKuopMbo9zz4tUK2eoPYGTPQxcfj8957aOyKLvVpLNYeDkdHGqe0izDXmLOi6wqcrJzuP1ChKAXWFmYMbl+TA1cSOBXxdxI/CzML/h34b/ZH7ic6PRpavQbBT8Ge6RB53Ci6HR7vjk1Ic+I/+IC8tDSjyKzImNJBRAEFt8z6GtqK7COEMAecgFtAK2CBECIMGA28JYQYcacCKeVKKWWIlDLEw8PD+M+gsiClPhGfLhd6rSB123ZSd/yIx4gR2DRqZFLV2do8vjxyheqBX5OSe4tlXZbh6+BrUp0KxYut/XG2teDDn64Uan+u7nMIIfj28rf6+hG9loGDF2x8Wb8EtowIIag+eQp5SUkkfPxxmeVVdEzpII4CgUKImkIIS6A/sPWOPluBgYbjPsDPUk8HKWUNKWUN4H1gjpRS5d69Gye/hiu74LHp5GZZETtzFjYhzXF7dYjJVW85GUmG45dkiuvM6zCPRh6mdUgKBeiT+A1pX5OfLt4slArcy96Ljj4d2XRlE7l5ufp61n0+h7Ro+H64UeIRNg0b4NS7N4lrviDn2rX7D6jEmMxBGGIKI4BdwAVgg5TynBBiphDiaUO3VehjDleBscA/lsIq7kNKlD5Ta0A7ZLPBRE+YCBoNPvPnI8zMTKo6Pz+fJScWYeF4jvEh4+ka0NWk+hSKggxsWwMnm3/eRTwf/DyJ2YnsDNupb/BrAd1m6uNzRopHVBs3Fo2tLbEzZxm17GlFw6QxCCnlDillXSllbSnlbEPbNCnlVsNxtpTyOSllHSllSyllaBEyZkgpH67Fx8VFStg6Up/FstdyEj5ZSdbJk3jOmI6Fj/GztN7JtF8/JMP6F1q69uKl+i+ZXJ9CUZDbdxF7L9zkTOTfaTDaeLehjnMdvjj3xd9f3q2HGeIR0yDiaJl1m7u5UW3MaDKPHCF1+44yy6uoVNQgtaI4nFij3zXa7R0yw5JJ+OgjnHr1wunJJ02uesOlDWy5sQpNRnOWPj5dlQ1VPBAGttPfRXxQ4C5CCMGA+gO4lHSJP2L/uN2oj0c4esO3g4yyP8K5b1+sGzYkbv68KhuwVg6ispIUDrumQs2O5NV5lqjx47Dw8aH62/81uepdYbt49/C76NKCGRg4EVtLtZxV8WBw/OsuIo6zUX/fRfSs1RNXa1e+OP/F351tXOC51ZAWC9+/UeZ8TcLMDM/p08lLuEX8UuNWtasoKAdRGcnPhy3DAYF8ehnR06ahi0/AZ/EizOztTar6YPRBJh+YjItZXfLiXmRAm9om1adQ3I+B7WrgaG3O+3v/vouwMrOif1B/9kfuJzSlwMy1T3N4fDZc3gmHyv6lbtOoIc79+pK09iuyL1wos7yKhnIQlZGjn0LYAegxh6Qdv5G+9yeqjR1r8iWtp+NPM/qX0fjb1yTm0gv0bV4Ld3tVGU7xYHG0tuDVDrXYeyGOEzf+XsraN6gvlhpLvjr/VeEBLYdCvadh7ztw40iZ9VcbMwYzZ2di35mJNFIW2YqCchCVjYSr+o0/gd3Jtg7h5rz52D3aEdeBA0yq9lryNYb9NAw3azcamo0nL8+a1zqquwdFxeCV9jVxt7dk/o8X/wpMu9m48a/a/2LLtS0kZheIOdyORzj76eMRGbfuIrV4mDk5UW38eLJOniRl8+YyyapoKAdRmcjP08+dmluR33U+UWPHYebigvdc02VpBbiReoNXd7+KhcaChe2X8d2xVJ5u4o2fq2mKDikUJcXOypyRXQI5cj2RXy//nVVhQIMB5Oblsvb82sIDrJ3guTWQEQ/fvVbmeITTM72wCWlO3ML30FWhrA7KQVQmDi6FyD+g50Jil6wk98YNvBcuxNzV1WQqo9OjGbJ7CNp8LSu7rWTP6Twyc/N4o5O6e1BULJ5v6Y+fqw0Ldl4i31AvopZTLbrX6M7XF78mJeeOinDej8Djc+DqHvj9/TLpFhoNXjNnIbOyiH13dplkVSSUg6gs3LwAv8yG4KdIvmZJypYtuL/xBnatWppMZVxGHEN2DyFdm87Kbivxsq3J6oNhdKtfnbrVHUymV6EoDZbmGsZ1C+J8TCo/nI7+q/3VRq+Soc1g3cV1/xzUYgg0+Df8/C6EHyyTfqtaNXEfPpy0XbtI3b27TLIqCspBVAbytPDd62DlQE69N4mdORPbkBDc33jdZCpvZd3i1T2vkpidyMePfUw9t3qsO3KDlCwtw9Tdg6KC8nQTb4I9HVi0+zK5Ov20UZBrEJ38OrH2wloytBmFBwgB//oAXAJg4yB9PZUy4PbKIKzq1SN21qwqUcNaOYjKwK/zIeYkeV3mEjlpOho7O7wXLUKYm5tEXXJ2Mq/ueZXYjFiWd11OY4/GZObq+GT/NdrVcaOpv4tJ9CoUZUWjEUzqEcyNxEzWH73xV/vQRkNJyUlh/aX1/xxk7Qh9v4ScVNg4UJ/0spQICwu83p1FXmIScQsWlFpORUE5iIpO+EE4sAjZ5AVivjhIbkQEPosXYVHdNDWeU3NTeW3va4SnhPNB5w9oXr05AGsOhpOQnsvYbnVNolehMBadgjxoVdOVJXuvkJKlBaCRRyPaerdlzbk1ZOmy/jnIsyE8vRRuHILdU8uk36ZBA9xeeYWUTZvJOFi2aasHjXIQFZmsZNg8FJwDSIxvQtru3VQbOxa7lqaJO2RoMxi2dxiXky6zpPMS2ni3ASA1W8vHv16jc5AHzQNMFxBXKIyBEIK3n6pPUmYuSwuk4Hi9yeskZicWHYsAaNQHWg+HP1bCybv0KSbuw4dhWaMGMW9PIy/9nmVtKjTKQVRUpITtYyE1mszA8dz8YBkO3brh+sogk6jL0mUx4qcRnE04y8KOC+no2/Gvc5//dp2ULC1juwWZRLdCYWwa+jjRL8SP1QfDuBav/4JuWq0pHXw6sOrMKlJzU4se2G0m1OgA20ZD9MlS69dYW+M1Zw7amBji5s4ttZwHjXIQFZXT6+HsJrRN3yRy7idY+vnhNXeOSZLi5eTlMPqX0RyPO87s9rN5LOCxv84lZeSy6sB1ejTwpJGvqhKnqDyM6x6EjYUZs7f/nQJjVLNRpOamsvrs6qIHmZnr61nbusH6l8q0ic62WVPchr5KyqbNpO3dW2o5DxLlICoiiddh+3jyvVsT9dUF8tMz8PnwA5PkWdLmaxm/bzwHow/yTtt3eLJW4Uywn+wPJT1XxxgVe1BUMjwcrBjZtQ4/X7zJvks3AQh2DeaJmk+w9sJaErISih5o7wH9voT0ONj0CuTpSm/DsGFY169PzNvT0CXcRV8FRjmIioYuFzYNQaIh9mJdsk6dwnv+PKzrGv8LWpuvZeKvE9kXuY+prabSO7B3ofNRyVn87/fr9GriTZCn2vegqHy83LYmNd3tmLXtPNo8/bLXEY+MQJun5eNT9ygZ6tMcnlwEoftgz9ul1i8sLfFeMJ/8zExi/vt2pSsupBxERWPvdIg6RiJ9SNmxF/eRI3Ds3t3oarT5Wibtn8TeG3uZ1GIS/YP7/6PPwp0XAZjQI9jo+hWK8sDSXMN/n6zHtfgMPv/tOgD+jv78O/DfbLq8qXCm1ztp9hK0el1fhe7Y/0ptg1WdOlQbN470fftIXl/EMtsKjHIQFYnzW+DwCtIdenPzy5049OiB+7BhRldz2znsCd/DxBYTebH+i//oczIime9PRjOkQ018nG2MboNCUV50rVed7vWrs2TvZSISMwEY3nQ4NuY2LDy68N6Du8+GOo/BjvEQ+mupbXB58T/YtW9P3Jy5ZF+8WGo55Y1yEBWFW9dgywhyrBsTte4c1vXq4W2CoLQuX8fk/ZPZE76HCSETiiwVKqVk9vbzuNtb8kanOkbVr1A8CGY83QAzIZi25SxSSlytXXm9yev8FvUb+yP3332gmTn0+Rzc6sCGl/TZlEuB0GjwXjAfM2dnot4cXWmWvioHURHQZsHGgeiyNUTsNkdYW+O7fBkaG+P+ctfl65h8YDK7w3czPmQ8AxoUnSJ859lYjoYlMbZbEPZWptmtrVCUJ97ONoztHsQvl+L58WwsAM8HP08NxxosPLoQbZ727oOtneCF9aAxh6/7lrpcqbmrKz6LF5EbEUHstGmVIh6hHMSDRkrYMYH8iLNEHA9Cl5SC30crsPDyMqoaXb6OKQemsCtsF+NDxjOwwcAi+2Xm6nh3+wWCqjvQN8TXqDYoFA+SgW0CaOjjyIyt50jN1mJhZsHEFhMJSw3jqwtf3XuwSw3o/zWkRMCGAaDLKZUNtiEheLz5Jqk7fqwU8QiTOgghRA8hxCUhxFUhxOQizlsJIdYbzh8RQtQwtHcTQhwXQpwx/O1iSjsfKEc/Qx7/ksgLzci+Ho3PksVGrwyny9fx1oG32Bm2k7HNx97VOQAs/fkqUclZzHqmIeZm6veDoupgbqZhbu/GJKTnMHeHfm9EB98OdPLtxIpTK4hKj7q3AP/W0Gu5vppjGWpIuL06BLsOHYibM5esM2dKJaO8MNk3gBDCDFgOPAHUB54XQtS/o9tgIElKWQdYAsw3tCcA/5JSNgIGAl+ays4HSuivyB2TiLncgIzzMXjOmI5Dp05GVaHL1/HWb2/xY9iPjGk+hkEN774T+3JcGp/uD6VPc19a1lQpNRRVj0a+TrzasRbr/ojgF8PeiLdavYVAMOvwrPtP+zTuq99tfe472DVFPwNQQm7HI8w9PIgcPgLtzZuleSrlgil/IrYErkopQ6WUucA3QK87+vQC1hiOvwW6CiGElPJPKeXthO7nABshRNUqfpx4HTYOJP6qHyknk3AfNgyX554zqgptvpbJBybz4/UfGd1sNK80fOWufaWU/Pf7s9hZmTPlCbWsVVF1GdutLnWr2zPp29MkZ+biZe/FqGaj+D3qd3Zc33F/AW1HQethcOTjUhcaMndxwXfFcvLS04kcOZL8nNJNWZkaUzoIHyCiwP+RhrYi+0gpdUAK4HZHn2eBE1LKf1xBIcRQIcQxIcSx+MpU5i8nDdY9T8IpM24dy8Wpz7O4jxxhVBW5ebmM3Tf2r5jD4EaD79l/47FI/rieyOQngnGzr1q+WKEoiJW5GYv7PkJiRi7Tt54DoH9Qfxq5N2LB0QUkZyffW4AQ+uWvDfvA3hlw8utS2WEdFIT3/HlknzpdYYPWFXqSWQjRAP2002tFnZdSrpRShkgpQzw8PMrXuNKSp4WNL5P4ewTxJyxxfPJJvN55x6jLWbN0WYz8eST7IvQ7pO8VcwD9julZ287TqqYr/UL8jGaHQlFRaejjxMgugWw5Gc2OMzGYacyY3mY6qTmpxZtq0mjgmY+gVifYMgIu/FAqOxy7dcN91EhStmzl1meflUqGKTGlg4gCCn7b+BraiuwjhDAHnIBbhv99ge+AAVLKaya0s/yQEn4YTdKug8SdcMT+sa54z5uLMDMzmooMbQbDfxrOoehDzGw7s8gd0oVNkkzedJo8KVnYpwkajfGTASoUFZFhnWvTxNeJyZtOE5GYSZBrEMObDmd3+G5+CC3GF765JfRbCz7N9NXoLu0slR3ub7yBY8+exC9aTMqWLaWSYSpM6SCOAoFCiJpCCEugP7D1jj5b0QehAfoAP0sppRDCGdgOTJZS/m5CG8uXfXNJ3ryJ2GPO2HXogM/ixQgLC6OJT81N5bU9r3Ei7gTzOsz7R26lovjqyA0OXElgSs96+LvZGs0WhaKiY2Gm4cPnmyIljFz3J7m6fAY1GETz6s2Zc2QOkWmR9xdi5QD/+VZfcGjDS3C15FlbhRB4zZuLbevWRE/9L+m/VZyvPJM5CENMYQSwC7gAbJBSnhNCzBRCPG3otgpwE0JcBcYCt5fCjgDqANOEECcND9OUUCsvjv2PxM+WEvOHC3Zt2uK79EM0lpZGE5+QlcCQXUM4d+scix5dRM9aPe87JjQ+nTk7LtC+jjsvtvI3mi0KRWUhwM2Oec825mREMgt3XcRMY8ac9nMQCKYcmIIuvxiZXG2c4cXN4BEE3/xHn+CvhGgsLfFdthSrOnWIHDWKrLPnSv5kTIGUsko8mjdvLissp9bLhL7e8nxQsLzx+usyLzvbqOJvpNyQT2x6QrZY20IeiDxQrDFZuTrZ4/39ssk7u2RUUqZR7VEoKhtvf39GBkzaJnefi5VSSrnt2jbZcHVDuejoouILSU+QcnkbKWdVl/LKnlLZkRsXJ6907iIvtW4jsy5dKpWMkgIck3f5Xq3QQeqqgDy7mfiZ47h5yhHHHt3x/fBDNFbGWyV0/tZ5XvzxRdJy0/is+2e092lfrHHvbj/PhZhUFj3XBG+VjE/xkPNWz3o09HFk7PqTXL2ZxpO1nqRfUD/+d+5/7A7bXTwhdm4wYAu414Gv++uTb5YQi2rV8P98FcLCghsvDyLnypX7DzIhykGYEHl2K7GTxpJw1h6np5/Ce5FxYw6HYw4zaOcgrMysWPPEGhp7NC7WuO2nY1h7+AZDO9aia73qRrNHoaisWFuY8clLIVhZmDF4zTGSMnKZ1GISjT0a8/bvbxOafI+04AWx94CB2wyB65fhz7UltsWyRg38V69GmJkR/vIgcq49uDU6ykGYiLwTG4kYOYbkaza4DRmE1/wFRl2ttC10G2/sfQNve2++fOJLajnVKta4CzGpTPj2FE39nZnwuKoxrVDcxsfZhk9eak5McjbDvz4BmLH40cVYm1sz6pdR998fcRsbZ3jpO8MS2OFwcFmJd1xb1aqJ/5rVoBGED3yZ7MuXS/hsjINyECZAu/cjwodNISPWEs+3J1Nt/ESj7XPIl/ks+3MZUw5MoYlHE1b3WE11u+LdBcSn5TBkzTEcrS34+MXmWKhcSwpFIZoHuDDn3404eO0W07acpZptNd7v/D4x6TGM/Hkk2brs4gmytIPnv4H6z8Duqfp6EiUsXWpVqxYBq1cjNBrCX3yJzOPHS/GMyob6hjAyGauncn3cErSZlvgt/xCX/9x7k1pJyNJlMeHXCXxy+hN61+nNp90+xcnKqVhjc3R5vL72OLcycvh0QAjVHa2NZpdCUZXo09yX4Z1rs+6PCBbtvkzTak2Z13Eep+JPMfnAZPLy84onyNwK+vwP2r0JRz/TpwrPTimRLVa1axPw9deYu7py45XBpP38SymeUelRDsJIyDwdiVP6cWP+JswcbKmxcRP2XboZTX5cRhyv7HyFPeF7GNd8HO+0fQcLs+LFM/LyJWM3nOJ4eBKL+z5CI9/iORWF4mFlfPcg+rfwY9kvV1n123W6BXRjYouJ/HTjJ2YfmV38tBgajT6539NL4fqvsOpxfR62EmDp60PA119hVbcukSNHkrj2q3JLy6GqwRiBvPgYYl//N6nnkrFv6In3qu8xc3I2mvwjMUeYuH8iWbosPuj8AZ39Oxd7rJSS/35/hu2nY3irZzA9Gxm3zoRCURURQjC7dyOSM7XM2nYeW0szXmz5IglZCaw6uwqN0DC11dTiTx03GwDOAfrNdCsfhd6fQNATxbbH3NWVgNX/I2r8BOLefZecS5fwfPu/CCPupSoKdQdRRjJ/2U5oz8dIPZ+ER592+G742WjOIV/m89mZzxi6ZyjOVs588+Q3JXYO8368yLo/IhjeuTZDO9Y2il0KxcOAmUbwfv9HeLSuB1M2n+GLQ2G82exNBjUYxPpL65lzZE7JfsnXehSG/qovPrSuP+yZXqK4hMbODt/ly3B77TWSN24kfNAr6EycpFTdQZQSmZtL/LvjubVxNxb2khrvTcDmySFGk5+Yncj036ezL3IfPWr04J2272BrUfxUGFJK3t1+gVW/XefF1v6M765WLCkUJcXawoyVA5oz/Ks/mbblHLm6fMa0H4NEsvrcarJ0WUxvOx0LTTGXr7vWhFd2w87J+lThEUf0Sf9caxZruNBoqDZmNFZ1A4mZ+l9Cn+mN94L52LdrV4ZneQ995TWXZWpCQkLksWPHykVX5rGjxIwfQW5sKk71raj+wVrM/BoaTf7+yP1M+30aqbmpjAsZxwvBL5RoFVR+vmTq92dZ98cNXm5bg2lP1VdJ+BSKMpCry2f0+j/ZcSaWoR1rMenxIFae+YQVp1bQzrsdizotws7CrmRCT2+A7eMgPw8enw3NX9anEi8mOVeuEDlmDLnXQnEbMgSPMaMRmpJPCgkhjkspQ4o6p+4gSkBeWhrxc6aR9N1OzG11+A1uhf3oz8DCOCuCMrWZLDq2iA2XNxDoEsgn3T4hyLVkv/wzc3WM/uYku8/HMaxTbSY8HmTUVOIKxcOIpbmGD/s3xd3+PCv3hxKRmMmSfkPxtPPknUPv8PLOl3m/8/v42N9Z8uYeNO4L/m1gyzDYNhouboenFoNz8fKiWQUGUnPjRuLmzEEbG1vFWabfAAAN/ElEQVQi51Jc1B1EMZA6Hcnr1xO/5D3y0rNwqZ+Px9TZmDU3XgW4A5EHmH1kNtHp0QxsMJARTUdgZVaylByxKdkM+eIo56NTmfpkfQa3L95tq0KhKB5SSlb9dp3ZOy7Q0NuJFf9pRnjWCSb+qt/rNLfDXDr6diyZ0Px8OPqpvviQlPDoRGgzQp9OvLh26XQI89L93r/XHYRyEPdASkn6r78SP3cWOeHR2HrkUO3Zpti8+gnYuRtFR3xmPPOPzmdX2C5qOtVkWutphHgW+Vrdk9+uJDB6/UmycnUsfaEpXYJVCg2FwlTsOR/H2A0nEcB7zzWhnp+WMfvGcCnpEkMaDWFYk2HFXob+F8kR+tjExW3gXhcenwt1uprkzqAgykGUECkl6b/sI2Hp+2RfuIyFnY5qbS1xeGMeov6/jKIjS5fF2vNrWXV2Fdo8LUMbD2VQw0FYmpVs2ZouL58ley+zYt81anvYs/yFZgR5OhjFRoVCcXdu3Mpk+NcnOBOVwkutA3izWw2WnlrI5iubCXQJ5N1271LfrX7JBV/eDT9OgKQwqNEBuk4HvxZGt/82ykEUE5mbS+ruPdz69GNyLl3Fwi4P94ZZOL34GqLTOLAoe9ZTXb6OH679wLI/l3Ez6yZd/LowNmQsAY4BJZZ1JjKFKd+d5mxUKn1DfJnxdANsLVVYSaEoL3J0eSzYeYnPf7+Ot5MN855tRJ71OWYemklidiIDGgxgaKOh2Fval0ywLheOr4b9CyAjHoJ6Qvsx4NfS6M9BOYj7oL15k+T1G0j65mvybiVh6ZCHW4MMnHr3QXSaCE4lCDzdhdy8XLZc28LnZz4nMj2Sxh6NGdd8HM2qNyuxrNRsLR/uvcLnv1/Hzd6Kd55uoDbAKRQPkOPhiUz49jSh8Rk80dCTEV19+CZ0Od9f/R43azdGNRtFr9q9MNOUMGFnTjocXgGHlkN2Mvi3hXajILA7lFTWXVAO4h7khoVx7amnQJeHnVc2rkHZ2HXvjeg8Ub+hpYwkZify3ZXv+PrC19zMuklDt4YMaTyELn5dSry6KFubx9rD4Sz75SrJmVpeaOXPpB7BONkYL4W4QqEoHdnaPFbuD+WjfdfIy5e81CaATo2yWXluCSfjTxLgGMDghoN5qvZTxd83cZucdPjzS72jSIkAJ39o9hI0fREcvctkt3IQ90AmXCVx+KM4BFph2WUwtBgMDp5lsiVf5nM87jgbL29kb/hetPlaWnm2YnCjwbT2al1ix5CSqWXd0Rus/j2M2NRsOgS6M6lHMA19VE4lhaKiEZeazXu7LrHpRCTmZhr6NPOhcd1INl9fzYXEC3jbedM/uD+96vTC1dq1ZMLztHDhBzixRl/aVGigTjdo0g8aPlsqe5WDuB9X9uiDQWXYzyCl5FT8KXaF7WJ32G5uZt3EwdKBXrV78Vzd56jlXLx6DYXkRaaw6Xgkm05EkpmbR7s6bgzvVIe2dYyzgkqhUJiO8FsZfPxrKJuOR6LNz6ddHTea1Y3jVPp3nLh5HHONOY/5P8ZTtZ6ijXebEi9QITEUTnwJp9eDS00YtL1UdioHYSJuZd3icMxhDkYf5FD0IeKz4rHQWNDepz09avSgs39nbMyLH9jOz5ecjU7h54s32XoymtCEDCzNNTzV2Ish7WtR39vRhM9GoVCYgtiUbL45eoONxyKJSs7C0dqcVkE6LJyPcCr5J1JzU7GzsONR30fp7NeZFp4tcLNxK76C/HzIvKWvZlcKHpiDEEL0AD4AzIDPpJTz7jhvBXwBNAduAf2klGGGc1OAwUAeMEpKueteukztILJ12YSmhHIm/gynE05zOv40YalhADhZOdHGqw0dfTvSya8TDpbFW2aaly+5cjONE+HJHAtLZP+VeBLScxECWtZw5d/NfHiikReO1irGoFBUdvLyJQeuxPPDqRh+uhhHcqYWS/N86gTEYuN0jijtUTJ0qQDUca5DK69WNHJvRD23egQ4BJQ8wF1MHoiDEEKYAZeBbkAkcBR4Xkp5vkCfYUBjKeXrQoj+QG8pZT8hRH1gHdAS8Ab2AnWllHet1GEMB5GpzSQ2I1b/yIwlLDWM0ORQQlNCiUyLRKK/Vq7WrjT2aEwTjya08WpDsGvwfV+82JRsLselcfVmOldupnPtZjrnY1JJz9Fnc3S1s6R9HXc6B3vQMdADN/uS7aJWKBSVB11ePn9cT+Tnizc5cj2Rc9Ep5Ms8NNbReHjcwNL+OmniMnkyFwAbcxuCXIKo6VQTf0d//B388Xf0x9veGwcLhzKl03lQuZhaAlellKEGI74BegHnC/TpBcwwHH8LLBP6Z9oL+EZKmQNcF0JcNcg7ZGwjE7ISeHX3q8RlxJGmTSt0zkJjQYBjAPVc6/FkrSep7VybRu6N8LbzLvELMmb9SQ6F3gLA2daCwGr2PNPUm2b+LjTzdyHAzVblTFIoHhLMzTS0reP+VzwxNVvL8bAkzkSlcCEmlQsxqSTfSkNjFY/GOoo2jXPJEREciDpAwtWEQrJszG1o6dmSZV2XGd9Oo0v8Gx8gosD/kUCru/WRUuqEECmAm6H98B1jy74ZoQgcLR3xdfAlpHoInnaehR7VbatjrjHOJRr9WCCjZCCB1e1xs7NUzkChUPyFo7UFnYOr0Tm42l9tGTk6wm5lEJaQSfMAFzyd9ItoMrQZRKRFcCP1BjEZMcRlxuFi5WISuyr1tlshxFBgKIC/f/EyIN6JpZklS7ssNaZZRdKqVgmCTgqF4qHHzsqcBt5ONPAuvJzdzsKOYNdggl2DTW6DKSvKRQF+Bf73NbQV2UcIYQ44oQ9WF2csUsqVUsoQKWWIh0fpIvgKhUKhKBpTOoijQKAQoqYQwhLoD2y9o89WYKDhuA/ws9RHzbcC/YUQVkKImkAg8IcJbVUoFArFHZhsiskQUxgB7EK/zPVzKeU5IcRM4JiUciuwCvjSEIRORO9EMPTbgD6grQOG32sFk0KhUCiMj9oop1AoFA8x91rmasopJoVCoVBUYpSDUCgUCkWRKAehUCgUiiJRDkKhUCgURVJlgtRCiHgg/C6n3YGEu5yrSFQWO6Hy2KrsND6VxVZlZ/EIkFIWuZGsyjiIeyGEOHa3KH1ForLYCZXHVmWn8akstio7y46aYlIoFApFkSgHoVAoFIoieVgcxMoHbUAxqSx2QuWxVdlpfCqLrcrOMvJQxCAUCoVCUXIeljsIhUKhUJSQKukghBAzhBBRQoiThkfPu/TrIYS4JIS4KoSY/ADsXCiEuCiEOC2E+E4I4XyXfmFCiDOG51KuCafud40MGXfXG84fEULUKE/7DDb4CSF+EUKcF0KcE0K8WUSfTkKIlALviWnlbafBjnu+lkLPh4breVoI0ewB2BhU4DqdFEKkCiFG39HngV1PIcTnQoibQoizBdpchRB7hBBXDH+LrKAjhBho6HNFCDGwqD4mtrPCf+YLIaWscg/0ZUzH36ePGXANqAVYAqeA+uVsZ3fA3HA8H5h/l35hgPsDuI73vUbAMOBjw3F/YP0DsNMLaGY4dkBfC/1OOzsB28rbtpK+lkBP4EdAAK2BIw/YXjMgFv1a+QpxPYGOQDPgbIG2BcBkw/Hkoj5LgCsQavjrYjh2KWc7K/Rn/s5HlbyDKCZ/1cyWUuYCt2tmlxtSyt1SSp3h38PoCyNVJIpzjXoBawzH3wJdRTnXU5VSxkgpTxiO04ALmKhEbTnQC/hC6jkMOAshvB6gPV2Ba1LKu21CLXeklPvRlwcoSMH34RrgmSKGPg7skVImSimTgD1Aj/K0sxJ85gtRlR3ECMNt3Od3ud0sqmb2g/xSeQX9L8eikMBuIcRxQ5nV8qI416hQXXHgdl3xB4JhiqspcKSI022EEKeEED8KIRqUq2F/c7/XsqK9L/sD6+5yriJcz9tUl1LGGI5jgepF9Klo17YifuYLUWlrUgsh9gKeRZyaCnwEzEJ/kWcBi9C/GOXOveyUUm4x9JmKvjDSV3cR015KGSWEqAbsEUJcNPw6URRACGEPbAJGSylT7zh9Av00SbohJvU9+kqF5U2leS2FvhLk08CUIk5XlOv5D6SUUghRoZdnVpbPfKV1EFLKx4rTTwjxKbCtiFPFqntdVu5npxDiZeApoKs0TD4WISPK8PemEOI79FM/5fFmKUld8UhRuK54uSKEsEDvHL6SUm6+83xBhyGl3CGEWCGEcJdSlmsOnGK8luXyviwmTwAnpJRxd56oKNezAHFCCC8pZYxhSu5mEX2i0MdObuML7CsH2wpRwT/zhaiSU0x3zNn2Bs4W0a04NbNNihCiBzAReFpKmXmXPnZCCIfbx+iDXEU9H1NQlrri5YYh5rEKuCClXHyXPp63YyNCiJbo3/vl6siK+VpuBQYYVjO1BlIKTJ2UN89zl+mlinA976Dg+3AgsKWIPruA7kIIF8O0c3dDW7lRCT7zhXnQUXJTPIAvgTPAafRvHC9Duzewo0C/nuhXvFxDP+VT3nZeRT8netLw+PhOO9GvIDpleJwrbzuLukbATPRvcABrYKPhufwB1HoA17E9+unE0wWuZU/gdeB1Q58Rhut3Cn1wsO0DsLPI1/IOOwWw3HC9zwAh5W2nwQ479F/4TgXaKsT1RO+0YgAt+jjCYPRxr5+AK8BewNXQNwT4rMDYVwzv1avAoAdgZ4X/zBd8qJ3UCoVCoSiSKjnFpFAoFIqyoxyEQqFQKIpEOQiFQqFQFIlyEAqFQqEoEuUgFAqFQlEkykEoFAqFokiUg1AoFApFkSgHoVAoFIoi+T/YjZe3ZNkdJAAAAABJRU5ErkJggg==\n",
+            "image/png": "iVBORw0KGgoAAAANSUhEUgAAAYgAAAD6CAYAAAC73tBYAAAABHNCSVQICAgIfAhkiAAAAAlwSFlzAAALEgAACxIB0t1+/AAAADh0RVh0U29mdHdhcmUAbWF0cGxvdGxpYiB2ZXJzaW9uMy4yLjIsIGh0dHA6Ly9tYXRwbG90bGliLm9yZy+WH4yJAAAgAElEQVR4nOzdd1zV1f/A8de5l41sBESmK7eIODIHzkwzc+SqTLOt9s3STMs0S22YLW1YmmapOXOlZu6taI6cKSAgshHZ657fHxf7mSJc4F5knOfjwSP4jHPONbjv+znjfYSUEkVRFEW5k+Z+N0BRFEWpmFSAUBRFUQqlAoSiKIpSKBUgFEVRlEKpAKEoiqIUSgUIRVEUpVAmDRBCiF5CiItCiMtCiLcKOd9JCHFCCJEnhBhUyHl7IUSUEGKeKdupKIqi3M3MVAULIbTAfKAHEAUcE0JskFKeu+2yCGAkMOEexbwP7DWkPldXV+nn51fq9iqKolRHx48fT5BS1izsnMkCBNAGuCylDAUQQqwA+gH/BggpZXjBOd2dNwshWgHuwFYgqLjK/Pz8CAkJMUrDFUVRqgshxNV7nTNlF1NtIPK2n6MKjhVLCKEBPuXeTxaKoiiKiVXUQepXgN+llFFFXSSEeEEIESKECImPjy+npimKolQPpuxiugZ43/azV8ExQzwIdBRCvALUACyEEGlSyv8MdEspFwALAIKCglRSKUVRFCMyZYA4BtQXQvijDwxDgeGG3CilfPLW90KIkUDQncFBURSlIsjNzSUqKoqsrKz73ZQiWVlZ4eXlhbm5ucH3mCxASCnzhBBjgW2AFlgkpTwrhJgBhEgpNwghWgPrACegrxDiPSllE1O1SVEUxdiioqKws7PDz88PIcT9bk6hpJQkJiYSFRWFv7+/wfeZ8gkCKeXvwO93HHv3tu+Poe96KqqMxcBiEzRPURSlzLKysip0cAAQQuDi4kJJx2or6iC1oihKpVGRg8MtpWmjSZ8gFEW5P3Lzc/k78W8uJV0iOTsZGzMbvOy8CPIIwt7C/n43T6kkVIBQlCok8mYkS88vZeOVjaTlpt11XiM0BHsFM7rZaJrXbH4fWqiYym+//Ub//v05f/48DRs2NEqZKkAoShWQkZvBd6e/Y+m5pQD09OtJd5/uNHVtiouVCxl5GVy5cYU9UXtYfWk1OyN3MqjBIN5o9QY1LGrc59YrxrB8+XI6dOjA8uXLee+994xSpgoQilLJXUy6yIQ9Ewi/Gc5jdR/jf4H/w83G7T/XOGgdCHQPJNA9kBebv8jXJ79m6fml/BX7F191+wpvO+97lK5UBmlpaezfv59du3bRt29fFSAURYFt4dt4e//b2FvYs7DnQtrUalPsPTbmNkxoPYGOXh15fffrPPX7UyzsuZB6TvXKocVV23sbz3Iu+qZRy2zsac+0vkXP/l+/fj29evWiQYMGuLi4cPz4cVq1alXmutUsJkWppJadX8bEPRNp7NKYVX1XGRQcbte2Vlt+7v0zWqHl+e3Pc/XmPXO2KRXc8uXLGTp0KABDhw5l+fLlRilXSFk1MlQEBQVJlc1VqS4WnlnI5yc+p4t3Fz7u9DFWZlalLiv0Rigjt47E3tKeX3r/goOlgxFbWvWdP3+eRo0a3bf6k5KS8PLyombNmgghyM/PRwjB1atX75raWlhbhRDHpZSFZsxWXUyKYmK5+TrCEtK5EJNKWHw6calZxN7MJj07j9x8Hbk6ia2FFgdrc5xtLfB3taWeWw1aeDniZGtxV3krLqzg8xOf84j/I8zqMAszTdn+jOs41uHzLp8z+o/RTNo7ifnd5qPVaMtUplJ+Vq9ezdNPP813333377HOnTuzb98+OnXqVKayVYBQFCPT6SQno26w/58EDl1J5HhEMjl5/7/libOtBW52lthbmWNhpsFaI0jPziMuNZv41GxSMnMBEAIaetjTqb4rjwV40riWPZtCNzHzyEyCvYOZ2WFmmYPDLYHugUxuM5n3D7/P0nNLGdl0pFHKVUxv+fLlTJo06T/HBg4cyPLly8scIFQXk6IYyYWYm6w5HsXm09eJTslCCGhcy552dVxoWtueB9ztqVPTFivze386l1KSlJ7DP3FphIQncfBKIsfCk8jNl/h7xZBk9xWtPFrxTfevsdRaGrX9UkrG7x7P3qi9rHh0BQ2cGhi1/KrqfncxlURJu5hUgFCUMpBS8uf5OBbtD+NQaCLmWkHH+jXp26IWXR5ww9Hm7i6ikkpOz+Hn43/xw5X/kZtrg2PyG7zZM4B+AZ5GT/GQlJXEgPUDcLV2ZcWjK4z2hFKVVeUAoWYxKUop7f8ngX7zD/D8TyFcTUxnUq+GHJ3SnUUjW9O/pZdRggOAuXkOO5M/pIaVlmlt5uBi48Brv55k8HeH+Cc21Sh13OJs5czUdlO5mHyRFRdWGLVspfJRHw8UpYSup2Qy9bez/Hk+Fk8HKz4e1JwBLWtjpjX+5y0pJe8ceIewlDC+7fEt7WoF8kRzyarjkXy09SJ95+1n6qONGd7Gx2hPE119utKhdgfmnZzHw34PU9Om0P3slWpAPUEoioGklCw7EkGPuXvZfzmetx5pyM4JwQwO8jZJcABYdmEZOyJ2ML7VeNrVageARiMY0tqHra91pLWfM2+v+5tXV5wkKzffKHUKIZjcZjI5+Tl8dvwzo5SpVE4qQCiKAdKy8xi7/C+mrDtDcy8Htr3WiZc61y1ywLms/k74mzkhcwj2CmZE4xF3nXezs2LJqDa82esBNp6KZvj3h0lMyzZK3T72PoxoPIJNoZu4mHTRKGUqlY8KEIpSjPCEdB6bt58tZ64zqVdDfh7dFl8XW5PWeTPnJhP2TKCmdU0+6PDBPbuPNBrBK8H1+PrJQM5G32TQt4eISTHO1pejmo6ihkUNvvrrK6OUp1Q+KkAoShFORt5g4DcHSU7PYdnz7Xg5uC4ajWk3h5FSMv3gdGLTY/m408cGrWzu3awWvzzXlribWQz7/jCxN8seJBwsHXi26bPsidrDX3F/lbk8xXS0Wi0BAQG0aNGCwMBADh48aJRyVYBQlHs4cDmBYQsOY2OpZc3L7WlXx6Vc6l1/ZT3br27n1cBXCXALMPi+ID9nfhrdRh8kFhwmKT2nzG0Z3nA4rtaufHHiizKXpZiOtbU1J0+e5NSpU8yePZvJkycbpVwVIBSlEIdDExm95Bg+zjasebk9dWqWz54J0WnRfHT0I1q5t+KZJs+U+P5Wvs4sfrYNUTcyeeGnkDIPXNuY2/Bcs+c4HnucE7EnylSWUj5u3ryJk5OTUcpS01wV5Q4nIpJ5dvExvJxs+OX5trjWMO6K5XvRSR1TD0xFJ3V88NAHaETpPr+19nPms8EBjFl2gjdWneKroS3L1C02oP4Avjv1HQv/Xkige2Cpy6kWtrwFMWeMW6ZHM3jkwyIvyczMJCAggKysLK5fv87OnTuNUrVJnyCEEL2EEBeFEJeFEG8Vcr6TEOKEECJPCDHotuMBQohDQoizQojTQoghpmynotwSkZjBc0tCqGlnybLnyi84ACy/sJyjMUd5s/WbeNl5lamsPs1rMfmRhmw+fZ1v914pU1nWZtYMbzScvVF71YymCupWF9OFCxfYunUrI0aMwBhZMkz2BCGE0ALzgR5AFHBMCLFBSnnutssigJHAhDtuzwBGSCn/EUJ4AseFENuklDdM1V5FScnIZdTio+ik5MeRrXGzL30K7ZIKTQnls+Of0cmrEwPqDzBKmS90qsPf0TeZs+0iLb2deLBu6cdQhjUcxo9//8iPZ3/kw45Ff5qt1or5pF8eHnzwQRISEoiPj8fNza34G4pgyieINsBlKWWolDIHWAH0u/0CKWW4lPI0oLvj+CUp5T8F30cDcYBazqmYjE4nGbfiLyKSMvjuqVblNuYAkKfL453972BlZsX0B6cbbUW0EIIPBzTD39WWccv/Iq4MM5scLB0Y1GAQW8O2EpMeY5T2KaZx4cIF8vPzcXEp+6QKUwaI2kDkbT9HFRwrESFEG8ACuOs5WQjxghAiRAgREh8fX+qGKsrXuy+z91I80x9rQttymq10y8IzCzmTcIZ32r5j9LQWtpZmfPtUK9Kyc3lr7ZkydTsMbzQcieTXi78asYWKMdwagwgICGDIkCEsWbIErbbsizgr9CC1EKIWsBR4Rkqpu/O8lHIBsAD02VzLuXlKFXHwSgJzt1+iX4Anw9v4lGvd5xPP8+2pb3nE7xF6+fcySR313e14q1dDpm88x6/HIhlaytdYu0ZtOnt1Zs2lNbzU4iWjpxtXSi8/3zhpVu5kyieIa4D3bT97FRwziBDCHtgMvC2lPGzktikKoB93GP/rSfxcbZnVv5nR02cXJTs/myn7p+Bk5cTb7d42aV0jHvSjfV0X3t90jsikjFKXM7zRcJKzk9kattWIrVMqKlMGiGNAfSGEvxDCAhgKbDDkxoLr1wE/SSlXm7CNSjX33qazJKTl8MWQlthalu8D9fy/5nP5xmWmt59u8n2gNRrBJ0+0QCMEE1efKnVXU1uPttRxqMOyC8uMMktGqdhMFiCklHnAWGAbcB5YKaU8K4SYIYR4DEAI0VoIEQU8AXwnhDhbcPtgoBMwUghxsuDL8CWlimKA7ediWXviGmOC69LMy7Rv0Hc6EXuCxWcXM6jBIDp5lW1bSEPVdrTmrd4NORyaxLq/DH6Y/w8hBMMaDuNc4jlOxZ8ycguVisak6yCklL9LKRtIKetKKWcWHHtXSrmh4PtjUkovKaWtlNJFStmk4PjPUkpzKWXAbV8nTdlWpXq5kZHDlHVnaOhhx9iu9cu17ozcDN7e/zaeNTyZEHTnDG/TGtbah5Y+jszcfJ6UjNxSlfFY3cewNbdl1aVVRm6dUtGoVBtKtfTJtoskpecw54kWWJiV75/BnJA5XEu7xswOM7E1N21W2DtpNIIPHm9KckYOH2+7UKoybMxt6OXXi+1Xt5OWk2bkFioViQoQSrVzJiqFZUcjGPGgL01rl2/X0r6ofay6tIoRjUfQyr1VudZ9SxNPB0Y95M+yoxGcjird2tMB9QeQmZfJ1nA1WF2VqQChVCs6nWTq+r9xsbVkfI8G5Vp3SnYK0w5Oo65DXcYFjivXuu/0Wvf6ONtY8MHm86UabG7m2oy6DnVZ9886E7ROKamYmBiGDh1K3bp1adWqFb179+bSpUtlLlcFCKVaWX08ipORN5j8SEPsrczLte6ZR2aSnJXMrI6z7vsaAjsrc17r0YCjYUn8cS62xPcLIehfvz+nE05zOfmyCVqoGEpKSf/+/QkODubKlSscP36c2bNnExtb8v+vd1IBQqk2MnLy+OSPi7TydWJAYIkX9ZfJlrAtbAnbwgstXqCxS+NyrftehrX2pp5bDT7ccoGcvLvWoRarb92+mGnMWHt5rQlapxhq165dmJub89JLL/17rEWLFnTs2LHMZVfoldSKYkyL9ocRn5rNt08FluuCuNj0WN4//D7NXJvxfLPny63e4phpNUzp3ZBnF4fwy5GrjHrIv0T3O1s508W7C5uubGJ84HjMteX7RFYRfXT0Iy4klW7w/14aOjdkUptJ9zz/999/06qVacaz1BOEUi0kpefw3Z5QejR2p5Wvc7nVe2uPhzxdHrM6zMJMU7E+k3V5wI2H6rnw5Y5/SMvOK/H9/ev1Jzk7mb3X9pqgdcr9VrF+WxXFRObvukx6Th5vPvxAuda74sIKDl0/xDtt38HPwa9c6zaEEIKJDzfk8fkHWHIwnDFd6pXo/gc9H8TZypnNoZvp5tPNRK2sPIr6pG8qTZo0YfVq0yScUE8QSpUXlZzB0kNXGdTKi/ruduVWb2hKKHOPz+Wh2g8x+IHB5VZvSQV4O9KtoRsL9oZyM6tki+fMNGb08uvFnsg9pOakmqiFSlG6du1KdnY2CxYs+PfY6dOn2bdvX5nLVgFCqfLm79Jnin+te/lNa83V5TJl3xSszKx4v/375TrmURrjezQgJTOXRfvDSnxvnzp9yNHl8OfVP03QMqU4QgjWrVvHn3/+Sd26dWnSpAmTJ0/Gw8OjzGWrLialSou+kcnq45EMae2Np6N1udW74PQCziaeZW7wXKPv8WAKTWs78HATdxbuC2NUe38cbAwfcG7m2gwfOx82h26mf/3+Jmylci+enp6sXLnS6OWqJwilSvtuzxWkhJc61y23Ok/Hn+b709/Tt05fevj2KLd6y+q17g1Izc7jh/2hJbpPCEGfOn04GnOU2PSyz71XKg4VIJQqKy41i+XHIhkY6IWXk0251JmRm8GU/VNws3FjctvJ5VKnsTSqZU+fZrX48UA4KZklG4voU6cPEqlSb1QxKkAoVdb3e0PJy9fxcnD5PT3MPT6XiJsRzOwwEzuL8hsQN5ZXutQlLTuPnw9fLdF9vva+NHVpyubQzSZqmXI/qAChVEnJ6Tn8fDiCfgG18XMtn4yp+6L28evFXxnReAStPVqXS53G1sTTgc4NavLjgTCycku2jWWfOn04n3SeKzfu2j5eqaRUgFCqpF+OXCUzN7/cnh6Ss5J59+C71HOsd98T8ZXVy8F1SUjLYVVIZInu6+XfC4FgW/g2E7VMKW8qQChVTnZePksOXaVzg5o0KId1D1JK3j/8PjeybzC74+z7noivrNr6O9PSx5HvCrroDOVq7Uor91b8Ef6HCVunlCcVIJQqZ8PJaOJTs3muY8lyC5XWptBNbL+6nbEBY2no3LBc6jQlIQSvBNcjKjmTTaevl+jenn49uZJyRWV4LWdarZaAgACaNGlCixYt+PTTT9HpSp6A8U4qQChVipSShfvDaOhhR4d6riav73radWYdmUWgWyAjm4w0eX3lpVtDN+q71eCb3VfQ6QzfL6KHbw8Egj+uqqeI8mRtbc3Jkyc5e/Ys27dvZ8uWLbz33ntlLlcFCKVKOXA5kQsxqYzu4G/y1cs6qePtA2+jkzpmdpiJVqM1aX3lSaMRvNi5LhdjU9l3OcHg+1Q30/3n5ubGggULmDdvXqk2g7qdSVdSCyF6AV8AWuAHKeWHd5zvBHwONAeGSilX33buGeCdgh8/kFIuMWVblarh+32h1LSz5LEAT5PXtfTcUo7FHGNG+xl42XmZvL7y9lgLTz7aeoFF+8Po3MDw1eA9/Xoy68gsLidfpp5TyZL/VXYxs2aRfd646b4tGzXEY8qUEt1Tp04d8vPziYuLw93dvdR1m+wJQgihBeYDjwCNgWFCiDt3SokARgLL7rjXGZgGtAXaANOEEE6maqtSNVyJT2PPpXhGtPPF0sy0n+b/Sf6HL058QRfvLjxe73GT1nW/WJhpGNHOlz2X4rkcZ3giPtXNVHWY8gmiDXBZShkKIIRYAfQDzt26QEoZXnDuztGUh4HtUsqkgvPbgV7AchO2V6nkfj58FXOtYFhbH5PWk5Ofw+R9k7GzsGPag9MqfCK+shje1oevdl1m0YFwZvVvZtA9t3czvRLwiolbWLGU9JO+qYSGhqLVanFzcytTOaYcg6gN3D6ROqrgmKnvVaqhjJw8Vh+P4pGmtXCtYdpppl+f/JqLyRd5r/17uFi7mLSu+82lhiX9A2qz9kQUyek5Bt+nZjPdP/Hx8bz00kuMHTu2zB9eKvUgtRDiBSFEiBAiJD4+/n43R7mPNp6KJjUrj6cf9DVpPSdiT7Do70UMrD+QYO9gk9ZVUYzq4EdWro5lRyMMvkd1M5WvzMzMf6e5du/enZ49ezJt2rQyl2vKLqZrgPdtP3sVHDP03uA77t1950VSygXAAoCgoKCyDdcrlZaUkp8OXaWhhx1BvqYbqkrPTWfK/il41vBkYuuJpSskJQoij0BUCCT8AymRkBYLeTkg88HSHmycwbku1HwAfNqBb3uwvH95nRp62NOhnis/HQrnhU51MNcW/7myOncz3Q/5+SVLi2IoUwaIY0B9IYQ/+jf8ocBwA+/dBsy6bWC6J1C5UmMq5eZk5A3ORt/kg8ebmnQ8YE7IHKLTolncazG25iXI7xR/Cf5eA+c3QtxZ/TEza3CtDy71wK8jmFmCEJB1E9ITIPEy/LMN9s8FjRn4PAjNB0Pjx8HK3jQvsAjPdvDj2cUh/H7mOv0CDOvt7e7bnQ+PfkhYShj+DuWzaFExLpMFCCllnhBiLPo3ey2wSEp5VggxAwiRUm4QQrQG1gFOQF8hxHtSyiZSyiQhxPvogwzAjFsD1opyp58PR2BroeXxlqYbptobtZfVl1YzqukoAt0Di78hPw8uboaj30P4PkDo3+R7zgS/h8C9KWiL2ZQnN1P/tBG6G85tgA3j4Pc3oeWT0H4cOPkZ4ZUZJriBG/6utiw+GG5wgOjm040Pj37IjogdPNfsORO3UDEFk66DkFL+Dvx+x7F3b/v+GPruo8LuXQQsMmX7lMovOT2HjaejGRLkTQ1L0/w6J2cl8+6Bd6nvVJ+xAWOLvliXD2dWwZ6PICkUHLyh27sQ8BTYlXA+urk11AnWf3Wbpu+WOrEYji+BkB+h+RDo+g44mH7+hkYjeKqdL+9vOsff11JoWtuh2Hs8bD1o4tKEnRE7q3yAkFJW+NlspVk0V6kHqRVlzYkocvJ0PNnONFNbbyXiS8lJYXaH2VhoLe598aVtML8trHsRzG1h8FL43yno+EbJg8OdhADv1tBvPrx2Gtq9rO+2+qoV7Jqtf9owsUGBXliZa0q0V0Q3n26cSThTpXeas7KyIjExscyrlk1JSkliYiJWVlYluk/tSa1UWlJKVoZEEuDtSEMP0/TLbw7bzPar23kt8DUecH6g8IuSQmHrZLi0FVzq6wNDw0dBY6LPX/ae8PBMaPMC7HgP9nyoDxb95oNPW9PUCTjYmNOvRW1+O3mNyb0b4WBd/L7V3Xy68eVfX7IzcifDGg4zWdvuJy8vL6KioqjoMymtrKzw8irZin8VIJRK61RUCpdi05g9wLAFXCUVkx7DrMOzaOnWsvBEfPm5sG8u7JsDWgvo+QG0eRHMinjKMCYnXxi0CFo+DRtehUUPQ7tXoPs0/aC3CTz9oC+/hkSy5ngUz3YofuC5jmMd/Oz92BGxo8oGCHNzc/z9q+YgvOpiUiqtX49FYm2u5dHmtYxetk7qmHpgKnkyj5kPFZKIL/Yc/NANds+CRn1h3HH9wHF5BYfb1e0CrxyEoGfh8Hx9oEgON0lVTWs70NLHkZ8PXzW4S6WbTzdCYkJIyU4xSZsU01EBQqmUMnPy2Xgqmt7NamFnVXxXR0mtuLCCw9cPM7H1RLztb1vOk58H+z6FBZ0h5RoM+Vn/Kd7Ow+htKBFLO3h0Lgz5BRJD4btOcME0+0M/3c6X0IR0DlxONOj67r7dyZf57I7cbZL2KKajAoRSKf1+5jpp2XkMDjJ+FtXI1Eg+P/E5D9V+iEH1B/3/iZvRsORR2DEDHugNY47onx4qkkaPwot7wMkfVgyHvZ+AkQdPezerhbOtBUsPhxt0fROXJrjbuLMjYodR26GYngoQSqX0a0gkfi42tPF3Nmq5UkqmH5yOVmiZ/uD0/5+6ePlP+LYDxJyBAd/D4CVga/oNiUrF2R+e3QbNBsPOD+C3lyEv22jFW5lrGRzkzfZzsVxPKX72lBCCrj5dORh9kIzcDKO1QzE9FSCUSicsIZ2jYUk8EeRt9Lnnqy6t4mjMUd4IegMPWw99l9KO9+HngVDDA17YrV/RXNGZW8GABdDlbTi1HH56HDKMt9b0ybY+SGD5EcPyM3Xz6UZ2fjYHow8arQ2K6akAoVQ6q0Ii0QgY1Mq43UvX064z9/hc2tZqy8D6AyE1Bn7qp5+l1PJpeO5PfXqMykII6PwmDFwI147Dj73hZsn2mL4Xb2cbujzgxrKjkeTmF7/3cSv3VjhYOqhupkpGBQilUsnL17H6eBRdHnDD3b5ki36KIqXkvUPvoZM6fddS6G59l1L0Cej/HfSbBxY2RquvXDUbBE+t1icGXPQwJIUZpdgn2/qQkJbNjvPFL4Iz05jR2asze6L2kJufa5T6FdNTAUKpVPb+E09cajZPBHkXf3EJrL+yngPRB3it5f/wClkKS/uDjQs8vwtaDDVqXfeFfycYsQGyb8KiXvppumXUuUFNajlYsexoZPEXo+9mSs1J5VjMseIvVioEFSCUSmXNiWs421rQtWHZdsq6XVxGHB8f+5hAl2YMPbZcvzK5xTB4fie4NTRaPfedVysYtUX//eLecP10mYoz02oYHOTNvn/iiUwqfvC5vWd7rM2sVTdTJaIChFJp3MzKZfu5WPo2r4WFmXF+daWUfHD4A3Lyspjxz3E0kSH6lBX9vwGLEqT0rizcGsGzW/W5on7qBzF/l6m4wa29EegXLRbHysyKhzwfYmfkTnSy+HEL5f5TAUKpNLacuU5Ono7+gcYbnN559U92Re5iTEI8vub2+qeGlk8ZrfwKydkfntkAZlbw02Nl6m6q7WhN8ANurAwxbLC6q09XEjITOB1ftqcXpXyoAKFUGmtPXKOOqy0tvIpPNW2ItOQwZu2ZyAPZOTzl87B+vMG9sVHKrvBc6sLITaAx1weJuAulLmpYGx/iUrPZeSGu2Gs7eXXCTJixM3JnqetTyo9K1qdUClHJGRwJS+KNHg2Ms/YhdA/ztr1EvLWWzxo/i/lDb+qnhVYnt4LEj71hSV/9+IRrvRIVkRsTQ1D4X4z9ZxvZk34hzCaf/Bs3ABBaLWZubpjXqoVV40ZYt2yJfePGtPZozc6InYwPHF/h91Co7lSAUCqF9SejAcq+a5wuH/Z8zNlDc1nu6cFg35407zDJCC2spFzr/3+QWPq4fgV2MRsQZYeGkbJxA2k7d5F98SIAj2jNiLBxIbexP7Y+PiAEMjeXvLg40g8cIOW33wDQurrydJs6fOIezpUbV6jnVLKApJQvUZE3uSiJoKAgGRIScr+boZiAlJLuc/fgbGvBqpfal76glGuw7kXywvcxvG4j4i2s2NB/I3YWdsZrbGUVfRIWP6rfa2LUFrB1+c9pmZfHzW3buPHrSjKOHgWNBpvAQGp06YJNmzYkunvT8bP9jOtSj9d73r1vRm5MDBnHj5P6x3ZSd++C7BxuNPWm+YQZ2LZrV16vUimEEOK4lDKosHNqDEKp8P4enEAAACAASURBVM5cS+FKfDr9W5ZhcPrMavjmQbh2guXtR3Fel85bbSer4HCLZwAMX6FPE/7LIMhOBUDm5nJj7Tqu9OlD9BsTyL1+nZqvv079Pbvx/XkpLqOfxbpZU7zcHAhuUJNfQyLJK2Sw2tzDA4c+ffD64nMa7N/Pn4/WRhNxnYiRo4gcM5acCMNSdijlSwUIpcJbe+IaFloNfZqVYt+HzGRY/SysGQ2uDxDzzFq+ij9Ix9od6enb0/iNrcz8OsATi+H6KeTy4dzcspkrvftwfcoUtLY18Jr3FXW3bcX1hecxq1nzrtuHtfEh9mY2uy4WvbOa1s4Om2eG8fKLEquxz5F+6BChfR8jaenPSJ2a/lqRmDRACCF6CSEuCiEuCyHeKuS8pRDi14LzR4QQfgXHzYUQS4QQZ4QQ54UQk03ZTqXiys3XsfFUNN0aueFgU8J9H67sgq/bw7n10PUdGLWFWZeWIaXk7XZvqwHSwjTsTVbAVCIWneXa+AlorK3w+uZr/Nasxq57d0QR26h2beiGm50ly48W/zTQ1acruWaCg908qLtlC7bt2hE7cyaRz79AXnKyMV+RUgYmCxBCCC0wH3gEaAwME0LcOYdwNJAspawHfAZ8VHD8CcBSStkMaAW8eCt4KNXLvn/iSUzPoX9JBqczk2H9GP2gq4UtjN4OnSay9/pBdkXu4uWAl6ldo4yD3VWQLiuL2A8/ImzyD2RnOOARdAP/5+piFxxsUDA102oY0tqb3RfjuHaj6DTg/g7+1HGow86InZi7u+H17Td4TJ9OxrFjhA96gqyLl4z1spQyMOUTRBvgspQyVEqZA6wA+t1xTT9gScH3q4FuQv+bKAFbIYQZYA3kADdN2Falglp74hpONuYEP2BAag0p4ew6mNcGTi6HDuPhpX1QO5Cc/Bw+OvoRfvZ+PN3oadM3vJLJPHOGsAEDSVq8GMchg6m7YzdOI0YjTiyCA18YXM7gIG8ksNKAldXdfLpxPPY4N7JuIITAaegQfH/5GZmbS/iwYaTu2lWGV6QYgykDRG3g9t+SqIJjhV4jpcwDUgAX9MEiHbgORABzpJTGS2avVAq3Ums82tyz+NQaNyL0O6itGqmfifPCbug+HcytAfjp3E9EpEYwuc1kzLXG36K0spI5OcR/+SXhQ4ehy8jAZ9FCak2bhtbBAbrPgCYD4M9p+kF+A3g729Cpfk1WhkSSryt6hmRXn67ky3z2RO3595h1s2b4rVqFpb8/UeNeJWWzabZNVQxTUQep2wD5gCfgD7whhKhz50VCiBeEECFCiJD4+KIHxpTKZ+uZGLLzdPQPLKI7KCsFtk+Dr4L0Yw49P4DndkCt5v9eEpsey4LTC+jq3ZX2tcswTbaKybp0ibChQ0n4+hsc+valzob12La/7d9Ho4H+34JvB1j3EoTtNajcYW18uJ6Sxe6LRa+svtdWpObubvgsWYxNQADREyaSvGpViV+bYhwGBQghxFohRB8hREkCyjXg9pzMXgXHCr2moDvJAUgEhgNbpZS5Uso44ABw1zxdKeUCKWWQlDKoZiGzKpTKbe1fUfi72tLS2/Huk/m5cGQBfNkSDnwOTQfAuBBoPw60/13/+enxT8nX5TOh9YRyannFJvPzSfzhB8IHDiIvNg6veV/h+eFstPb2d19sZglDf9avul7xlEF5m7o1cqOmAYPVRW1Fqq1RA+/vF2DboQMxU98lZf36Er1GxTgMfcP/Gv2b9j9CiA+FEHevhLnbMaC+EMJfCGEBDAU23HHNBuCZgu8HATulfuVeBNAVQAhhC7QDSp8sRql0opIzOByaxOMBtf87QColXNgMX7eDLRPBrTG8sEf/Sdfh7nUSITEhbAnbwqimo/C2M+4eEpVRztWrXH3qaeLmfEqN4GDqbNyAXffuRd9k7QRPrtJ31/3yBNyMLvJyc62GwUFe7LwQV+ye1be2Ij0Ufeiucxpra7zmfYVNu3ZET3mb1J0qf1N5MyhASCn/lFI+CQQC4cCfQoiDQohRQohCO3QLxhTGAtuA88BKKeVZIcQMIcRjBZctBFyEEJeB14FbU2HnAzWEEGfRB5ofpZQq/WM1ciu1xn9mL107Dov76McahAaG/QrPbNQv8ipEni6P2UdnU8u2FqObjS6PZldYUkqSli0j9PH+ZF+5gucnH1P7yy8wc3Y2rABHH32QyLqhDxJZRc8ZGdraB52Elceiirwu0D0Qewv7e+4RobG0xGvePKyaNOHaa+PJOKY2GypPBncZCSFcgJHAc8BfwBfoA8b2e90jpfxdStlASllXSjmz4Ni7UsoNBd9nSSmfkFLWk1K2kVKGFhxPKzjeRErZWEr5SalfoVLpSClZf/IarXyd8HGxgeSrsHo0fN8VEi5Bn7nw8iF4oFeRCfZWXVrFpeRLTAiagLWZdTm+gool9/p1Ikc/R+yM97Fp1Yo6G9bj0LdvydeB1GoOg3+C+Auw6hnIz7vnpd7ONnSs78qvxyKKHKw215gT7B3M7qjd5OoK34pUW8MW7+++xbx2baLGvapWXZcjQ8cg1gH7ABugr5TyMSnlr1LKcUANUzZQqX7OX0/lUmwaTzSpAdvfhXmt4cIm6DgBxp2A1qPvGme4U3JWMvP+mkdbj7b08O1RTi2vWKSU3PjtN0If60fGyZN4TJ+G9/cLMPfwKH2h9brBo5/BlZ2w5U19l989DG/jQ3RKFnsvFT2BpKtPV1JzUjkee/ye15g5OeH97TdIKYl8+RXyU1NL/RIUwxn6BPF9wSf52VLK66BfBQ1wryRPilJaG09cZZTZNgYf6gcHvoSmA/WBodtUsCpkILUQX/71Jem56bzV5q1quWI6Lz6eqLHjuP7WZCwbNKDOb+twGjrUOP8WgSPgof9ByEI48u09L+ve2B3XGpYsK2awur1ne6y0Vuy4WvRWpBa+vnh98QU5V69ybfzryLx7P8EoxmFogPigkGN3jyopSllISf65DQwLeYJpZkvQeDSFF/fot/8sJgX17c4mnmXNpTUMazis2qWTllKSsnEToY/2JX3/ftzefBPfn5Zg4eNj3Iq6TYeGj8K2KXBpW6GXmGs1PFEwWB2TknXPoqzNrGnv2d6grUht27XFY+pU0vfvJ37+/LK8AsUARQYIIYSHEKIVYC2EaCmECCz4Ckbf3aQoxnHtBPzYG+3Kp8nWaTj84DcwYgPUalGiYnRSx+wjs3GycuKVgFdM1NiKKS8+nqhx44ieOBELPz/8163D5dlRCK3W+JVpNDBgAXg00ydDjDlT6GVDW3uTr5OsCil6ZXU3327EZcRxNuFssVU7DRmMw4ABJH77HWn79peq+Yphitsw6GH0A9NewNzbjqcCU0zUJqU6uXkddrwHp5aDbU3Wek5gelQgR7roB6DzU1PJPHWa7IsXyImMJDcyirzkJGR6BrqMDDAzQ1iYo7GyxqxmTaKts3gg4wQj2w/GPPw60t8KYV61V05LnY6UtWuJ+2QOusxM3CZOxHnkM6YJDLezsNXPJPu+Kywbot/P2+6/4xu+LrZ0rO/KimORvNKlHlpN4V1cnb06oxVadkbupFnNZsVW7TH1HbLOnCH6zTfxX7e2bOMqyj0ZtGGQEGKglHJNObSn1NSGQZVMbiYcnAf754IuDx4cQ1a7/9Hmk8MMt0vjWa6Stmcv2Zcv/zsQqnV0xNzLCzNXVzQ2NmhsbZD5OmRODrr0dHLiY4m7egH7NB2aW7/W5uZYNWyITWAg1q0CsWnVCjMXl3u3q5LJunCBmOnvkXnyJNatWlHr/RlY1rkr6YBpXT8Fix6Bmg1g5O9g8d/Ohd/PXOeVX06weFTrInNqPbftOeIy49jw+J3LpQqXHRpK2KAnsGrYEN+fliDM1AaZpVHUhkFFBgghxFNSyp+FEG+gT6D3H1LKuYXcdl+oAFGJXNwCv0+ElEho9Bj0mEFefg2Ofr2EnN/W4p6ZDGZm2LQOwqZ1a2wCArBq0kSfH6gIc47N4adzP7GsxxLqpdqQfekfsi9dJPPkKTJPn0ZmZwNg2agRNTp2pEanjlgHBFTKN5a8pCQSvv6G5GXL0Do64jZxIg6P97t/A/IXt8DyYdCoLzyxRN8FVSAnT0f7D3cQ6OPEghH3ntOy7PwyZh+dzfrH11PHwbAgl7JxE9ETJ+I6biw1x4wp88uojooKEMX9ZdgW/FdNZVXKLjVGPzXy3Hr9CuiRm8nR+pIw51tSNmzAKS+Psx4NaD5tEg5duxSe+uEeQm+E8sv5X+hfvz9NPVsCYPXAA8CjgD4pXda5c6QfPUb63r0kLlxI4oIFaOzssG3fnhrBwdTo1LHCP13o0tNJXLKEpIWL0GVl4ThkMG6vvVZs8DS5Bx7R58H6423YOUOfKLGAhZmGQa28+X5fKLE3s3C3tyq0iK4+XZl9dDY7I3ZSp5lhAcKh76Ok7d1LwtffUKNTJ6ybFd89pRhO7UmtmJ6UcPxH2D4d8rIgeBJ59YcTP/8bbqxbh9BosBkwiGeSfAjuEcS0vk1KWLzkxe0v8nfC32zsvxEX6+Lf5PNTU0k/eIi0fXtJ37OXvPh4EAKr5s2wCw6mRnAwlg0bVpgpsvk3b5K84leSliwhPzERux49qDn+tfLvTiqKlLDpNTi+GPrNh5ZP/XsqPCGd4Dm7mdCzAWO71r9nEUM3DUUjNCzrs8zgavNv3iT0sX5orK3xX7sGjXX1XRRZGmXek1oI8bEQwr5gp7cdQoh4IcRTxd+pVHupMfDzQNg0HjwDkC/sJyncnSuPPkbKb7/hNHQodbdv52DvZwizceXxgJJv5LMzYieHrh9iTMsxBgUH0G97af9wTzw/+IB6e/fgt2Y1rmPHgIT4L74krP8ALgd34fq700jduQtdZtE5hUwl5+pVYj/+hMtduhI/dy5WDRvit2I5Xl99WbGCA+hXtfeeA3WCYeNrEHH431N+rrY8VM+F5Ucj0RWxsrqbTzfOJJwhNj3W4Gq19vZ4zp5FTlgYcXM+LcMLUO5k6CD1SSllgBCiP/pn9teBvVLKks1BNCH1BFEBnd8IG17VD0g/PJNsx05ET3qLrHPnsH3oITymvoOFnx8AQxccIu5mNjve6FyiT+1ZeVk8vv5xrM2sWdV3FWaaso8n5MXHk7Z3H2l79pC+fz+6jAyEpSU27drqny46d8bc07PM9dxLfkoKqTt3kbJmDRkhIaDRYN+rFy7Pjcaq8Z2bMlZAmcn6mU3ZqfD8LnDUJ0ncdDqascv+YsmzbejcoPDsy6E3Qum3vh9vt32boQ2HlqjamFmzSP5pKT6Lf8S2Xbsyv4zqoixjEHde1wdYJaVMqSiP3koFlJcD2ybDsR+gVgBywPckbztG3CdPoLG1pfbnn2H38MP/BoLoG5kcDk1ifPcGJe7S+fHsj1xLu8bCnguNEhwAzGrWxHHgABwHDkCXk0NmSAipu3eTtnsPMXtmAGBRpw7WAQFYt2iBdYvmWNarV+rBbl1ODtnnzpFx4i/S9uzRB4X8fCx8fan5+us49OuHubsBO+pVFNZO+umvP3SDFcPg2W1gYUvPxh642Fqw/EjEPQNEHcc6+Nn7sSNiR4kDhNvrr5O2Zw/Xp75LnQ3rVVeTERj6G71JCHEByAReFkLUBO69NFKpvm5Gw8pnIOootB9HfuvxRL/9Lmk7d2LbqSOeM2didsfeHRtO6TO39gso2afya2nXWHhmIT19e9KmVhujvYTbaSwssG3fHtv27ZGTJ5MTFk7a7t1kHD1K2q5dpKxdC4AwN8fc1wdLf3/MfXwwc3FF6+yE1tERoTUDjQAJutSb5KekkBcXT87Vq+SEh5P9zz/InBwALOvXw2X0aOy6dsGqRYsKMwZSYjUbwKBF+syvv70MTywpGKz2YuH+MOJuZuFWxGD1T2d/IiU7BQdLwwffNVZW1JrxPhHPPEP8V/Nwf3OisV5NtWXwILUQwhlIkVLmCyFsAHspZYxJW1cCqoupAgg/oM/ymZsJ/eaTbd2CqDFjyImMxP3NiTg9/XShb3i9Pt+LlbmW38Y8VKLqxu8az4HoA2x4fAMetuW/UEpKSW5kJJknT5J96RLZYeHkhIeTGxGBzC08M+m/hMDc0xMLPz8s69fHOrAl1gEBmLtVoicFQxz4ErZPheApEDyJsIR0uszZzcSHH2BMl8LToJyOP82Tvz/JrA6z6Fu3b4mrvD71XW6sWYPfypVYNy3ZhIfqyBhdTAANAb+Cnd9u+alMLVOqjlO/wvox4OQHIzeTdj6Wa68PRpib47NoIbZtCv+EfyHmJhdiUnnvsZL9IR+8dpA/I/7k1Zav3pfgAPod0Sx8fO7KcySlRJeWRn5SEvkpKcj8/P9f7Gdnh8bBATNHR4SFxf1odvlqPw7izsHuWeDWCP/Gj9G+rgsrjkXwcue6aApZWd3UtSlu1m7sjNhZqgDhNnECabt3c/2dd/BftbLKr6Q3JUNnMS0F5gAdgNYFXyqLq6J/49v7Cax7AXzawXN/cmPfOSJffgVzb2/8V6+6Z3AA+O2vaLQaQZ/mtQyuMjc/l9lHZ+Nj58MzTZ4p/oZyJoRAa2eHha8v1s2bY9OyJTaBgdgEBmJZvz7mbm7VIziAfmbTo5+DV2tY9yLEnGFYGx8ikzLZfzmh0Fs0QkMXny4ciD5AVl7Je7K19va4vzuV7AsXSFz0Y1lfQbVmaDbXIOAhKeUrUspxBV+vmrJhSiWQnwcb/wc7P4DmQ+CptSQuW8P1KVOwbdsG36VLMa9972mrOp1kw8lrdKzvimsNS4Or/fn8z4TfDGdSm0lYaKvJG21lZm4FQ34GK0dYPoyefhqcbS2K3LO6q09XMvMyORh9sFRV2vfogV3PniR8/TU5kUUnClTuzdAA8TegsmEp/y8/F9Y+DyeWQMc3kI9/S9znXxL3yRzsez+C17ffoq1hW2QRx8KTiE7JKtHah7iMOL499S3BXsF08upU1lehlBc7Dxj6C6THY7lmFINburP9XCxxqYU/IbT2aI29hT1/Xv2z1FW6T5kMWi2xs2aXuozqztAA4QqcE0JsE0JsuPVlyoYpFVheDqwaCWfXQo/3kV2nEvfppyT+sBDHYUPx/OQTNAZ0ofx2MhobCy09m7gbXPXc43PJ0+XxZus3y/AClPuidqB+hXXEQV7J+IY8nY7Vxwvfs9pcY043n27sitxFdn52qaoz9/Cg5pgxpO3aRerOXWVpebVlaICYDjwOzAI+ve1LqW7ysmHl0/otQHt9hGw/jvjPPidp4SKchg/D4913DUoznZ2Xz+bT0fRs7I6NhWFzJUJiQtgcupmRTUfibe9d1lei3A/NBkHHN7A/t4xp7gdYUcTK6of9HiYtN42D10rXzQTgPOJpLOrVJXbWLHRZamZ+SRkUIKSUe4BwwLzg+2PACRO2S6mI8nP1Tw6XtkKfudDuJRK++orEBQtwHDIE93feMXje/u6L8dzMyqNfS8O6l/J0ecw+OptatrV4rtlzZXgRyn3X5R1o8AjP3FyAe/IJDl5JLPSyNrXa4GDpwLarhe9YZwhhbo7HO1PJjYoiccH3pS6nujJ0FtPzwGrgu4JDtYHfDLivlxDiohDishDirULOWwohfi04f0QI4XfbueZCiENCiLNCiDNCiMJX1SjlQ6eD9WPh4u/6fDutR5O46EcSvv4Gh0ED8Zj2LkJj6AMprD95DRdbCzrWczXo+pUXV3Ip+RITW0/E2kytkK3UNBoY8B04+fGt5RdsPlj4+iVzjTndfbqzO3J3qbuZQL9NqX2fPiT+8AM5V6+WupzqyNC/6DHAQ8BNACnlP0CRK3qEEFpgPvAI0BgYJoS4M5HMaCBZSlkP+Az4qOBeM+Bn4CUpZRMgGChm5ZFiMlLqU2ecXqH/9NfmeVI2biTu44+x69WLWu+9V6LgkJKRy5/n4ujbwhMzbfH3JWQmMO/kPNrVakd3n+5leSVKRWHlgGboL9TQ5DLkytvEJKYUellP356k56Zz4NqBMlXn9uabCHNzYmbOpKpksC4Phv5VZ0spc279UPAGXty/chvgspQytODeFUC/O67pBywp+H410E3o+yh6AqellKcApJSJUsp8A9uqGNuej+HIt9BuDHSaQNqBA0RPeRubNm3w/OjDEm9tufF0NDn5Oga18jLo+k+OfUJWXhaT206uvKknlLu5NeTmw18QoLlM3MrCZ823rtUaR0tHtoWXvpsJwNzdDddxY0nfu4+0XbvLVFZ1YmiA2COEmAJYCyF6AKuAjcXcUxu4fQJyVMGxQq+RUuYBKYAL0ACQBbOmTggh1JSV++Xkcv0q2BbDoecHZJ47x7Vxr2JZpw5e8+ehsTR8/cIta09E0cC9Bk08i98Q6GD0QX4P+53RzUYbvMuYUnnUbDuYTfZDaR77G3lH717Udms20+7I3aVaNHc75yefxMLfn7iPPvo395VSNEMDxFtAPHAGeBH4HXjHVI1CnwKkA/BkwX/7CyG63XmREOIFIUSIECIkPj7ehM2ppq4ehA3jwK8j9P2C3Lg4Il96CY2jA94LFqC1sytxkaHxaZyIuMHAQK9inway87OZeXgmvva+amC6CrN9ZDp78psjtk6EqLvHIx72e5iMvIwydzMJc3Pc35pEztWrJP1i+IZE1Zmhs5h06AelX5FSDpJSfi+L78i7Btw+F9Gr4Fih1xR0WzkAieifNvZKKROklBnoA1JgIe1aIKUMklIG1axZePpgpZQSr8CKJ8HJF4YsRZebT9QrY5AZmfh8912p00+v++saGgGPGzB76fvT3xORGsHbbd/GUlvyJxWlcuj8gAef2E0kQbjAr09DWtx/zrf2aI2TpVOZu5kAanTujG3HjiR8/TV5SUllLq+qKzJACL3pQogE4CJwsWA3uXcNKPsYUF8I4S+EsACGAncurtsA3EqmMwjYWRB4tgHNhBA2BYGjM3DO8JellElmMiwbAkgYvhJp5Uj0lClknT+P55xPsKx/7y0ji6LTSdaeuEaH+jXvuS/xLaEpoSz8eyF96vThQc8HS1WfUjloNIJ+7ZoyMuN/6DKT9Oni8/9/ToqZxoxuvt3YHVX2biYA97cmocvIIP6LL8tcVlVX3BPEePSzl1pLKZ2llM5AW+AhIcT4om4sGFMYi/7N/jywUkp5VggxQwjxWMFlCwEXIcRl9LvUvVVwbzIwF32QOQmckFJuLtUrVEpGp4M1z0FyOAz5BVzqkvDNN6Ru2YrbG69j16VLqYs+EpbEtRuZDAws+ulBSsn7h97H2syaCUETSl2fUnk8EeRFqNaflbXehIiD8Md/e7Af9nuYzLxM9l/bX+a6LOvWxWnYMG6sWkXWxYtlLq8qKy5APA0Mk1KG3TogpQwFngJGFFe4lPJ3KWUDKWVdKeXMgmPvSik3FHyfJaV8QkpZT0rZpqDsW/f+LKVsIqVsKqVUg9TlZc9HcPlP6P0x+D3EzT/+IOHLr3Do9xjOo0eXqeg1J6KoYWlGz8ZFp/XacGUDIbEhjG81Hldrw9ZJKJWbo40F/QI8eS+8CdlBL+pnzZ369d/zQe5BOFs5syVsi1Hqqzl2DFo7O2Jnf6imvRahuABhLqW8KyevlDIeUEnWq5pL22DPhxDwJLQaRXZoKNffmoxVi+Z4zJhRpimmGTl5bDlznT7NamFtce9psfEZ8Xx07CNaurVkYP2Bpa5PqXxGPOhHZm4+v9g/B74dYNNrEKvvWTbTmNHDtwd7ovaQlpNW5rq0jo64jhtHxuHDpO3YUebyqqriAkRRc8HUPLGqJClMn53Voxn0+RRdRgZRr76KsLLC68svSzWd9XbbzsaQnpPPgCK6l6SUfHD4A3Lyc5jRfgYaYfjiO6Xya1rbgUAfR5YejUY3cCFY2sHKEZCdCsCjdR4lOz+bHRHGeUN3GjpEn6fp40/QqWmvhSruL7CFEOJmIV+pQLPyaKBSDnIz9Qn4AAYvRZpZcX3adHJCw6j96RzM3Q3Ptnova45fw9vZmtZ+zve8Zlv4NnZG7mRMwBj8HPzKXKdS+Yx40I+whHT2x2j1e1onXdFPtZaSFjVbULtGbTaHGmc4UpiZ4T7pLXIjIkheutQoZVY1RQYIKaVWSmlfyJedlFJ1MVUVW9+CmDMw4Adw9id5+XJubtpEzVfHYftg2WcQXU/J5MCVBPq39Cp0i0mApKwkZh2ZRTPXZoxoXOzwllJFPdLMAxdbC346FA5+HaDbu3B2HRz9HiEEfer04UjMERIyC9+NrqRqdOxAjc6dSfj6G/ISjFNmVaKe4au7s7/B8cXQYTw06Enm6dPEzv4Q286dcHnhBaNUse6va0hJkbOXZh+ZTVpuGjPaz0CrKVnqDqXqsDTTMqyNDzsuxBGZlAHt/wcNHoFtUyAqhD51+qCTOqMNVgO4TZqELjub+C+/MlqZVYUKENXZjQjY+CrUbgVd3iYvOZmo117DvGZNan/0UYkS8N2LlJLVIVG09nPC16XwHeb+vPonW8O38lKLl6jnVK/MdSqV25PtfNAKweKD4frMr/2/AftasPIZ6pg70si5kdG6mQAs6/jjNHwYN1avVtNe76ACRHWVnwdrntevexi4ECm0RL/1FvnxCdT+4gu0jo5GqeZYeDKhCekMae1T6Pn4jHjeO/QejZwbMarpKKPUqVRutRys6d2sFr8eiyQ1KxesnWDwT5AeB2uf51H/PpxNPEtYSljxhRmo5iuvoLGzI/ZDNe31dipAVFd7P4HIw/DoZ/pxh6VLSd+zF7dJk7Bu1tRo1aw4FkENSzN6N7t77YOUkqkHp5KVl8WHnT7EXKOGtRS90R38ScvOY2VIwZakni3hEf0anUdiw9EIjVGfIrSOjtQcO5aMQ4dVttfbqABRHV09CHs/hhbDoPkTZJ49S+ycT6nRtStOTw43WjU3s3L5/cx1HgvwLHRb0RUXV3Dg2gHeCHpDZWpV/qOFtyNBvk78X3vnHR5VsQXwnNedtwAAIABJREFU32x675AeWkjoAqEXKYKIPpEnAvoURBCVJr3IExCkC6gUFcUHiiIgKAhIUxGUIkV6JySkk5Ded5N5f+yiCQZI2Q1JmN/37ZebuTPnnL1bzt45M+esPnidvNslSZsPgsb98DiwhJZOgWwP3W7UX/su/fthWauWyvZaAOUgHjaykvVTSy41oOdC8jMyiB43HnNXV7xmv2vUegtbT0aTrc2nf4t/1o8OTQ5l0bFFtPdpT7+gfkbTqag6DG5fk4jELPacj9U3CKG/4/UI5snw00SmR3Iq/pTR9AkLC6pPmkhueDhJ69YZTW5lRjmIh41db0FaDDz7GVg5EDt7Drnh4XgvWIC5i4tRVa0/GkGwpwONfJwKtWvztEw+MBlbc1tmtZuligApiqR7A098XWxY9VuBWIOlHfT9gsfSM7CWgq1X71v5uETYdeyIXfv2xC9fgS4pyaiyKyPKQTxMXNoJJ7/SL2n1aU7Ktu2kbN6M2+uvYdeqpVFVnYtO4UxUCv1b+P3DAXz454dcSLzAjLYzVK4lxV0x0whebluDo2FJnI5M/vuER13sn1xMt/R0fry6lSxdltF0CiGoPmki+RkZJCxdZjS5lRXlIB4WMhPhhzehWgN4dCK5ERHEzpiBzSOP4DF8uNHVbTgagaW55h91H/ZF7GP1udX0C+pHF/8uRterqFr0a+GHvZV54bsIgCb96O3ZhnSp5aejxt2/YBUYiEu/viStX0/O1atGlV3ZUA7iYWHnZMhMgGdWIKWGqPHjQQi833sPYf7PAHJZyNbm8d2fUfRo4ImzreVf7dHp0Uz9bSr1XOsxocUEo+pUVE0crC3oG+LH9tMxxKYUrgXR/F8f45sv+P7sakiLM6pe95Ej0djaEjd/gVHlVjaUg3gYuLANTq+HDuPB+xHily4j+9RpvGbNxNL3/pXdSsquc7GkZusKBae1eVrG/zqefJnPokcXqQpximIzqF0N8qVkzaGwQu0aKwd6BT3HEUszojYPhPw8o+k0d3HBfdgwMg4cIH3/fqPJrWwoB1HVybilT5vs2Qg6jCPj8GFuffopzs/1wbFHD5OoXPfHDfxcbWhdy+2vtsXHF3Mm4Qwz283Ez/Gfq5oUirvh52rL4w08+epwOOk5ukLnejUeggC2JJ2HA4uMqtf1Py9gEeBP3PwFSK32/gOqIMpBVHV+nKBf2vrMx+jSMoieNBnLGjWoPmWKSdRdiUvjcGgi/2kV8Fdivr3he1l7YS0vBL9At4BuJtGrqNq89mhtUrN1rDtyo1C7l70Xrb3asMW1Gvn75kJY2SvO3UZYWlJ94kRyr10jacMGo8mtTCgHUZU59z2c3QSdJiGrNyB2+gx0iYl4v7cQja2tSVSuPRyOpbmGviH6u4QrSVd467e3aOzemHEh40yiU1H1ecTPmTa13Pjst1BydIWnknoH9iZa5vCHRw34djBkGC8rq32XLti2akXCh0vJS0kxmtzKgnIQVZX0eNg+FrwegXZjSNm0ibTdu6k2+k1sGjQwicqMHB2bTkTxVCMvXO0sSclJYdTPo7C3sGdJ5yVYmlneX4hCcRfe6FSbuNQcvv8zqlB7F/8uOFg6sLl2S8hKgs1D9TnGjIAQgupTJpOXmkrCio+MIrMyoRxEVURKvXPISYPeH5NzI4LY2XOwbd0a10GmS4j3/cko0nN0/Kd1ALp8HeN/HU9cZhxLOi+hmm01k+lVPBx0CHSngbcjn+wP/Tv9BmBlZsW/av2LvTePkvjY23DtJzj4gdH0WgcH49znWRK/+oqc68ZLEFgZMKmDEEL0EEJcEkJcFUJMLuK8lRBiveH8ESFEjTvO+wsh0oUQ401pZ5Xj7Ca4sBU6v4V0qUP0hIkIS0u85801SgrvopBS8uWhcOp7OdLM35klx5dwOOYwb7d+myYeTUyiU/FwIYTgjU61CY3P+Dv9hoG+QX3R5mv5zt4W6j8DP82CG4eNptvjzTfRWFlxc+F7RpNZGTCZgxBCmAHLgSeA+sDzQoj6d3QbDCRJKesAS4D5d5xfDBivMsjDQFoc7BgPPiHQZiTxy5aTffYsXjNnYuH5z4yqxuJ4eBIXY9N4qU0A20K38cX5L3g++Hl6B/Y2mU7Fw8cTDb0IcLPlo33XCiXqq+1cm5DqIWy8vJG8p5aAs58+HpGZaBS95u7uuL3+Guk//0zGoUNGkVkZMOUdREvgqpQyVEqZC3wD9LqjTy9gjeH4W6CrMORlEEI8A1wHzpnQxqqFlLBtDORmwjMfkXniT26tXIlTn2dxfLy7SVV/eTgcBytz/L1jmH5wOi08W6jNcAqjY6YRDO1Yi1ORKRwKvVXoXL/gfkSlR/F74lno8z9Ij4Pvh+k/F0bAdcAALHx8iJs7D5lnvD0XFRlTOggfIKLA/5GGtiL7SCl1QArgJoSwByYB75jQvqrH6Q1waTt0fZs8K0+iJk7Cwt8PTxMtab1NQnoOO87E0P0RDRMPjMXXwZclnZao+g4Kk/BsM1/c7a34aN+1Qu1d/briZu3GhksbwKcZdH8XLv8Ih1cYRa/GyopqEyaQc/kyyd9uMorMik5FDVLPAJZIKdPv1UkIMVQIcUwIcSw+Pr58LKuopMbo9zz4tUK2eoPYGTPQxcfj8957aOyKLvVpLNYeDkdHGqe0izDXmLOi6wqcrJzuP1ChKAXWFmYMbl+TA1cSOBXxdxI/CzML/h34b/ZH7ic6PRpavQbBT8Ge6RB53Ci6HR7vjk1Ic+I/+IC8tDSjyKzImNJBRAEFt8z6GtqK7COEMAecgFtAK2CBECIMGA28JYQYcacCKeVKKWWIlDLEw8PD+M+gsiClPhGfLhd6rSB123ZSd/yIx4gR2DRqZFLV2do8vjxyheqBX5OSe4tlXZbh6+BrUp0KxYut/XG2teDDn64Uan+u7nMIIfj28rf6+hG9loGDF2x8Wb8EtowIIag+eQp5SUkkfPxxmeVVdEzpII4CgUKImkIIS6A/sPWOPluBgYbjPsDPUk8HKWUNKWUN4H1gjpRS5d69Gye/hiu74LHp5GZZETtzFjYhzXF7dYjJVW85GUmG45dkiuvM6zCPRh6mdUgKBeiT+A1pX5OfLt4slArcy96Ljj4d2XRlE7l5ufp61n0+h7Ro+H64UeIRNg0b4NS7N4lrviDn2rX7D6jEmMxBGGIKI4BdwAVgg5TynBBiphDiaUO3VehjDleBscA/lsIq7kNKlD5Ta0A7ZLPBRE+YCBoNPvPnI8zMTKo6Pz+fJScWYeF4jvEh4+ka0NWk+hSKggxsWwMnm3/eRTwf/DyJ2YnsDNupb/BrAd1m6uNzRopHVBs3Fo2tLbEzZxm17GlFw6QxCCnlDillXSllbSnlbEPbNCnlVsNxtpTyOSllHSllSyllaBEyZkgpH67Fx8VFStg6Up/FstdyEj5ZSdbJk3jOmI6Fj/GztN7JtF8/JMP6F1q69uKl+i+ZXJ9CUZDbdxF7L9zkTOTfaTDaeLehjnMdvjj3xd9f3q2HGeIR0yDiaJl1m7u5UW3MaDKPHCF1+44yy6uoVNQgtaI4nFij3zXa7R0yw5JJ+OgjnHr1wunJJ02uesOlDWy5sQpNRnOWPj5dlQ1VPBAGttPfRXxQ4C5CCMGA+gO4lHSJP2L/uN2oj0c4esO3g4yyP8K5b1+sGzYkbv68KhuwVg6ispIUDrumQs2O5NV5lqjx47Dw8aH62/81uepdYbt49/C76NKCGRg4EVtLtZxV8WBw/OsuIo6zUX/fRfSs1RNXa1e+OP/F351tXOC51ZAWC9+/UeZ8TcLMDM/p08lLuEX8UuNWtasoKAdRGcnPhy3DAYF8ehnR06ahi0/AZ/EizOztTar6YPRBJh+YjItZXfLiXmRAm9om1adQ3I+B7WrgaG3O+3v/vouwMrOif1B/9kfuJzSlwMy1T3N4fDZc3gmHyv6lbtOoIc79+pK09iuyL1wos7yKhnIQlZGjn0LYAegxh6Qdv5G+9yeqjR1r8iWtp+NPM/qX0fjb1yTm0gv0bV4Ld3tVGU7xYHG0tuDVDrXYeyGOEzf+XsraN6gvlhpLvjr/VeEBLYdCvadh7ztw40iZ9VcbMwYzZ2di35mJNFIW2YqCchCVjYSr+o0/gd3Jtg7h5rz52D3aEdeBA0yq9lryNYb9NAw3azcamo0nL8+a1zqquwdFxeCV9jVxt7dk/o8X/wpMu9m48a/a/2LLtS0kZheIOdyORzj76eMRGbfuIrV4mDk5UW38eLJOniRl8+YyyapoKAdRmcjP08+dmluR33U+UWPHYebigvdc02VpBbiReoNXd7+KhcaChe2X8d2xVJ5u4o2fq2mKDikUJcXOypyRXQI5cj2RXy//nVVhQIMB5Oblsvb82sIDrJ3guTWQEQ/fvVbmeITTM72wCWlO3ML30FWhrA7KQVQmDi6FyD+g50Jil6wk98YNvBcuxNzV1WQqo9OjGbJ7CNp8LSu7rWTP6Twyc/N4o5O6e1BULJ5v6Y+fqw0Ldl4i31AvopZTLbrX6M7XF78mJeeOinDej8Djc+DqHvj9/TLpFhoNXjNnIbOyiH13dplkVSSUg6gs3LwAv8yG4KdIvmZJypYtuL/xBnatWppMZVxGHEN2DyFdm87Kbivxsq3J6oNhdKtfnbrVHUymV6EoDZbmGsZ1C+J8TCo/nI7+q/3VRq+Soc1g3cV1/xzUYgg0+Df8/C6EHyyTfqtaNXEfPpy0XbtI3b27TLIqCspBVAbytPDd62DlQE69N4mdORPbkBDc33jdZCpvZd3i1T2vkpidyMePfUw9t3qsO3KDlCwtw9Tdg6KC8nQTb4I9HVi0+zK5Ov20UZBrEJ38OrH2wloytBmFBwgB//oAXAJg4yB9PZUy4PbKIKzq1SN21qwqUcNaOYjKwK/zIeYkeV3mEjlpOho7O7wXLUKYm5tEXXJ2Mq/ueZXYjFiWd11OY4/GZObq+GT/NdrVcaOpv4tJ9CoUZUWjEUzqEcyNxEzWH73xV/vQRkNJyUlh/aX1/xxk7Qh9v4ScVNg4UJ/0spQICwu83p1FXmIScQsWlFpORUE5iIpO+EE4sAjZ5AVivjhIbkQEPosXYVHdNDWeU3NTeW3va4SnhPNB5w9oXr05AGsOhpOQnsvYbnVNolehMBadgjxoVdOVJXuvkJKlBaCRRyPaerdlzbk1ZOmy/jnIsyE8vRRuHILdU8uk36ZBA9xeeYWUTZvJOFi2aasHjXIQFZmsZNg8FJwDSIxvQtru3VQbOxa7lqaJO2RoMxi2dxiXky6zpPMS2ni3ASA1W8vHv16jc5AHzQNMFxBXKIyBEIK3n6pPUmYuSwuk4Hi9yeskZicWHYsAaNQHWg+HP1bCybv0KSbuw4dhWaMGMW9PIy/9nmVtKjTKQVRUpITtYyE1mszA8dz8YBkO3brh+sogk6jL0mUx4qcRnE04y8KOC+no2/Gvc5//dp2ULC1juwWZRLdCYWwa+jjRL8SP1QfDuBav/4JuWq0pHXw6sOrMKlJzU4se2G0m1OgA20ZD9MlS69dYW+M1Zw7amBji5s4ttZwHjXIQFZXT6+HsJrRN3yRy7idY+vnhNXeOSZLi5eTlMPqX0RyPO87s9rN5LOCxv84lZeSy6sB1ejTwpJGvqhKnqDyM6x6EjYUZs7f/nQJjVLNRpOamsvrs6qIHmZnr61nbusH6l8q0ic62WVPchr5KyqbNpO3dW2o5DxLlICoiiddh+3jyvVsT9dUF8tMz8PnwA5PkWdLmaxm/bzwHow/yTtt3eLJW4Uywn+wPJT1XxxgVe1BUMjwcrBjZtQ4/X7zJvks3AQh2DeaJmk+w9sJaErISih5o7wH9voT0ONj0CuTpSm/DsGFY169PzNvT0CXcRV8FRjmIioYuFzYNQaIh9mJdsk6dwnv+PKzrGv8LWpuvZeKvE9kXuY+prabSO7B3ofNRyVn87/fr9GriTZCn2vegqHy83LYmNd3tmLXtPNo8/bLXEY+MQJun5eNT9ygZ6tMcnlwEoftgz9ul1i8sLfFeMJ/8zExi/vt2pSsupBxERWPvdIg6RiJ9SNmxF/eRI3Ds3t3oarT5Wibtn8TeG3uZ1GIS/YP7/6PPwp0XAZjQI9jo+hWK8sDSXMN/n6zHtfgMPv/tOgD+jv78O/DfbLq8qXCm1ztp9hK0el1fhe7Y/0ptg1WdOlQbN470fftIXl/EMtsKjHIQFYnzW+DwCtIdenPzy5049OiB+7BhRldz2znsCd/DxBYTebH+i//oczIime9PRjOkQ018nG2MboNCUV50rVed7vWrs2TvZSISMwEY3nQ4NuY2LDy68N6Du8+GOo/BjvEQ+mupbXB58T/YtW9P3Jy5ZF+8WGo55Y1yEBWFW9dgywhyrBsTte4c1vXq4W2CoLQuX8fk/ZPZE76HCSETiiwVKqVk9vbzuNtb8kanOkbVr1A8CGY83QAzIZi25SxSSlytXXm9yev8FvUb+yP3332gmTn0+Rzc6sCGl/TZlEuB0GjwXjAfM2dnot4cXWmWvioHURHQZsHGgeiyNUTsNkdYW+O7fBkaG+P+ctfl65h8YDK7w3czPmQ8AxoUnSJ859lYjoYlMbZbEPZWptmtrVCUJ97ONoztHsQvl+L58WwsAM8HP08NxxosPLoQbZ727oOtneCF9aAxh6/7lrpcqbmrKz6LF5EbEUHstGmVIh6hHMSDRkrYMYH8iLNEHA9Cl5SC30crsPDyMqoaXb6OKQemsCtsF+NDxjOwwcAi+2Xm6nh3+wWCqjvQN8TXqDYoFA+SgW0CaOjjyIyt50jN1mJhZsHEFhMJSw3jqwtf3XuwSw3o/zWkRMCGAaDLKZUNtiEheLz5Jqk7fqwU8QiTOgghRA8hxCUhxFUhxOQizlsJIdYbzh8RQtQwtHcTQhwXQpwx/O1iSjsfKEc/Qx7/ksgLzci+Ho3PksVGrwyny9fx1oG32Bm2k7HNx97VOQAs/fkqUclZzHqmIeZm6veDoupgbqZhbu/GJKTnMHeHfm9EB98OdPLtxIpTK4hKj7q3AP/W0Gu5vppjGWpIuL06BLsOHYibM5esM2dKJaO8MNk3gBDCDFgOPAHUB54XQtS/o9tgIElKWQdYAsw3tCcA/5JSNgIGAl+ays4HSuivyB2TiLncgIzzMXjOmI5Dp05GVaHL1/HWb2/xY9iPjGk+hkEN774T+3JcGp/uD6VPc19a1lQpNRRVj0a+TrzasRbr/ojgF8PeiLdavYVAMOvwrPtP+zTuq99tfe472DVFPwNQQm7HI8w9PIgcPgLtzZuleSrlgil/IrYErkopQ6WUucA3QK87+vQC1hiOvwW6CiGElPJPKeXthO7nABshRNUqfpx4HTYOJP6qHyknk3AfNgyX554zqgptvpbJBybz4/UfGd1sNK80fOWufaWU/Pf7s9hZmTPlCbWsVVF1GdutLnWr2zPp29MkZ+biZe/FqGaj+D3qd3Zc33F/AW1HQethcOTjUhcaMndxwXfFcvLS04kcOZL8nNJNWZkaUzoIHyCiwP+RhrYi+0gpdUAK4HZHn2eBE1LKf1xBIcRQIcQxIcSx+MpU5i8nDdY9T8IpM24dy8Wpz7O4jxxhVBW5ebmM3Tf2r5jD4EaD79l/47FI/rieyOQngnGzr1q+WKEoiJW5GYv7PkJiRi7Tt54DoH9Qfxq5N2LB0QUkZyffW4AQ+uWvDfvA3hlw8utS2WEdFIT3/HlknzpdYYPWFXqSWQjRAP2002tFnZdSrpRShkgpQzw8PMrXuNKSp4WNL5P4ewTxJyxxfPJJvN55x6jLWbN0WYz8eST7IvQ7pO8VcwD9julZ287TqqYr/UL8jGaHQlFRaejjxMgugWw5Gc2OMzGYacyY3mY6qTmpxZtq0mjgmY+gVifYMgIu/FAqOxy7dcN91EhStmzl1meflUqGKTGlg4gCCn7b+BraiuwjhDAHnIBbhv99ge+AAVLKaya0s/yQEn4YTdKug8SdcMT+sa54z5uLMDMzmooMbQbDfxrOoehDzGw7s8gd0oVNkkzedJo8KVnYpwkajfGTASoUFZFhnWvTxNeJyZtOE5GYSZBrEMObDmd3+G5+CC3GF765JfRbCz7N9NXoLu0slR3ub7yBY8+exC9aTMqWLaWSYSpM6SCOAoFCiJpCCEugP7D1jj5b0QehAfoAP0sppRDCGdgOTJZS/m5CG8uXfXNJ3ryJ2GPO2HXogM/ixQgLC6OJT81N5bU9r3Ei7gTzOsz7R26lovjqyA0OXElgSs96+LvZGs0WhaKiY2Gm4cPnmyIljFz3J7m6fAY1GETz6s2Zc2QOkWmR9xdi5QD/+VZfcGjDS3C15FlbhRB4zZuLbevWRE/9L+m/VZyvPJM5CENMYQSwC7gAbJBSnhNCzBRCPG3otgpwE0JcBcYCt5fCjgDqANOEECcND9OUUCsvjv2PxM+WEvOHC3Zt2uK79EM0lpZGE5+QlcCQXUM4d+scix5dRM9aPe87JjQ+nTk7LtC+jjsvtvI3mi0KRWUhwM2Oec825mREMgt3XcRMY8ac9nMQCKYcmIIuvxiZXG2c4cXN4BEE3/xHn+CvhGgsLfFdthSrOnWIHDWKrLPnSv5kTIGUsko8mjdvLissp9bLhL7e8nxQsLzx+usyLzvbqOJvpNyQT2x6QrZY20IeiDxQrDFZuTrZ4/39ssk7u2RUUqZR7VEoKhtvf39GBkzaJnefi5VSSrnt2jbZcHVDuejoouILSU+QcnkbKWdVl/LKnlLZkRsXJ6907iIvtW4jsy5dKpWMkgIck3f5Xq3QQeqqgDy7mfiZ47h5yhHHHt3x/fBDNFbGWyV0/tZ5XvzxRdJy0/is+2e092lfrHHvbj/PhZhUFj3XBG+VjE/xkPNWz3o09HFk7PqTXL2ZxpO1nqRfUD/+d+5/7A7bXTwhdm4wYAu414Gv++uTb5YQi2rV8P98FcLCghsvDyLnypX7DzIhykGYEHl2K7GTxpJw1h6np5/Ce5FxYw6HYw4zaOcgrMysWPPEGhp7NC7WuO2nY1h7+AZDO9aia73qRrNHoaisWFuY8clLIVhZmDF4zTGSMnKZ1GISjT0a8/bvbxOafI+04AWx94CB2wyB65fhz7UltsWyRg38V69GmJkR/vIgcq49uDU6ykGYiLwTG4kYOYbkaza4DRmE1/wFRl2ttC10G2/sfQNve2++fOJLajnVKta4CzGpTPj2FE39nZnwuKoxrVDcxsfZhk9eak5McjbDvz4BmLH40cVYm1sz6pdR998fcRsbZ3jpO8MS2OFwcFmJd1xb1aqJ/5rVoBGED3yZ7MuXS/hsjINyECZAu/cjwodNISPWEs+3J1Nt/ESj7XPIl/ks+3MZUw5MoYlHE1b3WE11u+LdBcSn5TBkzTEcrS34+MXmWKhcSwpFIZoHuDDn3404eO0W07acpZptNd7v/D4x6TGM/Hkk2brs4gmytIPnv4H6z8Duqfp6EiUsXWpVqxYBq1cjNBrCX3yJzOPHS/GMyob6hjAyGauncn3cErSZlvgt/xCX/9x7k1pJyNJlMeHXCXxy+hN61+nNp90+xcnKqVhjc3R5vL72OLcycvh0QAjVHa2NZpdCUZXo09yX4Z1rs+6PCBbtvkzTak2Z13Eep+JPMfnAZPLy84onyNwK+vwP2r0JRz/TpwrPTimRLVa1axPw9deYu7py45XBpP38SymeUelRDsJIyDwdiVP6cWP+JswcbKmxcRP2XboZTX5cRhyv7HyFPeF7GNd8HO+0fQcLs+LFM/LyJWM3nOJ4eBKL+z5CI9/iORWF4mFlfPcg+rfwY9kvV1n123W6BXRjYouJ/HTjJ2YfmV38tBgajT6539NL4fqvsOpxfR62EmDp60PA119hVbcukSNHkrj2q3JLy6GqwRiBvPgYYl//N6nnkrFv6In3qu8xc3I2mvwjMUeYuH8iWbosPuj8AZ39Oxd7rJSS/35/hu2nY3irZzA9Gxm3zoRCURURQjC7dyOSM7XM2nYeW0szXmz5IglZCaw6uwqN0DC11dTiTx03GwDOAfrNdCsfhd6fQNATxbbH3NWVgNX/I2r8BOLefZecS5fwfPu/CCPupSoKdQdRRjJ/2U5oz8dIPZ+ER592+G742WjOIV/m89mZzxi6ZyjOVs588+Q3JXYO8368yLo/IhjeuTZDO9Y2il0KxcOAmUbwfv9HeLSuB1M2n+GLQ2G82exNBjUYxPpL65lzZE7JfsnXehSG/qovPrSuP+yZXqK4hMbODt/ly3B77TWSN24kfNAr6EycpFTdQZQSmZtL/LvjubVxNxb2khrvTcDmySFGk5+Yncj036ezL3IfPWr04J2272BrUfxUGFJK3t1+gVW/XefF1v6M765WLCkUJcXawoyVA5oz/Ks/mbblHLm6fMa0H4NEsvrcarJ0WUxvOx0LTTGXr7vWhFd2w87J+lThEUf0Sf9caxZruNBoqDZmNFZ1A4mZ+l9Cn+mN94L52LdrV4ZneQ995TWXZWpCQkLksWPHykVX5rGjxIwfQW5sKk71raj+wVrM/BoaTf7+yP1M+30aqbmpjAsZxwvBL5RoFVR+vmTq92dZ98cNXm5bg2lP1VdJ+BSKMpCry2f0+j/ZcSaWoR1rMenxIFae+YQVp1bQzrsdizotws7CrmRCT2+A7eMgPw8enw3NX9anEi8mOVeuEDlmDLnXQnEbMgSPMaMRmpJPCgkhjkspQ4o6p+4gSkBeWhrxc6aR9N1OzG11+A1uhf3oz8DCOCuCMrWZLDq2iA2XNxDoEsgn3T4hyLVkv/wzc3WM/uYku8/HMaxTbSY8HmTUVOIKxcOIpbmGD/s3xd3+PCv3hxKRmMmSfkPxtPPknUPv8PLOl3m/8/v42N9Z8uYeNO4L/m1gyzDYNhouboenFoNz8fKiWQUGUnPjRuLmzEEbG1vFWabfAAAN/ElEQVQi51Jc1B1EMZA6Hcnr1xO/5D3y0rNwqZ+Px9TZmDU3XgW4A5EHmH1kNtHp0QxsMJARTUdgZVaylByxKdkM+eIo56NTmfpkfQa3L95tq0KhKB5SSlb9dp3ZOy7Q0NuJFf9pRnjWCSb+qt/rNLfDXDr6diyZ0Px8OPqpvviQlPDoRGgzQp9OvLh26XQI89L93r/XHYRyEPdASkn6r78SP3cWOeHR2HrkUO3Zpti8+gnYuRtFR3xmPPOPzmdX2C5qOtVkWutphHgW+Vrdk9+uJDB6/UmycnUsfaEpXYJVCg2FwlTsOR/H2A0nEcB7zzWhnp+WMfvGcCnpEkMaDWFYk2HFXob+F8kR+tjExW3gXhcenwt1uprkzqAgykGUECkl6b/sI2Hp+2RfuIyFnY5qbS1xeGMeov6/jKIjS5fF2vNrWXV2Fdo8LUMbD2VQw0FYmpVs2ZouL58ley+zYt81anvYs/yFZgR5OhjFRoVCcXdu3Mpk+NcnOBOVwkutA3izWw2WnlrI5iubCXQJ5N1271LfrX7JBV/eDT9OgKQwqNEBuk4HvxZGt/82ykEUE5mbS+ruPdz69GNyLl3Fwi4P94ZZOL34GqLTOLAoe9ZTXb6OH679wLI/l3Ez6yZd/LowNmQsAY4BJZZ1JjKFKd+d5mxUKn1DfJnxdANsLVVYSaEoL3J0eSzYeYnPf7+Ot5MN855tRJ71OWYemklidiIDGgxgaKOh2Fval0ywLheOr4b9CyAjHoJ6Qvsx4NfS6M9BOYj7oL15k+T1G0j65mvybiVh6ZCHW4MMnHr3QXSaCE4lCDzdhdy8XLZc28LnZz4nMj2Sxh6NGdd8HM2qNyuxrNRsLR/uvcLnv1/Hzd6Kd55uoDbAKRQPkOPhiUz49jSh8Rk80dCTEV19+CZ0Od9f/R43azdGNRtFr9q9MNOUMGFnTjocXgGHlkN2Mvi3hXajILA7lFTWXVAO4h7khoVx7amnQJeHnVc2rkHZ2HXvjeg8Ub+hpYwkZify3ZXv+PrC19zMuklDt4YMaTyELn5dSry6KFubx9rD4Sz75SrJmVpeaOXPpB7BONkYL4W4QqEoHdnaPFbuD+WjfdfIy5e81CaATo2yWXluCSfjTxLgGMDghoN5qvZTxd83cZucdPjzS72jSIkAJ39o9hI0fREcvctkt3IQ90AmXCVx+KM4BFph2WUwtBgMDp5lsiVf5nM87jgbL29kb/hetPlaWnm2YnCjwbT2al1ix5CSqWXd0Rus/j2M2NRsOgS6M6lHMA19VE4lhaKiEZeazXu7LrHpRCTmZhr6NPOhcd1INl9fzYXEC3jbedM/uD+96vTC1dq1ZMLztHDhBzixRl/aVGigTjdo0g8aPlsqe5WDuB9X9uiDQWXYzyCl5FT8KXaF7WJ32G5uZt3EwdKBXrV78Vzd56jlXLx6DYXkRaaw6Xgkm05EkpmbR7s6bgzvVIe2dYyzgkqhUJiO8FsZfPxrKJuOR6LNz6ddHTea1Y3jVPp3nLh5HHONOY/5P8ZTtZ6ijXebEi9QITEUTnwJp9eDS00YtL1UdioHYSJuZd3icMxhDkYf5FD0IeKz4rHQWNDepz09avSgs39nbMyLH9jOz5ecjU7h54s32XoymtCEDCzNNTzV2Ish7WtR39vRhM9GoVCYgtiUbL45eoONxyKJSs7C0dqcVkE6LJyPcCr5J1JzU7GzsONR30fp7NeZFp4tcLNxK76C/HzIvKWvZlcKHpiDEEL0AD4AzIDPpJTz7jhvBXwBNAduAf2klGGGc1OAwUAeMEpKueteukztILJ12YSmhHIm/gynE05zOv40YalhADhZOdHGqw0dfTvSya8TDpbFW2aaly+5cjONE+HJHAtLZP+VeBLScxECWtZw5d/NfHiikReO1irGoFBUdvLyJQeuxPPDqRh+uhhHcqYWS/N86gTEYuN0jijtUTJ0qQDUca5DK69WNHJvRD23egQ4BJQ8wF1MHoiDEEKYAZeBbkAkcBR4Xkp5vkCfYUBjKeXrQoj+QG8pZT8hRH1gHdAS8Ab2AnWllHet1GEMB5GpzSQ2I1b/yIwlLDWM0ORQQlNCiUyLRKK/Vq7WrjT2aEwTjya08WpDsGvwfV+82JRsLselcfVmOldupnPtZjrnY1JJz9Fnc3S1s6R9HXc6B3vQMdADN/uS7aJWKBSVB11ePn9cT+Tnizc5cj2Rc9Ep5Ms8NNbReHjcwNL+OmniMnkyFwAbcxuCXIKo6VQTf0d//B388Xf0x9veGwcLhzKl03lQuZhaAlellKEGI74BegHnC/TpBcwwHH8LLBP6Z9oL+EZKmQNcF0JcNcg7ZGwjE7ISeHX3q8RlxJGmTSt0zkJjQYBjAPVc6/FkrSep7VybRu6N8LbzLvELMmb9SQ6F3gLA2daCwGr2PNPUm2b+LjTzdyHAzVblTFIoHhLMzTS0reP+VzwxNVvL8bAkzkSlcCEmlQsxqSTfSkNjFY/GOoo2jXPJEREciDpAwtWEQrJszG1o6dmSZV2XGd9Oo0v8Gx8gosD/kUCru/WRUuqEECmAm6H98B1jy74ZoQgcLR3xdfAlpHoInnaehR7VbatjrjHOJRr9WCCjZCCB1e1xs7NUzkChUPyFo7UFnYOr0Tm42l9tGTk6wm5lEJaQSfMAFzyd9ItoMrQZRKRFcCP1BjEZMcRlxuFi5WISuyr1tlshxFBgKIC/f/EyIN6JpZklS7ssNaZZRdKqVgmCTgqF4qHHzsqcBt5ONPAuvJzdzsKOYNdggl2DTW6DKSvKRQF+Bf73NbQV2UcIYQ44oQ9WF2csUsqVUsoQKWWIh0fpIvgKhUKhKBpTOoijQKAQoqYQwhLoD2y9o89WYKDhuA/ws9RHzbcC/YUQVkKImkAg8IcJbVUoFArFHZhsiskQUxgB7EK/zPVzKeU5IcRM4JiUciuwCvjSEIRORO9EMPTbgD6grQOG32sFk0KhUCiMj9oop1AoFA8x91rmasopJoVCoVBUYpSDUCgUCkWRKAehUCgUiiJRDkKhUCgURVJlgtRCiHgg/C6n3YGEu5yrSFQWO6Hy2KrsND6VxVZlZ/EIkFIWuZGsyjiIeyGEOHa3KH1ForLYCZXHVmWn8akstio7y46aYlIoFApFkSgHoVAoFIoieVgcxMoHbUAxqSx2QuWxVdlpfCqLrcrOMvJQxCAUCoVCUXIeljsIhUKhUJSQKukghBAzhBBRQoiThkfPu/TrIYS4JIS4KoSY/ADsXCiEuCiEOC2E+E4I4XyXfmFCiDOG51KuCafud40MGXfXG84fEULUKE/7DDb4CSF+EUKcF0KcE0K8WUSfTkKIlALviWnlbafBjnu+lkLPh4breVoI0ewB2BhU4DqdFEKkCiFG39HngV1PIcTnQoibQoizBdpchRB7hBBXDH+LrKAjhBho6HNFCDGwqD4mtrPCf+YLIaWscg/0ZUzH36ePGXANqAVYAqeA+uVsZ3fA3HA8H5h/l35hgPsDuI73vUbAMOBjw3F/YP0DsNMLaGY4dkBfC/1OOzsB28rbtpK+lkBP4EdAAK2BIw/YXjMgFv1a+QpxPYGOQDPgbIG2BcBkw/Hkoj5LgCsQavjrYjh2KWc7K/Rn/s5HlbyDKCZ/1cyWUuYCt2tmlxtSyt1SSp3h38PoCyNVJIpzjXoBawzH3wJdRTnXU5VSxkgpTxiO04ALmKhEbTnQC/hC6jkMOAshvB6gPV2Ba1LKu21CLXeklPvRlwcoSMH34RrgmSKGPg7skVImSimTgD1Aj/K0sxJ85gtRlR3ECMNt3Od3ud0sqmb2g/xSeQX9L8eikMBuIcRxQ5nV8qI416hQXXHgdl3xB4JhiqspcKSI022EEKeEED8KIRqUq2F/c7/XsqK9L/sD6+5yriJcz9tUl1LGGI5jgepF9Klo17YifuYLUWlrUgsh9gKeRZyaCnwEzEJ/kWcBi9C/GOXOveyUUm4x9JmKvjDSV3cR015KGSWEqAbsEUJcNPw6URRACGEPbAJGSylT7zh9Av00SbohJvU9+kqF5U2leS2FvhLk08CUIk5XlOv5D6SUUghRoZdnVpbPfKV1EFLKx4rTTwjxKbCtiFPFqntdVu5npxDiZeApoKs0TD4WISPK8PemEOI79FM/5fFmKUld8UhRuK54uSKEsEDvHL6SUm6+83xBhyGl3CGEWCGEcJdSlmsOnGK8luXyviwmTwAnpJRxd56oKNezAHFCCC8pZYxhSu5mEX2i0MdObuML7CsH2wpRwT/zhaiSU0x3zNn2Bs4W0a04NbNNihCiBzAReFpKmXmXPnZCCIfbx+iDXEU9H1NQlrri5YYh5rEKuCClXHyXPp63YyNCiJbo3/vl6siK+VpuBQYYVjO1BlIKTJ2UN89zl+mlinA976Dg+3AgsKWIPruA7kIIF8O0c3dDW7lRCT7zhXnQUXJTPIAvgTPAafRvHC9Duzewo0C/nuhXvFxDP+VT3nZeRT8netLw+PhOO9GvIDpleJwrbzuLukbATPRvcABrYKPhufwB1HoA17E9+unE0wWuZU/gdeB1Q58Rhut3Cn1wsO0DsLPI1/IOOwWw3HC9zwAh5W2nwQ479F/4TgXaKsT1RO+0YgAt+jjCYPRxr5+AK8BewNXQNwT4rMDYVwzv1avAoAdgZ4X/zBd8qJ3UCoVCoSiSKjnFpFAoFIqyoxyEQqFQKIpEOQiFQqFQFIlyEAqFQqEoEuUgFAqFQlEkykEoFAqFokiUg1AoFApFkSgHoVAoFIoi+T/YjZe3ZNkdJAAAAABJRU5ErkJggg==",
             "text/plain": [
               "<Figure size 432x288 with 1 Axes>"
             ]
           },
           "metadata": {
             "needs_background": "light"
-          }
+          },
+          "output_type": "display_data"
         }
+      ],
+      "source": [
+        "df = pd.DataFrame(np.random.randint(10, size=(10,4)), columns=list(\"ABCD\"))\n",
+        "\n",
+        "df.plot.kde()\n",
+        "plt.show()"
       ]
     },
     {
@@ -5867,34 +5844,34 @@
     },
     {
       "cell_type": "code",
+      "execution_count": 100,
       "metadata": {
         "colab": {
           "base_uri": "https://localhost:8080/",
           "height": 265
         },
         "id": "stuGd8fe-vBD",
-        "outputId": "389c8456-752f-4941-941e-650105ed19d9"
+        "outputId": "3af47a14-a9af-49f7-e397-3aa359aa5205"
       },
-      "source": [
-        "df = pd.DataFrame(np.random.randint(10, size=(10,4)), columns=list(\"ABCD\"))\n",
-        "\n",
-        "df.plot.line()\n",
-        "plt.show()"
-      ],
-      "execution_count": 446,
       "outputs": [
         {
-          "output_type": "display_data",
           "data": {
-            "image/png": "iVBORw0KGgoAAAANSUhEUgAAAWoAAAD4CAYAAADFAawfAAAABHNCSVQICAgIfAhkiAAAAAlwSFlzAAALEgAACxIB0t1+/AAAADh0RVh0U29mdHdhcmUAbWF0cGxvdGxpYiB2ZXJzaW9uMy4yLjIsIGh0dHA6Ly9tYXRwbG90bGliLm9yZy+WH4yJAAAgAElEQVR4nOydeUBU5frHP2eGYRj2fVeRVVEB99zNpWzRtG5mWf2qm2XZLbW97r3VbbFuZlmWLbfbZlld08xswyXTSkEUUEBARGVkB2UfGGbO74/DACrLzDALBZ9/Suac874M8Mz7ft/n+T6CKIr0008//fTTe5HZewL99NNPP/10TX+g7qeffvrp5fQH6n766aefXk5/oO6nn3766eX0B+p++umnn16OgzUe6uvrK4aFhVnj0f30008/f0pSUlLKRVH06+g1qwTqsLAwDh48aI1H99NPP/38KREE4VRnr/VLH/30008/vZz+QN1PP/3008vpD9T99NNPP70cq2jUHaHValGr1Wg0GlsNaRZOTk6EhoaiUCjsPZV++umnH8CGgVqtVuPm5kZYWBiCINhqWJMQRZGKigrUajWDBw+293T66aeffgAbSh8ajQYfH59eG6QBBEHAx8en16/6++mnn76FTTXq3hykDfwR5thPP/30LfoPE3spdY3NfHrgFE3NevtOpOoMZG617xwAzbFj1Ozcid1tefN2Q+kx+86hn/OpyIOUj0Bv578VK9LnAvXXX3+NIAgcO9a7/9i+O1LEk1uO8vz2TPtO5LfX4ctboa7CrtMoef4F1Mvuo2DJXWjPnLHPJPR6+N//wY6n7TN+P+eja4Z9r8H6ibDtftj7ir1nZDX6XKDeuHEjkydPZuPGjfaeSpfklNQA8NHvp/gmrdB+EylKk/57xn6VpqJejyYrC2VMDPWHDpE3dx6VGz5FtPUKqjwHNFVt70k/9qP4CPxnBux4CiJnQew1sPt5acfzJ6RPBera2lr27dvH+++/z+eff27v6XRJdkktQwLdGDPIi8e+Sie3JXDbFL1e+oMAUCfbfvwWtGo1+tpavG66iYht3+A8ahQlzz3HqZtvofFEvu0mYngPagqhrtx24/bTRnMj7HoO3p0O1YVw/YdwwwaYvx78YuCrv0py3Z8Mm6XnteeZbRlkFlZb9Jmxwe48NXdYl9ds3bqVOXPmEB0djY+PDykpKYwePdqi87AUOcU1TIz04ZHLh3D1G3u559NDbF02CRelDX9kZ/OhqVb6fzsGak1mFgBOsbEoQkIY8N67VG3dSsmqF8mfPx/fZcvwueN2BGvnvrd/D4rSIHKmdcfr53wKkmDrfVCeDfE3wuUvgLO39JqjCyz8BN67FP53G9y2HRwc7TpdS9KnVtQbN25k0aJFACxatKjXyh9VDVqKqzVEB7gR6OHE64tGcqKslsc2H7HtYVpRqvTf0LGgTgG9znZjt0OTmQlyOcroKEDKzPGcP5+I7d/ieumllL36KvkLb5CusybqgxAyRvr/fvnDdjTWwvePwfuXgbYeFn8FC95uC9IG/KJh3hugToLEf9pnrlbCLivq7la+1qCyspJdu3Zx5MgRBEFAp9MhCAIvv/xyr0vJM8gcMQFuAEyM9OXBy2J4+cdsxgzy4v8mhtlmIkXpIFPAyFukw5qybAiItc3Y7dBkZaGMiECmVJ73dQdfX0LXvkb1Tz9R/Oyz5F+/EJ877sD3vmUXXdvzSVRDaSZMfwzqSqE43bLP76dj8nbBtgfg3GkYuwRmPQVKt86vH36ttPI+sB4GjJP+/Segz6yoN23axC233MKpU6c4efIkBQUFDB48mL1799p7aheR3RKoowPbfiHvmRbBzCH+PLc9k0Onz9pmIsXp4D8EwiZL/7aT/KHJysJp6NBOX3e/7DIivv0Wj2uuoeK998i/Zj71KSmWnUThIUCUdheBcdKHWD/Wo+EsfL0MPlkAcke4/Xu4anXXQdrA7H9B6Dj45m9QlmP9udqAPhOoN27cyIIFC8772nXXXdcr5Y+c4hpclQ4Eezi1fk0mE1izMIEAdyfu+/QQlXVN1p2EKErBKCgevMNB5WWXQK0tLUVXXo7TsK5X8nIPD4JfeJ4B7/8HUavl1OKbKf7Xs+hq6ywzEcP3HjIaghKgMk9aZfdjebK2wZvjIW0jTF4BS3+FQRONv9/BUTpkdFBKqaVNFvodsCN9JlDv3r2bOXPmnPe1+++/n/Xr19tpRp2TXVJDVIDrRZKMh7OC9YtHU17XxAOfH0ant6JeXV0I9eUQGA+C0KJT2z5QG3TnrlbU7XGdNInwb7bidestnN24kRPz5lJriV1TQTL4xoDKE4LipK+VHO35c/tpo6ZECqxf3Ayu/rBkF8x6GhRO3d15MR4hcN37UHYMti2XFh5/YPpMoP4jkVNS26pPX8iIUA+emTeMvbnlrN2Za71JGDRYQ1AKHSv90jecs96YHdCYJWV8KI0M1AAyFxcCn3iCQZ99ikzlTMGSuyh89DGaz5opGYmi9CEVOlb6d2DLe9Ivf1gGUYTUjfDmOMj+AWb+E5bshuCEnj034lK49Ek48iUcfN8yc7UT/YG6l1Fe20hlXRPRnQRqgEVjB3DdqFDe2JXLz9ml1plIUTogQMBw6d+GIFV4yDrjdYImMwvFoIHIXV1Nvtd55EgGb9mMzz1Lqdq+nRNXz6X6hx9Nz5ypPAENlTCg5T1wCwQXv/4DRUtw7jRsuA6+XirlQS/dB1MeBLmFUi2nPAhRl8EPj0uZS39Q+gN1LyOnuCXjI7DzQC0IAs/NH05MgBvLv0hFfbbe8hMpSgOfSFC2BMiQUYAgSQA2RDpIND/TROboiP8DDzB40/9QBAZyZvlyztx/P9pSEz7gDJKP4cNKECTtvn9FbT56PSS9B29NgNP74YqX4fYfpBQ7SyKTwYJ3wDVQKv+vr7Ts821Ef6DuZbRmfHSxogZQOcpZf/NodDqRZZ8eorHZwjnOxeltsgeAkwf4DbGpTq2rqkKrVhutT3eF05AhhH3xOf4PPUjtL3s5cfVczn212bjVtToZHN2k799AYByUZUmVcv2YRnkufHglfPeQlEJ37+8w/i4pqFoDZ29Y+BHUlsDmJX9I86b+QN3LyCmpwctZga9r91VVg31dePn6ONLUVTz3bZblJlFfCVUFbVqsgQEtB4o2OpjRZEnGWU6xPQ/UAIKDAz533sngr7fgFB1N0ZNPUvDXv9KkVnd9ozpZ2lHI5G1fC4oDfbOUW92Pcei0knHS+klQmiWVfd+8GbwGWX/skFEw50U4vgN+edn641mY/kDdy8guriE6wM3oIpw5w4NYMmUwn+w/xdZUC3kctB4kxp//9dCxoDkHFcctM043aFoOEi2xom6PcvBgBn78EYFPP0VDWjon5s6j8uOPEXUd7Eqa6qD4aJvsYcDw3vTLH8ZRlAbvzYCd/4KYObAsCRJukmQkWzHmDoi7AX5eBcd32m5cC9CnArVcLichIYH4+HhGjRrFb7/9Zu8pnYcoiuSW1HapT3fEI3OGMDbMi8e+OtLqutcjDOXRHQVqsJn8ocnMxMHfHwdfX4s/W5DJ8Fq0iPBvt+E8dgwlL6zi1OKbaTx+wYdQYSqIuosDtWcYKN37S8m7Q6uBHc/Au5dCTbHkx7HwY3ALsP1cBAGuflWSsL66E6q62Un1IvpUoFapVKSmppKWlsaqVat4/PHH7T2l8yiq0lDT2NytPn0hCrmMdTeNwkXpwNINKdQ2NvdwIungHnqxl4JvjBScbBWoszItvpq+EEVQEAPeeYfgl/9N08mT5C+4lvL16xG1WumCCw8SDchkEDiiP/OjK07vh7cnw741konSfUkQO8++c3J0gRs+kWSYL/8Pmq1cOGYh+lSgbk91dTVeXl72nsZ5GA4STV1RAwS4O/HGjSM5WV7Ho1+l98y86cKDRAMymVSZZ4NArW9ooOlEPkoL6dNdIQgCHnPnEr79W9xmz6Js7evk/+V6Go5mSN+rdzi4+Fx8Y2AclGTYzayq19JYA989DP+dIx223rwZ5r8pVbf2Bnyj4Jp1ksf6T3+392yMwi6mTHz/WJvPsaUIHAFXvNjlJQ0NDSQkJKDRaCgqKmLXrl2WnUMPMaTmRfubHqgBJkT48NDlMfz7B8m86fZJZnRSb6qTTuWHX9fx66FjYe9qydFMaXpus7E05uSAXo9TrO1MoBx8fAhZswb3q66i+Jl/cXLhQnyGN+N73eSOVzRB8ZKbW8VxKQe4H+mwbttySVYYfzfM+IdVf0/MZth8KFgG+9+UMk9G/MXeM+oSo1bUgiCsEAQhQxCEo4IgbBQEwYyaTvtjkD6OHTvGDz/8wK233mr/HnztyC6pIcBdiYez+cn+S6dGMGuoP89vzyLllBmVeMVHAfHijA8DA8aBqIfCw2bP0RjaSsdt79bnNnMm4d9uw3Pu5VSky8h/K5P65A52EYZdR79OLWUKbblHKl5RqOCOH+GKl3pnkDYw+xkYcAl80+IM2YvpdkUtCEIIcD8QK4pigyAIXwKLgA/NHrWbla8tmDBhAuXl5ZSVleHv72/v6QCQW1Jrsj59ITKZwCvXJzB33T7u++wQ3/5tMj6uJlh+Xlg6fiEhLY0W1MkweEqP5toVmswsZB4eKEKCrTZGV8jd3Qm6ZRLu1Z9QdMyfU7fciueNi/B/8MG2KknfaJArpUAdt9Au8+wVZHwt5UQ3nIUpD8HUh83z57A1cgVc/wG8MxW+uEXyFumlHyzGatQOgEoQBAfAGbBjEz/LcOzYMXQ6HT4+52uPoiiir62ludy2rZZ0epHc0ppWj4+apho+zviYRp3pBRUezgreWjyKiromHvg81TTzpqI0UHmDe0jHrzt7SxWLVtapDdamhjTFXcdK2H3MSuXynVGQjEuInPBvvsH7tts498WXnLh6Lg1pLStouULy5+6jB4oV1RW89u6lFG++A9yDJX+Omf/4YwRpA+7BknlTRa7ke92DHfYPR4t5c/dxmnWWL6jpNlCLongGWA2cBoqAKlEUf7rwOkEQ7hIE4aAgCAfLysosPlFLYNCoExISuOGGG/joo4+Qy+XnXSM2NKCrrkZ9/wNtJ/82oKCyHo1W3+pBvS1vGy8ffJlVB1aZ9bzhIR48e80w9h0v57UdJnjyFqVJ2mtX+a2h1i18EbVaGnNycBo6lNJqDUs/SeGODw+ydEMKpdUaq4zZIS2FLjI3DwIee5SwjZ8h6pope2Nd2zWGUvJeJKHZAlEUeex/D/G+spx5Awfx5dR70QcOt/e0zCN8mmTedHQTJP/H7Md8euAUm1LUyGWWzw3vNlALguAFXAMMBoIBF0EQbr7wOlEU3xVFcYwoimP8/PwsPlFLoNPpSE1NbU3Ru+qqqy66Rq+RAkHDoUOUrrZd+/kLS8eTipMA+Cr3K7Ye32rWM28YO5DrR4fyxq7jxq1Gm5ukirHOZA8DoWOhrgzOnTJrXt3ReOIEYlMTaU7+zFqzh13Zpdw9LZxmvcibu21TbENzo7RSDh3T+iVVfDxu0y+l4ciRtg7ogXFSEdC507aZVy/hnb1HOSwcZnRDI45iJM8mPc9ff/wrp6qt8zthdSavhOg5LeZNB02+vVqjZf+JCmbHBlilY5Qx0scsIF8UxTJRFLXAZsAEF+8/FvqGBhAEvBYvpvKjj6j+4UebjGvI+Ijyd0Uv6kkuTmZexDzGBY7j2f3Pkl1p3mHHs/OHMzTIneVfpFJQ2Y15U9kx0Gs7P0g0YMgptpJBU2Gy1KvxuWwdMYFufP/AFB6/YijXjw5lY1IBZ841WGXc8yhKA13TRfnTqoQE9FVVNJ08KX3BUBTUh+SPQ6fPsvbg+zTKddxW70Xp8dt5Yuw/ya7M5rpvruPDox/SrO9hLr+tkcmkPozuQVJ+dV2FSbfvyS5DqxOZHWudQh5jAvVp4BJBEJwF6aNiJmBBY4nehajRICgUBDz6CE7xcRQ9+SSN+flWHzentJYB3ipclA5kV2ZT3VTNhOAJvDT1Jdwd3Vn580pqmkyvOnRSyFm/eBR6vciyz7oxb2o9SOzGB9g/FhQuFtepdXqRD3/N56svdtEoV7Bk8XS+uGsCEX7SAc/fZkrNbdftsqIPt4FOCl1UCVJgbkht0akDhoEg7zOl5BW1jdz72V4UXvuYVd9IdPAlNDWLeOkn8/X8r5kYPJFXUl7h5u9uNntxYTdUXlLVZF0pbL7TpPz4HVkl+Lg4MmqgdXLFjdGoDwCbgEPAkZZ73rXKbOyMqNejbwnUgqMjoa++iqBQcOb+B9DXW8FKtB05xW0HiQbZY1zgOHxVvqyetpoztWf456//NCudMMzXhdUL40lXV/GvbV2YCBWlgaOrVODRFXIHyeTGgoH6eGkNC9/5nae3ZRLfUIxq6BBumRSBrJ3eF+KpYtG4AfzvoJrTFdb9eaBOBo+Bkvd0OxwHD0bm5tZ2oKhQSdkffWBFrdOLLP8ilSplIsiaWFZZScDQyXioFPyUWYK/sz9rL13Ly9NepqiuiEXfLuLN1Ddp0v0xqv8ACB4JV/xbaqq7599G3aLV6dl9rJQZQ/ytok+DkVkfoig+JYriEFEUh4uieIsoin9Kb0exqQlEEUEh5TErgoMJXr2axuPHKX7mGavlXDc168kra0vNO1B0gDD3MPydpbTBUQGjWDF6BTtO7+DjzI/NGuPyYYHcPTWcTw+cZsvhTjwOitKlRgHG2E2GjpGCk7ZnMoRWp2fdrlyuXLuPvLJa1vxlBIPOnsF9RMed6pddGolcJli3uw1Isk47fdqAIJOhioujITW17YtBcX0il3rtzlz2nchH5fM7c9yjiNRqkQ8cx4wh/uw+VkqzTo8gCMwJm8PWa7YyZ/Ac3k57m4XbFpJW9gd6f0bfJpW873kJcnd0e3lSfiXVmmZmWUn2gD5cQt4R+gYp6BgCNYDr5En4LltG1dZvOPfFl1YZ92RFHc16kegAN7R6LSklKYwPGn/eNbfG3srsQbN5NeVVUkrM61Tx8OUxjBvszeObj5BdfIGMotdLPQC7O0g0EDpWsvnsQYA6eqaKeet+ZfVPOcweFkDiimlc7Seir6vrtCIxwN2JWy4ZxJbDao6X1po9dpdUF0K1+mJ/jxZUCQk05ua2Nc4NjIOaIqjtndlOluDn7FLe2JXLsNgUdGi5V+cCrgHgOZDZsQGcrdeeV2Dl6eTJqimreHPmm9Q113HLd7fwUtJL1GutvBOyBIIAV62RJL7Nd8K5gi4vT8wsQekgY0qU5c3DDPQH6naIGg3IZAgO59cB+d57Dy6TJ1Py/PM0HLF8Q1ND0IwOcCOzIpP65nrGBp4fJARB4F8T/0WoWygP7XmI8gbT87wd5DLW3TgSV6WCezakUKNpl35YeQKaai92zOuMHjjpabQ6Xvz+GNe8+SvltY28c8to3rxpFH5uynbWpp1XJC6dHoGTQm69VbXh1H/AuA5fViXEg16P5mjL70LrgeIfaNVoAuqz9Sz/IpXIQB1F+l3MDZ9LWGGL9asgMDXaD0e5jMTMkovunRo6lS3ztrAwZiEbsjZw7TfXsr9ovx2+CxNxdJb0al2z1BmmkwYRoiiSmFnClChfnB2t58jRpwJ1cXExixYtIiIigtGjR3PllVeSk9OWY6xv0CBTKi/KIRZkMoJf/jdyX1/OPPAAunOWbfCaW1KDXCYQ7udCUpGkT18YqAFcHV1ZM30NtU21PLznYbNO1v3dnVh300hOVdafb95U1LKV7y7jo3Uy/uA5CAqSTBo/Kb+SK9fu5e09efxlVCg7Vkzj8mFtOrAmIxMcHFBGR3X6DF9XJbdNDGNbWiHHiqtNGt8o1Ekgd5T8YzpAFSe9R63yh+G6P6H80disY9mnh9DpREbGpaAX9SyNXgSVea3SkKvSgQkRPiRmlXQoD7o6uvL3S/7OB5d/gIPMgSU/LeGp356iuskKPztL4hsJ89+CMynw45MdXpJZVM2Zcw1Wy/Yw0GcCtSiKLFiwgOnTp5OXl0dKSgqrVq2ipKSk9XVR04CgUnV4v4OXF6FrX0NbVsaZRx5py6O1ANklNYT5OOOkkJNUnES0VzTeTt4dXhvtFc0/JvyDgyUHeePwG2aNd0m4D49cHsN3R4r5768npS8Wp4NMcX67qe4IHWt0zmmNRss/vj7Kwnd+p0mnZ8Nfx/PSX+Iu8jXRZGWhjIhA5th1h5u7pobjpnTg1UQTinmMRX1QWiU7dFx6L/fwwDE8vO1AUeUpfWj9CTM/nv02kzR1FU/MCyRR/Q0LohYQeq6lQUVo245jdmwApyrqye1CjhoTOIZNczdxx/A72Hp8K/O/ns+u073LGO0iYufBhPsg+T1I/99FL+/ILEUQYMaQ/kBtEXbv3o1CoWDp0qWtX4uPj2fKFMmvQmxqQtTrkTl1Xv6qiosj4PHHqPtlLxXvvGOxueW0NAto0jVxuPQw4wI73nIbmBcxj79E/4X/Hv0vu0/vNmvMu6aGc1lsAKu+y+LgyUopyPgPBYfuW4C1MmAc1BRCVdedZXZnl3L5q7+w4cAp7pg0mJ9WTGVyB3qeKIpS6bgRjnmezo78dcpgfswo4Yi6yvg5d4dOKxlOhXb9M1DFx9OQlta2ggyK+9Nlfnx9+Awb9p/mrqnhHGvcjIDAXXF3SXKXIIfgtjROw4qyI/mjPU4OTqwYvYJPr/oUbydvHtj9gNlSns2Y9TQMnADb7ofSY+e9lJhVzKiBXvi5meCnYwZ2sTl9KekljlUe6/5CExjiPYRHxz3a6etHjx5l9OjRnb4utlQkyjpZURvwuvFGGg4dpuz1N1DFx+MysWe1PxqtjpMVdcyLDyatLI1GXWO3gRrgsXGPkVGewZP7nuSLq79ggPsAk8YVBIGXr49n3rp9LPs0hd8d0pANubhSs0sMWRHqZPC42BvkbF0Tz36byebDZ4j0d2XT0omMHtR5nmlzaRm6igqjmwXcMXkwH/x6kjWJ2Xxwe/fvmVGUHIVmTYcZH+1RxcdTtWUL2oICHAcOlFbgWdtAUw1O7paZix3JKanh8c1HGBfmzaKJKq79ZiuLhiwi0CVQkrsChkkm/C0EuDsRH+pBYmYJyy6N7Pb5w3yGsfHqjXxw9APeTnub/UX7eXTso1wdfrVVKvt6hFwBf2kxb/rSYN7kRuG5Bo6eqebROSbsQs2kz6you0PfoAFBQFB2/ckoCAJB/3oGx4hwzjz4ENri4h6Ne7y0FlGUmgUkFSchE2SMDuz8A8WAUq5kzfQ1CILAyj0r0TSb7oHhoVKwfvFonBqKkTVUojdWnzYQMEJyj7vgQFEURb5NL2TWmj18k1bI/TMi2X7/5C6DNIAmMwMwvpmtu5OCu6aGszu7zDxL144o6KSjywWoRkqryVb5I9BwoGhhn3U7UNvYzNINKbgoHVh300jeO/IOCpmCO0e0FIGcOdThQevs2ABSC84Z7ceikCm4K+4uNs3dRJh7GE/se4J7d95LUW2Rpb+lnuMeBH/5r+Q9/s39IIrsyJJ2D9bWp8FOK+quVr7WYtiwYWzatKnT1/WaBmRKJYIROcQyZ2dCX3+dk3+5njPLVzDo448QutFUOyOnncfHFylJxHrH4u5o3Ios1C2UVVNWsWznMlYlreKZic+YPH5ssDvPXyLCQdhY4Mni8d3f04qDo7T9bReoS6o1/OPro/yUWcKIEA823DmeoUHGfT+GjA/lEONXKLdNDOO/+/J5NTGHDXeaMvlOUCeDWxB4hHZ5mTIyEsHZmYbUNDzmzm1LayxOh7BJPZ+HnRBFkUc3pXOyvI5P77yEGv0Ztp/Yzm3DbsNX5QslmdBU0+EH2azYAFb/lMOOrFJuGj/Q6DHDPcP5aM5HfJ79OWsPrWX+1vmsGL2ChTELkQm9aC05eIrUCGHnMzDwEhIzEwj3dSHS3/rWqL3oXbAuM2bMoLGxkXffbSuqTE9PZ+/evUBL6XgX+vSFKMPDCXr+ORpSUylZvdrseWWX1OAolxHgAenl6YwN6noldyFTQ6eyZMQSNuduZkvuFrPmMNm1ED0Czx+UszOra43xIkLHQmEqYnMjXySfZtaaPezJKePxK4aw5d6JRgdpgMasLBwHDWrzezYCF6UD90yPYN/xcvafMM2foUPULYUu3Wy/Bbkc1YgRbZkfboHg4v+HP1D84NeTbD9SxMOXD2FChA9vpb6FykHF7cNvly5Qt2T5dBCoYwLcGOCtIjHT9F2mXCZn8dDFbLlmC/F+8Tx/4Hlu/+F2Tlad7MF3YwUmLYfoKxB/fBJN/n6brKahDwVqQRDYsmULO3bsICIigmHDhvH4448TGBiIXqtFbG5G5tS1Pn0h7ldcgdctt3D240+o/v57s+aVU1xDhL8rR8rTadY3Mz7Q9FXhsoRljA8az/MHnjdP+y9KA59IwoL8WWGMeVN7QseCrpF/vrORR786wtAgd35YPpW7p0XgIDft10uTkWlWj8SbLxmEv5uSNT/l9Kx6tLYMzuZ3K3sYUMXHo8nObi2UIij+D32gmHKqkhe+y2LW0ACWTgsnuzKbn079xOKhi/FyapGt1MmSX3kHNgOCIDB7aCC/5lVQZ2aD5RDXEN6Z/Q7PTnqW3HO5XPfNdbx/5P3eY/Ikk8GC9dQ7BbBW/hpXhNtGlOgzgRogODiYL7/8kry8PDIyMti+fTtRUVGtB4mCynTD84CHH0KVkEDRk3+n8cQJk+/PKaklOsCVpOIkHAQHRvqPNPkZcpmcl6a8hIfSg5U/rzQ9P7UoHVlQPG/fPBoRuOfTFDTa7g1pdHqRjUVSDrRz6WGemz+cz5dcwmBfl27u7OBZ586hLSw0q/WWk0LOfTMiSTpZyd7cHmQPnGlJNewm48OAKiEBmptb24YRFCfZxGpt6JltIcprG1n26WGCPVW8sjAeQRBYl7oON4Ub/zfs/9ouVB9sLXTpiNmxATQ16/klx/wqTUEQmB85n63XbGVK6BReO/QaN22/qfeYPKm8eNPvKXyEGuKTHrZJc+M+Fag7w7Ai6io1rzMER0dCXnsVQankzAOmmTfVaLScOddAdIB0kDjCbwTOCmeT5wDgo/LhlWmvUFRbxN/3/d34lWV9pVQuHRTHQB9n1ixM4OiZap7pymUttYkAACAASURBVLwJSVu/bv1vPL6jgkq5Hw8MqeLmSwadZ6JkCppj0k7A3Ga2N4wdQLCHE68k9mBVrU4GmYPR1ZmqeEPhi+FAMQ5EHZR2/d71NnR6kQc+P8zZ+ibW3zwKD5WCo+VH+bngZ24ddiseSg/pwoZzkhVuFzuOsWFeeDorSDRVQusAP2c/Xrv0NdZMX0NpfSmLvl3E64deN6vrkSXR6vR8csqDb4JXIJzYLXmCWJn+QE2LPu3oiHBBtxdjUQQGErz6ZRqP51H01NNGBwpDccBAH4GMigyj0vK6IsE/gZVjVrK7YDcfZHxg3E2GarqW4DQ7NoCl0yLYmHSar1IuNm9qatbz+s5crnp9L6cq6njthgS8YibibKb/iAFNZkvpuBnSB4DSQc79M6NIKzjHLnNbdhUkSaZUjsZ9WDr4+KAYMKBNp/6DelO/tiOHX49X8Ow1wxkWLAXldanr8FR6cvPQdj1CzrT8jAd0Hqgd5DJmxPizq8WkyRLMHjSbrfO3cmX4lbx35D2u33Y9qaWp3d9oJQ6cqKRG04zHxDsgYbHksmeEeVNP6A/UtJSOd5M/3R2ukybh+7f7qN62jXOff27UPYZmAY2KPPSi/iIjJnO4eejNXDboMtYeWktysRE+HEXtVoMtPHRZNJeEe/Pk10fOK9FOKzjHvHX7WJOYw5zhQSSunMb8kSEIoWOlDic15q+iNJmZOAQE4ODdcUWmMVw3OpSB3s688lMOelP6REKXaWddoUpIoCE1Vfpw9goDpccfqpR897FS3th1nIVjQlk4VsrFP1x6mF/P/Mrtw2/H1bHdwa76ICBA8KgunzkrNoBz9VoOWiplEvBQevD85Od5e9bbaJo13Pr9rbyY9KJdTJ4SM4txUsiYEu0PV66Wcso332nVLj99PlCLzc2I2iaTMj46w3fpUlymTqHkhVU0pHe/qsouqcHZUU5eTSqOMkfi/EzMY+4AQRB4ZuIzDHQbyMN7HqasvhutsDgdPAZITWtbcJDLeP3Gkbg7KbhnwyFKazS88F0WC976lbP1Tbx36xjeuHEkvobu5gZN94zpLYwMGJrZ9gSFXMbyWVFkFlXzY4aJmQelWaCtM/og0YAqPp7msjKai4sl3TZwxB8m86OgUjJbig1y51/XtPU7XHd4Hd5O3iyKWXT+DepkqXq1m4KerkyaesqkkElsuWYLi4Ys4rOsz7j2m2v5rfA3i4/TGQYTpsmRfqgc5W3mTXodfHlrp+ZNPaXPB2pDj0RTMz46QpDJCPn3v3Hw80O9fDnNZ7teUeSU1BDl70pycRIj/UeilFumDNVg3lTfXM/Dv3Rj3lSU3qERk7+bE+tuGsXpynomv7ibd385wQ1jB5C4ctrFKUlBcZJPiIkGTQb0DQ005eebrU+355qEECL8XFiTmGNa9/XWtLOuKxIvRBVv6PhikD/ioCTDJgdMPUGj1XHvp4fQiyLrbx6Fk0KS/Q4UHSCpOIklI5acf16i17elLnaDq9KBiZE+JGZ2bNLUU1wULjwx/gk+nPMhCpmCuxPv5unfnkYvWr7794VkFlVTWKXhsvZ/Az4RMH+9ZD3ww+NWGbfPB+q20nHLtLiXe3oSsnYturJyCh95tEvzpuziWsL8IftsNuOCLFQC3UKUVxT/uOQfpJSk8Pqh1zu+qLFWqrTq5PBs3GBvnp43jOhAVz67czyrro3D3Ulx8YUKlbSSNKMpKEBjdjbo9Wbr0+2RywSWz4omt7SWb9MLjb9RfRCcfcFrsEnjOQ2JQVAq2w4Ug+KhuQHKbdAurAf869tMjpyp4pXr4xnkI2XpiKLIusPr8Hf25/qY68+/oTJPauJrZEbM7NgATlfWk1NiJc9wpIYam+ZtYvHQxXyV+5VN7FMTM0skE6ah/ue/MPRqmHg/FByQ/q4sTJ8K1HK5nISEBIYNG0Z8fDyvvPIKzXX1CA6Kizyoe4JqxHACnnyCur17KV+/vsNrKuuaKK9txMntJECPDxI7Ym7EXBZGL+SDjA/YeXrnxReUHAXELpsF3HLJIL792xQmRnZjij5gHBQekvx7TaShJb2tp9KHgatGBDEk0I3XduQaf6ClTu4y7awzBIUCp+HD25WSt7yXvVin3nxIzWcHTnP3tHAua2cx+2vhr6SWpXJ33N0X7+466SHZGbOGSivOHRbI/ugKpVzJitErcHd05+vcr606FkiBetRArzbZrz0zn4K/JoLS8pWKfSpQq1QqUlNTycjIIDExke+//55nX/63xVbT7fG84Qbc582lfN2b1O779aLXDaXjtcIxVA4qhvl23Hqqpzw67lGG+Qzj7/v+zunqCw47DFqqqR4fHRE6FrT1UJph8q2NWVnIPDxwCA7u+TwAmUxgxexo8svr2Hy4a2c/QEpRLM8xWfYwoIqPR5ORgb6pSeqf6ODUazM/jhVX88SWI4wf7M3Dl8W0ft2wmg5xDWFB5IKLbyxIkg5KfaONGifA3Yn4AZ78ZAWd+kKUciVXh1/NztM7qWq0oJPiBZw510BGYXXn1YhyB6MzhkylTwXq9vj7+/PO22/z9oYN0I0RkzkIgkDQ00+jjIyg8KGH0BadbzRjCNT5dWmMDhiNQtaBpGABHOWOvDL9FWSCjBU/r6ChuV2Pw+I0cPYBdwsEyPZOeiaiyczCKXaoRV3TLosNYESIB6/vzKWpuZtV9ZlD0n9NPEg0oEqIR9RqaczKkv5Y/WN75Yq6RqPlng2HcHNS8MZNI8+rHN1dsJuMigzujrsbhbyD30X1QQgdbVw/zRZmD/UnreAcJUaaNPWEBVELaNI3sf3EdquNsSPTdiZMF2IXU6biF16gMcuyNqfKoUMIfOIJk+4ZHByMTq+nvLYWy6zlzkfm7EzI2tc5ef31qJcvJ+yTT1rNm7KLa3Bzqaeg9iQLY66zwuhthLiGtJo3Pb//eZ6d9KwUFIvSJE3VEgHScxC4+El/0GPvNPo2UaulMScHr1tu6fkc2iEIAisvi+b2D5L5X0oBi8cP6vxidTIIMqmzuhmo4tuc9FTx8dJ7mrEZRNEy760FEEWRRzalc7qyns/uHI+/W9suUi/qeTP1TQa6DWRuxNyLb26slXZKQx42aczZsYEtJk0lXb//FmCI9xCGeg9ly/Et3DT0JquMkZhZQrifCxF+1jdhupA+u6KGds1srbCiNqAMH0zQ88+jSUun5N8vt349p6SGoEBpW26qEZM5TA2dyl1xd7E1byubczdDc5Nkgm4J2QOkgBQ6zuQVdWNeHqJWazF9uj3To/0YNdCTN3Ye77okXp0srYKVbmaNowjwxyEo6PzMD00VnDtl1vOswfv78vn+aDGPXB7D+HCf81776dRP5JzN4Z6Ee3CQdbB2KzwEot7kHUd0gCsDvZ2tkqbXEQuiFnCs8hhZFVkWf3a1Rsv+ExV2WU2DnVbUpq58rcXx7GzkMhkBIReb3lsS9zmX0/B/t1L50ceoRibgfuWV5JTUEhqVh5vgxhAv6xuPA9wbfy/pZem8cOAFhopyYvVa47uOG0PoGMjeLmm+zsYVrrRWJA7reWrehQiCwEOXxXDTfw6wMek0t0/qIKNDr5d2AcM70GVNQBUf366UvCWLpihdKoKxMwdPVvLi98e4LDaAu6aeb6ak0+t4K/UtIjwiuCLsio4fYPjwDeneJ709giAwOzaAT34/RW1jM65K64abKwdfyerk1WzO3cyTPh33ODSXn7PLaNaL56fl2ZA+u6IuKyvjvkceYemttyIzQXczF/+HHkI1ahRF//gnRelZVDVoqeIYYwPGIpeZV7puKnKZnJemvoSXkxcrU1ZTJRMgKKH7G42ltTO58Wl6mqwsBJUKx0HW2RpPjPTlknBv3tydR0NTB6vqilxorDI67awzVAnxaAsL0ZaWQkCs1KqqFxwoltc2suyzQ4R4qXj5+viLzgG+y/+O/Kp87k24t/PfQ/VB8Iky+sO3PbNjA2jS9cykyVg8lB7MHDST7fnbLe4HkphZgo+LIwkDum5+YS36VKBuaGhoTc+bNWsWMy+5hH8+9phNxhYUCkJeXYNMpaLioZWohGKqtMUWz5/uDm8nb1ZPW02Jtpq/+weg97RggAwZJWm9JsgfmsxMnGJizPZZMYYHL4uhvLaRj38/efGLJqaddUZr4UtampRX7hdj9wpFnV7k/o2HOVevZf3i0Xiozj8k1Oq1rE9bT4xXDLMGzer4IaIoZXyY+f6MGSSZNO2wkfxxbdS11DTVsPNUB+moZtLUrOfnY6XMHOqP3EzTsZ7SpwK1TqdrTc87fOAAy2+7DbmzddJpOkIREEDIK6uRqwt4IPVLEEWr5E93R4J/Ag/p3PhZ5ch/Mz+03IMdXSTfA7VxFYqiXk9jVpZFCl26YmyYN1Oj/Xh7Tx61F/okFySBkwf4dN/nryucYmNBoUDTPp/azpkfaxKz+S2vgufmDyc2+OKy72152yioKeC+kfd13knl7EmoL+/SiKkrWk2asi1n0tQV4wLHEeIawubjmy32zAP5FdQ0NjM7NrD7i61EnwrU7Wm1Nu2hGZOpuFxyCSkzr2da/mkWpKuI9OxZgDALvY6bivK5XBnIG4ffIKnIvNLvDgkdC+oUo0qotadPo6+vt0jpeHesnB3N2XotH+zLP/8Fg79yD+UvmVKJU+zQdhWKcVBbDLVmOvn1kJ1ZJby5O49FYwdw/ZiLGx836Zp4O+1tRviOYFrotM4fZJCxerDjmN1i0pR80nImTZ0hE2RcE3kNB4oOcKbWiBx6I9iRWYKTQsbk7oq+rEifDdSiRgMymdm9DnvCpiEzOBShYOGPdWiMMG+yOBV5CNo6nom8kUHug3j4l4cprbdQQAkdJ/XUK8/p9tLWHolWyPi4kIQBnswaGsC7e09QVa+VvthYI3lH91D2MKCKj6fh6FHE5ua2snw7yB+nK+pZ8UUqw4LdeXpex4VUm3M3U1RXxH0J93Wdv65OAoUL+Jn/M5oa7Yejg3VMmjpifsR8BAS+Pt7zSkWDCdOUqBYTJjth00BtDYMWc9E3NCBTOl30S2rtOer1IrlnT/HGXD06Hw/Uy1d0a95kcVoOuVxCx7Jm2hoamht4eM/DaPXanj/bEPSMMGjSZGaCgwPKqKiej2sEK2dHU6Np5j/7WjrxnEkBRLMrEi9EFR+PqNGgyc6WvE8Aimzrm6zR6rj3M8k3ev3i0a1mS+dd06zh3fR3GeU/ignBE7p+oDpZOnuQm5+x4aJ0YFKED4lZxTaJAUGuQUwInsDXx79G10NzrIxCyYTJXml5BmwWqJ2cnKioqOgVwVoURUSN5qLScVEUqaiowMkClqedceZcA1pFDnUqAfeXn0VXXk7hQw8j6mzotlaUBnJH8BtCpFckT014ikOlh1ibsrbnz/aJAJWXUQeKmswslJGRyGy0q4kNdueqEUH8d18+lXVN7dLOLBOonRPaCl9w8pBS82yc+fHMtgyOnqlmzcIEBvp0fP7yZfaXlDWUcd/IblbT2gYoPmKRHcfs2EAKKhvIbqnItTYLohZQXFfMgaIDPXqOwYRp5hD/7i+2IjbLow4NDUWtVlNWZv00ne4Qm5tpLi1F3tCArOp8bwAnJydCQ0OtNnZ2cQ1ylxN4K/0IGzeTc3//O8VPPUX5W+vx+9t9Vhv3PIrTJV/hllLhq8Kv4nDpYT7K/Ih4/3hmD5pt/rMFoUWn7jpFTxRFNFlZuE6fbv5YZrB8VhTfHS3inV/yePzsQfCNAZWnRZ7tEByM3M9XOlC86aaWA0XbBepNKWo2JhVwz/QIZnWyAqzX1vP+0fcZHzSesYHdBODCVNA3WyRQzxrqzxNbJL13SKDxnenNZcaAGXgoPdhyfAsTQyaa/ZzEzBJGD/TCpyMTJhtis0CtUCgYPNg0C0lrUf3DD5xZvoKwrzahsoE+2p5jxVXInfMYFzgdQRDwXHg9DYcOUf7WW6gS4nGdMsW6ExBFaUU99PxS4UfGPkJmRSb/+PUfRHlGEeYRZv4YoWMhN1GqznPy6PCS5pISdJWVVqlI7IqoADeuiQ/mo9/yedQ1GVlMJ0UeZiAIAqr4eOrbt+bK+qbL98FSZBVV8+SWI0wI9+HB2Z0bJ3127DMqNZXcl2DEosBCqYsA/i0mTYmZJdw3w/pSl6PckavDr+bL7C85pzmHp5PpH8bqs/VkFlXz+BW2KUjrij55mKjJsK022p7U4mPIHOqYFHoJIP1xBz79FMqoKAofehhtoQkeyuZQpYaGsxeVjjvKHVk9bTUOMgdW7ll5vnmTqYSOAcS2Hnsd0NMeiT3hgVnRBOuKkTVUmJ121hnOCQloT52Wzh1aeygesegYF1Kt0XLPhhQ8VApev/F8s6X21DbV8mHGh0wOmUyCvxGFTupkSb5x9bPIPC+LDSBNXWUTkyaABZEL0Oq1bM83z6hpZ5Z0wG5vfRr6aqDOykIZFWUzbbQ9x6qk1Vb7/GmZSkXo62sRdTrUy1dIdpnWwqCZdtAsINg1mBenvMjxs8d5bv9z5p8nhIwGhC7lD01WJggCyhjbr1YG+7qwJLwCgDJPC5bQc0HhS6s3tfXkD1EUeeR/6RScbWDdTaPwc+t8i/5J1idUNVZx30gjJTZD6qKFMAQ8W2V/xHjHEOsTy5bcLWb9LidmlhDh50K4HUyYLqTPBWqDNmrrLTdAs05PpT4TV1kAwa7n+/U5hoUR9MLzaNLTKX3Riu3ni9IBQSpM6YDJIZO5O/5uvsn7hk25m8wbw8kD/IZ0eaCoycrCcdAg5K4u5o3RQ672PkOt6MTaNMv+CTgNGwZyuWTQ5BYArgFWPVD8z958fsgo5rE5Qxg3uPMS76rGKj7O+JgZA2YwzMcI7/MqNdQUWjRQR/m7MsjHdiZNIK2qs89mk1VpmlFTVYPBhMl+RS7tMeq3VBAET0EQNgmCcEwQhCxBELrJ6em9NJeWoauosEugziuvQabKI9pjZIevu192Gd63387Zzz6jatu31plEUZpk/u7YeYBcGreUicETWXVgFRkVpjcCACT5Q50saeIdoMnMtIvsYcCt7BAlbsP4IqWQgkrLdbKWOTujjIlu6/gSFG+1FXVSfiUv/nCMOcMCuXNK1+c/H2V8RJ22jmUjlxn3cAvq0wYEQWD20AB+z6u4uELUSlwZfiVKuVJyjDSBn7NLadaLvUL2AONX1GuBH0RRHALEA5b3EbQRmkwp8NgjSOw5mYog1zAxZHyn1/ivXIFq9GiK/vlPGo8ft/wkitO7dcyTy+S8OOVFvJ28efDnB83rmhE6VtLCK/Iueqn57FmaC4tsUujSIU31UHyUgNgpCILA6zst29/QOSEBTfoRKeUyMA7KjkmpbhaktEbDfZ8dYoCXin9fH9dlml2lppINWRu4POxyor2M69CC+qDUqSZgePfXmoAtTZoA3B3dmTVoFt/lf4em2XhtPDGzBF9XRxIGWCYjqKd0G6gFQfAApgLvA4ii2CSK4jlrT8xaaLKy7KaN7i+Ucjqviuo8s0NQKAhZswaZiwvq+x9o7ZJuEerKofqMUR7UXk5evDL9FUrqS3hi3xOmd3ge0KLBdyB/NB6TmkbYonS8Q4pSQdThGjGBm8cPYvPhM+SX11ns8ar4ePR1dTQez5M+FEWdVAFpIc7WNXHfp4ep1mhZf/PojhsOt+O/R/5Lo66RexLuMX6QgiTJWdHBsuc4o1tMmmwtf9Q01XTcN7QDmpr17MkuY+aQALuZMF2IMSvqwUAZ8IEgCIcFQfiPIAgX7ZsFQbhLEISDgiAc7A250p3RaEdt9HhNKvLmQELdu95OKQL8CXr2XzSdOEHtnl8sN4GidttxI4j3i+fhMQ/zi/oX3j/yvmlj+caA0r1Dg6a2jA87BWpD1WToGO6ZHoGjXMbaHd2XvBtL24FiqkVLyUVRZHt6EbNf3cOh02d56bo4hgZ1nZNcVl/G59mfc3X41YR7hHd5bSvNjdLvioUzYqDFpGmIP7uOlaK1gUkTwNjAsYS4hrDl+Bajrm8zYeodsgcYF6gdgFHAelEURwJ1wEXeoKIoviuK4hhRFMf4+VkmnccaaDLso41q9VrO6bPxdTAuOLlOmYLcw4PaXZaza2w91DKUNxvBjUNu5IqwK1iXuo79RfuNH0vW0tqqgxW1JjMTh8BAHLzs4+2LOhm8w8HFFz83Jf83MYytaYWtfSx7imLQIOSenpJO7TlIOlztoZNeSbWGuz9JYdlnhwj2VLHtb5O5JqH7hhfvHXmPZn0zS+OWGj9Y8VHQNVpUn27PZbEBVDVoST5ZaZXnX4hMkDE/cj4Hig6grlF3e31iZgkqhZzJUfYzYboQYwK1GlCLomioxdyEFLj/cOjOnUNbWGgXbfRQcTqi0ESsp3FvneDggOv06dT+vEcy+bEERengMdAkA3hBEHh64tOEuYfx6C+PUlJnwpY1dByUZEDT+bKCvbJuAOlwU518XhC6e2o4Lo4OvGahVbWh8KUhLU2q1AyMMzvzQxRFvkg+zaw1e9iTU8YTVw5h8z0Tu11JAxTVFrEpZxPzI+czwP1iB71OMeyCrBSop0TZ1qQJYH6kcUZNoiiyI7OEKVG+Hfqk2ItuA7UoisVAgSAIht7yMwHLCW42RGNHbfSnE78iigKTQjs/SLwQ15kz0FVVUZ9yyDKTMOIgsSOcFc68Ov1VGpobeGjPQ8abN4WOlXrtnWmbv76+nqb8fPvJHlUFUFtyXhDycnHkjklhfHekmIxCMw5OO0CVEE/T8Tx01dVSoC7JAJ1pH7inK+q5+f0DPPrVEWKD3Plx+VTumhrRaUHLhbyT/g4Ad8fdbdrk1cngHmqZ7vQd4KJ0YHKkL4mZJTbz/gl0CWRi8ES25m3t0qipt5gwXYixWR9/Az4VBCEdSABesN6UrIc9tdHkkiT0jYGMDDW+P6PrpEkIjo7U7trV8wk01kDFcaP16QsJ9wznmYnPkFqWypqDa4y7yeBK107+0GRngyjaLzWvk7Szv04Jx93JgVcTLbOqVhkMmtKPSO95s0Zq+2UEOr3I+/vyufy1X0grqOL5BcPZuOQSwnyNP1cpqClg6/GtXBd1HUGuQaZNXp1sMUfBzpgdG4D6rO1MmqDNqKkrCe+nzBJkAsywswnThRgVqEVRTG3Rn+NEUZwviqKNfTktg7200UZdI6dqMxHrIwnzMf6PTebigvOES6jZtavnK4/io9J/e9B1/IrBV3DjkBvZkLWBH0/+2P0Nzt5S55R2FYqaTGkzZjfpQ30QHFQXFfx4qBTcNTWcHVmlpBb0PKnJacQIEISWA0VDhWL3OnVuSQ1/efs3nv02kwkRPiSunMri8YOQmZh98Hba28hlcpbELTFt4jUlcO601WQPAwY3usQM28kflw64FE+lZ5eHiomZJYweZH8TpgvpU5WJmqwsu6ym00rT0KPFTxGLo4Npb7nbjJloCwpozO1hrm9r6XjPSqYfHvMwcb5x/PPXf5Jfld/9DaFjJc2z5YNGk5WF3NMThyATV3mWoiAJgke2Oge257ZJg/F2ceSVn7J7PIzc1RVlZKTU8cUnSspJ7iLzo6lZz+s7c7nq9X2cLK9j7aIE3v+/MQR5mN6B6ETVCb498S03xNyAv7OJK0PDjmOAdVvE+bs7kTDAk8Qs2wVqg1HTrtO7OKe5+MNYfbaerKLqXid7QB8K1PqGBkkbtcNK7kDxARBlxHp1XJHYFa6XTgfoufxRlA7OvuDWswCpkCtYPW01jnJHVv68knptN1V9oWOgrgzOnQKgMVPqkdilD7K1aG6UPrA6STtzVTqwdFo4e3PLLZKRoEpIoCE9HVGQSSv4Tg4U0wrOMW/dPtYk5nD58EB2rJzGNQkhZr9Hb6e+jVKu5I7hd5h+szoZZIoe7byMZXZsAOnqKoqrbGPSBNKhYmdGTYYGvL2lbLw9fSZQN2Zng15vF210f2ESOk0IwwJN170U/v44xcdRs7OngTpN0kotECCDXIN4acpL5J3L49n9z3Ytyxi20OqDiE1NaHJz7VeRWJQOuqYut/W3XBKGn5uS1T9m91huUiXEo6+qounkqbZS8nbPbGjSseq7LBa89Stn65t479YxvHHjyB5tu3PO5vDDyR9YPHQxPiof0x+gTpZ2XQrrNc8wcJnBpMmGq+oY7xiG+Qxjc+7mi36+iVklRPq7MtiEswBb0WcCdYOdtNF6bT0ZFUdorosgOtDNrGe4zZiJ5sgRtCVm9jVsboSyrB7LHu2ZGDKRe+Lv4dsT3/K/nP91fqH/MFA4Q0ESjXl5oNXiNNROGR9GpJ2pHOUsmx7BgfxKfsur6NFwrYUvqanSCrWxSurqDew/UcEVa3/hnV9OcMPYgSSunGaRLfdbqW/honDhtmG3mX6zrlnK0LGyPm0g0t+VMBubNIFUqZhzNofMyrbktaoGLQdOVPZK2QP6UKButJM2eqj0EDpRh64+gpgAMwP1zBkA1O7ebd4kSrOkTh0W3s7eHX83k0Im8WLSi2SUd2LeJHeAYKnwxe4ViepkKY/creut7aJxAwnycOKVn3q2qnYMD0fm5iblU7d8SDacPsyTW46w6N39iMBnS8az6toR3ZaBG0NGRQY7T+/k1thb8VCa0aigNAOaG2wWqAVBYHZsAL/nlVOjsUC/TiO5IvwKlHIlW3LbDhUNJkyzhvYHaruisZM2mlSchAw5Dk2DGeDdcQ+77nCMiEAxcCA15lYpmlg6biwyQcaLk1/EV+XLyp9XdnhAA0g6dXE6mowjCM7OOIYNsug8jEZ90Ki0MyeFnL/NiOLQ6XP8nG2+HYIgk6GKi5MCtf8w9IKcz7dtZ2PSaZZMGcwPD0xlYoTlqt/ePPwm7o7u3Bx7s3kPsIJjXnfMGhqAVifyS065zcZ0d3Rn9qDZfHeizajpp8wSfF2VjOwlJkwX0icCtajV0piTYxdtNKkoCZUYQZS/t9kGL4Ig4DZjBvW/70dXa4Z5gI0HUwAAIABJREFUUHE6OLqBl+VboXk6efLKtFcobSjl8X2Pd2zeNGAc6JvRpKXgFBODILPDr111kVTsYmQQun5MKAO8VaxJzOnRqloVH09jTg4PfXaIbF0wscJJNt87iSevikXlaLnKt9TSVPae2cvtw2/HzdG8nRsFyeDiD54DLTav7hg9yAsvZwWJmcU2GxNajJq0New4vaPVhGnWUH+T0yBtRZ8I1I15eYh20EarGqvIqsyisWYw0WbKHgbcZs5A1Gqp27fP9JuL0iV/DysFyBF+I3h07KPsO7OP99Lfu/iCkDGIIjQeP2lf2QOMTjtTyGXcPyOKI2eq+MlMDVUURdLcQ0Gv58S+g4iBcYxzKrCKdeabqW/i7eTNTUNuMv8h6mTp/bHhrlMyaQqwqUkTwJjAMYS6hvJ17tfsPyH5Y/dWfRr6SKC2lzaaUpKCXtRTXTnIbH3agGrkSOSenqbLH3odlBy16EFiR9wQcwNXDr6SN1Pf5PfC389/0S2AJmEA+katfSsS5Y4mGVItGBlCuK8La37KQa83bVVdXKVhyccHWZ4ulY2/MEQgduRkhNoSqajEgiQXJ7O/aD93DL8DZ4V58hr1lVCZZ/WKxI6YHRtAtaaZ5HzbmDRBO6Om4gN8fTQdlULOpMjeY8J0IX0jUGdl2UUbTS5OxlGmRKcZ2OMVdatJ055fELUmHLxUHAdtvcX16QsRBIGnJjxFuEc4j/7yKMV1529lG8UIwM4ViUHx4GB86puDXMYDs6LILqlh+5Eio+4RRZGNSaeZvWYP+46Xs3zBaBSDB+NyPKtds1vLdXwRRZF1h9fhp/LjhpgbzH+QHfRpA1OjfVE6yMzeuZjLNZHXICDwc+F3TI3uXSZMF9I3AnVmpl200QPFBwhyGgqig9mpee1xnTkDfVUV9YcOG3+ToRrOBgUMzgpn1ly6hkZdo2TepGv7QNHUuIFMROlv5oqvJ+i0UHjYrCA0Ny6YmAA3Xt2RQ3M3W/OT5XXc9N4BHt98hOEhHvy4fCp3TgnHucVJTzR0SylKNee76JDfC3/nUOkhlsQtwcmhB7nP6mQQ5FLVpo1xdpRMmnZk2c6kCSSjpjifcTQ6HWDGkN67moY+EKhFvZ5GO5SOV2oqyT2bi4s+BlelA8EePS8gcJ04scWkyQT5ozgN5Erwi+n+WgsQ7hHOM5OeIa0sjTUpbeZNmpJGlB5ahBLLBSmjKTlqdtqZTCawYnYUJ8rq2Jpa2OE1Or3Ie7+cYM7aXzh6popV147gsyXjGdTi66JKSEBXWYm2vFo60LVQD0VRFFmXuo4glyCui7quZw9TJ0vVk1300rQms1pMmo4V286kCcBbNxmZogp375M2HddU/vSBWnv6NPr6eptro8nF0layvmow0QGuFkkLlLm44DJhAjU7TTBpKkoH/6EdeltYizlhc1g8dDEbsjbwQ/4PUuf3E2dw8tZ32ZncahhMoczc1l8+LJBhwe6s3Zl70YFXdnEN1771K89/lyVZd66cxo3jBp7381YlGApfWvKpLSR9/KL+hSPlR7g77m4c5T1omaXXgTrFLrKHgZlD/REEbF78knNyIHLRhR0F22w6rqn86QO1JqvlINHG2mhSURIuChcKir2JsYDsYcB15gy0ajWNOUaYNIliW+m4jXlw9IPE+8Xz1G9PcSI3Cd3ZsziFBdonUBckgWsgeISadbsgCDx4WTSnK+vZlCJ1CGlq1vNqYg5Xv7EX9dkG3rhxJO/dOobADnZOyshIBGdnqUIxKF6qTmzomUOfXtSzLnUdoa6hzIuc16NnUZYNTTVWN2LqCn+3FpMmGwbqgsp6jhU1MMJjBrsKdnFW03tNQf/8gTozExQKlJGRNh03qTiJET4jOVevJ8rfcoHa7dJLQRCMkz+qCkBzzuoZHx1hMG9SypX8Z9OTADgNj4fCVGhusu1k1MmSEVMPdjWXxviTMMCTN3bmkpRfydVv7GXtzlyuGhFE4sppzI0P7nTXJDg4oBoxQip8CTQcKB4xey4AO0/v5FjlMe5NuBeFrIe7JTseJLZndmwAR85UUVRl2Y7tnbGjxWPkr/E30KxvZvuJi42aegu9J1A31sC2ByDLslsQTWYWyqhIBEfLdlPuipK6Ek5WnyTUSUoFs+SK2sHPD1WckSZNrQeJtl9Rg3RY89LUl1CdKEIUQDlmmtSLr6RnQcok6srhbH6Pg5BhVV1YpWHhO79To2nmv7eN4bVFI/F26f53SxUfj+bYMfReLWcFPZA/9KKet1LfYrDHYK4cfKXZz2lFnQQqb6mPpB0xmDTtsNGqOjGzhCh/V6aHxzPcZ/j/t/fm4VHVZ///68xkMpnsewIJJEDCDgn7pgKJUK0WAbWtrda91oKorfZr18f++vTpbrWutbY+rdVWH0nAKi6goLhAArInZGEJZJnsyySZfc7vj5MJCZlkZjJnluB5XZeXdeYsdyfJPZ/z/tz3+6aoeqhRU6gQOolaEwk1n8EH/y1pZjIgimJQ5vOV6CXzH61N+qP0tTTvYqILCzEdP4610c0vdMMRcFpsBoll45ex2pRNfQL8X1jfmKvzAZQ/ZFwtXpaTzE2LJ3Lrsizee/AKCqZ73iChy88Dmw1TTZMkw/iwoViqL6W6o5q759yNWiVDSVntAenzCYb17ACmpEjOdTvLR2k+5gWdvVb2n2njyr4vhw25G6hqr6KsNTSnDIZOolapYfUPofkkHC+S5ZK2xkbsbW0B70gs0ZcQp42jvT2JxKhwkqPlXc3HFKwGPDBp0h+F5KkQHoSSuAGk1/XSMymV3xz/M8cSxgdWp64tBVUYjMv3+VKCIPCrjXP4+XWzifHSROmCk17fnoEPK+qiqiJiwmNYk7Vm1Nfox9gh/c0FWfYA6fO9ckZqQEyadlc0YXeI/d2IV0+6mgh1BEVV8uQeuQmdRA0w4zpImw17fuX1IFBXXOhIDPxG4qK0RVQ19chW8TGQ8ClT0GRNdC9/NBwNSP30SNja27E16Fl4xVdJ1aXy/XgdHXUlgQugtlT6nQryl1VYUhKaCRMuOOk1V4DVey2209zJrppdXDPpGt/qpp3UHZT+HYSORFesmZmO1S7yYeXozbA8YWd5IykxWvIzpXZ+5xffjjM7MNoCo5F7Q2glapUKVv9YamU9+m+fL2cqLwNBIGJaYGqIAWoNtdT31LM4fTGVjd2yyx7gNGkqpHffCCZN3c1gqA/KRuJAzH1VN/Fz5vHYqsdoEew8Em7EYQiACY/DHlB/ZXfo8vIwHj6MmDYHRDs0ev+Y/faZt7E4LGzI3SBPULUHAAEyFshzPR9ZkJVAYlS4X6s/zDa7SxOmDbkb6LZ2s6tml9/uPVpCK1EDTLta8i/e8xufqwNM5eWEZ2ejigpcEb9Tn86Kmku32eaXRA0DTZr2uj5A7x9rU29xlkdqZ8xgVvIsHsm9iU8idfx5/2/8f/OmcrB0B7XsbCC6vDxsTU3Y1H2T6PXuh91eTHF1MdMTpzMzSSY5r7ZUqrOPiJXnej6iVgkUTE9ltx9NmvadbnNpwrQwbSETYiawrXqbX+7rC6GXqAUBCn4Mnefg0Es+XcpUVhbwjcT9DftJikjC1CO1pMpZ8TEQ3bx5qBMShpc/+is+PDch8gemE2WEjRvXP/n9xgVbuLa7l2frdvFp3af+vXn/RmJoPNbr8iWd3HimGSLiPZpKPpCKtgrKWstYn7NenoAcfQ1IIfL5OHGaNJX4yaRpZ5kenUY9xAtcEATW56ynRF/C+a7zfrn3aAm9RA0wpRAmLIWPfg/W0Q2+tLW3Y6tvIGJW4DYSRVGkVF/K4nGLqWzqBmCqjDXUAxHU6j6Tpg9dmzTpj0q+wroEv9zfUy6e/C6ER/JTzQSmiBr+396h5k2yUnsAIpP84sM9GiKmTUXQaqUNxfQ5Xld+FFcXo1FpuHbytfIE1HZKqrMPEWnIyeW5kkmTP+QPURTZVdY0rAnTuinrUAkqiquLXZwdPEIzUTtX1YZ6OPjiqC5hPnkSCGxH4pmuMzQbm/v0aQPpsRHERfqvdTu6YDWOri56D34+9M0Q2Eh09PRgOXt2yM8gMnMxjzU2YXVY+f6e7w8yb5KV2hLIDKy/8kgI4eFEzJrVt6GYB01lHm+aW+wW3jz9JoUTC0c3ZssV/U8coSENOXGaNO0sk9+k6VhdJ/ou07CTxtOj0lk+fjnbT23HLlOZsByEZqIGmHSF9M/ex8Di/VQTZ8VHIKe6lDRI+vSS9CVUNhrITYv26/2iV6xA0GqHelSbuqTVkgwlab5gqqgAURxadZO5iElGA//fjDs52nKU3x/4vfw3N7ZDS2XIPdbr8vMxlZXhSJ4FNpMUowd8cP4DOs2d8m0igpSotbFSCWeIsWZmGnUdRsob5DVp2lXWiEqAgumpwx6zMXcjTb1NfFrvZ2nOC0I3UQOs/gn0NEGJi6khbjCVDdZGA0GJvoRxUeMYF5VBVWO3z8MC3KGKjCRq2TK6LzZpajwu/TvIFR/95ZEXf1lOkB6119pU3DLzFl45+Qpvn3lb3pv3l52F1mO9Li8P0WLBbOj7EvdQpy6uKmZc1DiWjlsqXzDnS6Vqj2CMRnND4Yw0v5g0vVfWyMLsxBG7SVdlriJBmxBS8kfo/YQGMnEJ5KyBT56QWsy94GJt1N84RIekT6cv5ny7EbPNIYsHtTuiCwuw1tVhrhywMgugB/VImMrLUCckEJZ+0WNmfBZEpUBtKQ8ueJB5qfMk86aO0/Ld/Hyp1JWZMV++a8pAv5NeTRuE6TxqfGnobuCz+s9Yn7MelSDTn6y5W5o6HiIVMReTEiMNmt1ZLt8exvm2Xk7qDf2t6sOhUWu4dsq17D6/mzZT4KbOjERoJ2qA1T8CYxvse87jUxy9vVjOnAmoPl3VXkWHuYPF4xZT0eep6+8VNVwwaTK8P0D+aDgiJcIY1zpcoHC27w9p+BEEaaVbW4pGpeF3V/wOXZiOB/c8SK+1V56b15ZC6kzQ+v9n4A2atDTCxo3DeOSY1NrvwYbitlNSudh1OdfJF0j9IRAdIffEMZA1M9M5XtdFfYc8DSjO1bknsxE35GwIKaOm0E/UGfNh2jXw6ZOS7ugBppPDaKN+xFk/vTh9MVWNUqL2t0YNEJacjC4vj+4PBrST649Km1VB3EQTLRbMVdXD/wwyF0ljwnrbSItK47dX/JazXWd59NNHfd9Acjig7kDI6dNOdH0TX/pbyR3D1ws7RAfbq7ezZNwSMqIz5Auitq87NEQaXVyxZqakIztd7nzFacLkHOgwErkJucxJnkNRVWgYNYV+ogZpVW3uhM+e9uhwU7nU8RXIFXVJQwlZsVmkR6VT0WhgQqKOyPCwgNw7uqDggkmTzSx5NwRZ9jBXV4PVOrz85FzJ9Zn6Lxm3hM35m3n77Nv86+S/fLt5axWYOkN2tajLy8NaV4dNNxnMXdBxdthjS/Ql1HXXsSFHxk1EkD73pFyITJT3ujLSb9Ikg07d0Wuh5GybV5PGN+RuoLqjmhOtJ3y+v6+MjUSdPhtmbYB9z0JPq9vDTeXlrrVRP2Fz2DjQeIBF6VJiqGw0BET2cBJTWABA9wcfSCVfDlvwNxLL3VTdjJ8nacgDDJrunHMnKzNX8rsDv+NIs/dde/2EaNmZk36Dppa+Da0R5A+nAVNhVqF8AYhiX6NLaH6ROREEgTUz09h3upUuH02a9lQ0DzJh8oSrsq8KGaOmsZGoAVb9UJqm/cnjbg81lw2jjfqJ8tZyuq3dLElfgsXm4HRzj99ax10RPnky4VlZUpdiQ4i0jpeVo4qMJDxrmMnv2mhInTUoUasEFb+87JekRabx0IcPjX7iRm0pRMRBUmCHRXhKxKyZoNFgrGmXnP2G2VDsNHfyfs37XDPpGrRqz6enu6X9LPQ0h6w0NJA1M9Mkk6YK30yadpY1khqjJa/PhMkTYsJjWJu9lrfPvB10o6axk6hTpsGcr0qleobhH4VEiwVTVVVQ9OmF6Qs509KDzSH6rXXcFYIgEF1YSM/+/djPHJRqY+OzA3Z/V5jKytBOnz7y5PcJi6QyugEabZw2jj+s+gOtxlYe2fvI6JoOzpdCxsKQLDsDUGm1RMyYgfHocUiZPuyKeseZHVgcFjbmbpQ3AOcMyRCt+BjI/IkJJPlo0mS22dlT0UThjLRBJkyesD5nfUgYNYXmb/JwrPwB2C3w8WPDHmI+dQqs1sA2uuhLyInPIVmXTGXfRmIgV9TQJ39YrfTsOyi1JwcxSYl2O6aKCvflkZmLJI22pWLQy7OSZvHDJT/k0/pP+fPRP3t3c7NBkn9CPAnp8vIwHj+OmDJ72Frq4qpiZiTOYEaSzL/LtaWgiYKUwPrgjIZ+k6aK0Zs0fXaqlR6L3W1ZnisWpi1kYszEoNdUj61EnTQF5n0TDvwNOmtdHnLBgzowNdRWu5VDTYdYnC4lhspGA2qVwOSUwDn2gdTxpk5IwHBcH/SNREvNOcTeXvebuf0bikMHCdyQewPrpqzjuSPP8XHdx57fvO5zQAz5x3pdfh6iyYTZPl5q6rrI9vVk20nK28rlM2AaSG2JVE2lDsxmt69cOTMNg8nG/tOjq2neWdZIZLiaZVOSvD7XadRUqi8NqlGTx4laEAS1IAiHBEF4058BueWKh6XNkI9ctx2byt1oozJzrOUYRpuRxeOkRF2hN5CdFIk2TIYRSV4gqNVEL51Hd51GWqUFEVNZX9WNO/kpKUdykXORqAVB4CdLf0JuQi6P7H2Ehu4Gz27uvFYIl50B6PKk9v7e5r7fk4vkj+KqYsJV4Vwz+Rp5b2w1SoN1Q3wjcSBOk6bRlOmJosiu8kauyE1xacLkCaFg1OTNivp+oNxfgXhM/ERYcKtkgdp+dsjbHmmjMrJfvx8BgYVp0gqustEQUH16IDGzUnFYVfQ2B3elZCrvm/w+ZcrIBzobX4aZoagL0/HYqsewO+x8/8PvY7F74E9eWwrJ04LuGugOTcZ41MnJmM72rRIHyB9mu1l+AyYnDUekqqAxlKgjw8O4PHd0Jk3H6jpp7DJ7Ve1xMWlRaawYv4Lt1cEzavIomwmCkAlcA7zg33A85PKHpN3yD3836GXR4cB88mRAW8dLGkqYnjidOG0cRoudmrbegOvTTqJSexHUIoaDVUG5vxNzeTkRubmeTX7PXCTVfZs6Xb6dFZvFL1b8gmMtx3js4PB7E8CYKTsD6YlBl5+H8ViZNP17wBCB3ed202XpkteAycn5vkaXEJeGLsZp0lTW0OXVeTvLGvt1bl/YmLuRJmMTn9R/Muwx7a+9Rv2Pf4xo8W3giSs8XXY+DvwAGFbNFwTh24IgHBAE4UBzs3/nnRE7DhbeCUdegZbq/pctNTU4PNFGZcJkM3Gk+QhLxi0B4FRzN6IYmNZxV6jaThCVpaX7gz1B66YSRRFTWTlaT6tuJiwCxD5t2TVXZl3J16Z9jX+d/BdnO88Of632M9DbOmaSkC4vD0tNDbaYGYOkj6KqIsZHje//vZKV2lLJayXat8QVaAqmj86kaWdZIwuzEkgYwYTJE1ZmriQxInHY6S+iKNL+z5cxV1Z5tkDxEreJWhCEa4EmURQPjnScKIrPi6K4UBTFhSkpKbIFOCyXPQhhEfDhr/tf8lgblYnDzYexOqz9G4lOj4/cYCRqUQT9UWIW5GCtr8dcUeH+HD9ga2jA3tHh+ZdlxgJAcDuZ/N68e9GqtTxz5JnhD3JKKCFe8eGkv/GlNxU6asDYTn13Pfsa9slrwDSQ2gNj5vMZSEqMlvkTE7xK1E4TJl9kDycatTSwYTijJtPxE5grK4m/XuZSyj48+U1YAawTBOEs8G+gQBCEf/olGm+IToEl98Cx1/uHhJrLyz3TRmWipKEEtaBmfprk0FbZaCBcrSI7KQgTrzvOgamT6JUrh5o0BRBnR6LH8lNEnFQj7yZRJ+mS+Mb0b/DOmXeoah9G2qkthfBoqTZ5DKCbPRvUaoxNfS/oj7G9ejsgswGTk85aaRjHGJCGXHHljDRO1HdR56FJ03temDB5gtOo6c1TQ+spOoq2Imi1xF4j8+ZvH24TtSiKPxRFMVMUxWzg68AHoije7JdovGX5FukPc8+vAKk0z2NtVAb26/czO3k2URqpFK+i0cCU1GjC1EGoeuzrbgubvnyoSVMAMZWVez/5vc9JDzdyzW2zbiNSE8kzh4dZVdeWSmVnqsBW3IwWVWQk2mlTMZ5pAcBRf4Rt1dtYOm4p46PHy3/DEJsh6S3OhPu+h9Ufu8oamZrmmQmTJ+Qk5DA3eS7F1cWDpEWHyUTXm28R86W1qGP88zQ9tuqoLyYyEZZtgvI3EOsPYyr3Qhv1kR5rDydaTvTLHgCVegPTAuCY55KGI5J3RupMogsLMJ04gVXvx3mEw2AqLyd80iRUkV48VWQukpwRW0+NeFh8RDy3zLyFXed2Ud56UQGSpVcamBCi/h7DocvLw3TiJGLUOPbX7aW+p94/m4ggyR5hEZAW3IHHoyUnNZrJHpo0jcaEyROcRk3HW473v2Z47z0cBgPx198g670G4lWiFkVxjyiKMk3WlIll34WIeGzbf469vT1gG4kHGw9iF+399dMGk5X6TlNw9GmQNqOSp0F4JDGFkoGP4YNhJpT7kVFNfh+h8eVibpl5C7HhsTx9+CInxYbDY67sDKRE7ejpwayZRnFXJbHhsRRMLPDPzWpLpfFsYYF54vQHnpo07a5o6jNhkteY7arsq9CF6SiqvmDU1LG1CM2ECUQu8t+TytheUYOkca7YgulzqWwmYkZgSvNKGkrQqDTkp0iNC5WN0tTxYFV8SB7UUkeidvJkwrOz6X4/sIna1t6OTa/3vjwyZRqEx3iUqGPDY7lt1m18WPvhYIe9MfpYH5kv/f60dcbwfpiNa7K+JK8BkxObBeoPj7nP52KcJk173Jg0OU2Y5mbIW4ceHR7Nmqw1/UZNlnPn6N2/n/jrN/q1d2PsJ2qAxfdg6pZ+IBHTvdBGfaBEX0J+aj4RYREA/R4fQWl26W4CQ8Og1vHowgJ6SkqwG+QdDjoSo666Uakhc8EFM3s3fHPGN0nQJvD0oQGr6vMlkDAJopK9u3eQ0WRloY6L43RNCxZBYGOCn7pK9cfAbh6TFR8DmeeBSZPZZufDimaunOm9CZMnbMjZQI+1h501O+koLgaVirj1fmj1H8Clkai10ZjIJTzWiqr5sN9v12nu5GTbyUH6dIXeQGS4mox4nd/vPwRnDe4Aa9OYwkLJpGnv3oCF0Z+oRyM/ZS6CxhMeTZyP1ERy55w7+azhMw7oD1xodBmDSUgQBCLy87BXNzDDbGF69yitXd3R/8QxtqShi3E2r+w52YTF5rqt49M+E6Y1M+TVp50sSFvAxJiJbKsoorN4G1GXrUDjZ+/7SyNRA6aGXiJSwuCD/3ZbPeArB/QHEBEHbyQ2GshNi/HLN7hbnF1t6Rc2iXR5eagTEzEEsPrDXF6OZvx41PGee/72k7lImuFXf8ijw7867ask65J56vBTiB3nobtxzCahnqkZpDZZuKHT7vFUcq+pLYHYDIj1QzVJgFkzMw2D2UbJGdcmTbt8MGHyBEEQ2JC7Acu+Umx6vV83EZ1cEola0kYbiVh4BdR8Aqf3+PV+JfoSdGE65iRfSIyVjd1MTQ1WxcdRqdtMdyFBCmo10atW0f3RR4hW36ZjeIpXHYkX40yy5z2TP3RhOu6eczcHGw+yr/zffdcYm/rr3nipkHpld6ZHU8lHxRhprfeEy3NTiNCo2Fk2tKrJ4ZBMmFZOHb0Jkyesm7KOwqMilpgIYlav8tt9nFwSidrsbLJYczPEZsLuX/p1VV2iL2F+6nw0ag0Ard1mWrrNQTNjouGIy9FbMYUFOLq66D1wwO8h2Lt7sNTUjL7qJjIREqdcMLX3gBum3kB6VDpPnf0PYpgO0oLrGjgazHYz/1YfRBRA1ZUoNW/ZZf5iNTRKDVGXSKLWhau5LCfFpUmTHCZMnpBo1rCoCj6ercYe5v80ekkk6n5tdPZcWPmwtHqoes8v92oxtlDdUd0/HxEuVHwExYzJ1Cl5XLgYvRW1fDlCRIQ0osvPmCtOSpPffam68bDxxUm4Opx75t7DUWsHe8dPh74vzrHE+zXv0yx048jOwKi3SRt+LZXy3uQS0acHsnZmGvWdJk7UDzZpksuEyR1db7yB2i7y1iwTn9Z/6td7wSWTqMsJGz9O0kbzvwkJ2X5bVR/QX5ia7SSoFR/6vsL79KGJWqXTEbV8OYYP3ve7SVP/wIZZPiTqCYskE/2Ocx6fcl321WRabTyltQXNiMoXiquLyYjOIHHBUozVDdKvrNw6dW0pqDRBn6MpJwUzUl2aNO0sa2RRdgLxkf6rFRdFkY6tRWjnzKZnQhLFVf73qb40EnV5+YXaXbUGVj4i/bKflH/GwX79fmI0MUxPvOAnUdFoIE6nITXGD/Wv7nBqmsNMHY8pLMBW34D55Em/hmEqL0edmEhYqg8rGS8aX5xoGsv4Tkcn5bZO3j8XHH+T0VLXXce+hn1cl3Mdkfn5OAzdWIzRI04lHxW1B6TfD02EvNcNIsnRQ02azrX2UtFo4Eo/VXs4MR0/jrmykoTrb+Ark7/CnvN7aDW2+vWeYz5RO3p6sJw9O1gbnftVSMqF3f8zaHCqHJQ0lLAgbQFhqgvm/FWNBqamRQds6vkgGo5AVCrEuC4P6jdp8nOXoqlchsnvqbNAE+lVoqa2lGu6e8iOzuTpw0/jEOX9efuT7dXbERBYP2X9BSc9y0R5NxTtNqj//JKSPZysmZlGWcMFk6adfR4ga2XuRryYjq1bESIiiL3my2zI3YBNtPHmaf8OvhrzidpUUTFUG1WpYdUj0pDTE0XDn+wl+h495wzn+tvGQXoMqtAbgjYsgIajIz7ShiUno8vP92uXosNiwSzH5Hd1GIyf73WiDoubwHfnb6G6o5qaye6YAAAgAElEQVR3z77rWwwBwu6ws616G8vGL2Nc9DjCp0xBFR2NsTNGak6Ra4HRdAKsvZdsogapHA9gZ5meaWkxTPSje6XDaKTrzbeI7TNgmhI/hbkpcymuKvar9Db2E3X/MNuLksSsjZA6U3LWs9tkuVeJXiodG1g/3dhlpstkC44+bTVJ01GGkT2cxBQWYCorw9rg4dxBLzFXVYHNJs9kncyF0peP1eTZ8X1lZ1/K/hI58Tk8c/gZbA55ft7+ZL9+Pw09DWzIkQyYBJUK3dy5GOvM0mT29jPy3OgS3Eh0MiUlmskpkklTR6+F0rPtfq/2MLz3Ho7ubuKuv77/tY05GznVeYpjLcf8dt+xn6jLyyRtNO2iH5BKBat/BK3VcOw1We61v2E/8dp4chNy+1+r6NtIDMqKuukEiHa3U8ejC/xr0tRfHimHIVbmInBYPdtQ62qAzvOQuQiVoGJz/mbOdp3lrdNv+R6HnymuKiZOGzfIgEmXn4e5thmHVZBP/jhfKklj8RPluV6I4TRp2n64vs+Eyb+JumNrEZqJE4lcdOGL70vZX5KMmqrke3q/mEsgUY+gjU6/VpIF9vza59pUURQp0ZewKH3RoMkblfogJmoXreOu0E6eRPikSX6TP0xl5aiiotBMlCEZeLOhWHdg0DkFEwuYkTiDZ488i9URmCaf0dBpljY+r5l0DeHqC9UJuvx8cIgYOyLk21B0NroEY/8kAKydmYbNIfKH9ypIi9UyR2YTpoFYzp2jt6SE+I0bB+Wb6PBo1mat5Z2z79Br7fXLvcd0ohYtFsxV1cNro4IAq38ijTk65NtQmlpDLfoePUvSB8+xq2w0kBytJdHHmWyjQn8UtHFSOaIbYgoL6Ckt9YtJk6msDO0MmSa/x6RJqz9PDJrOl4A6vF/6EQSBzfM2U9ddN+xsu1DgzdNvYnVY2Zg7eGxTxByp09VozJBnRd3bBm2n+uZSXprkT5BMmrpMNgpn+MeEyUlHUZFkwLRhqAHThtwLRk3+IGQStcFk5d5/HqTo81qPzzFXV4PVOrI2mrtGWlF89DvPdU8X7NfvBxi0kQhSop6WHsTW8fQ5Hq2WogsK/GLSJNrtmCoq5LWXzVzkWYdi7QHpaSLsQlnk5RmXMzdlLn8+8mfMdrN8McmEKIoUVxUzI3EG0xIHOz2GJSQQnp2NsT1Skn583ZyqHfzEITdWvZ6G/3oUa1OT+4P9hFolUDhDKgn1p+wh2u2SAdPll6G5WGYF5qfOJys2i+Jq/9RUh0yijtaGca6tl8d3VWG1e7bjbfJEGxUEKPgJdNXB538fdXwlDSWk6FLIjs3uf83hECWPj2DIHnabNNHEzUaik36TJpnlD0tNDaLRKO/AhsxF0s+rs274Y+xWycDpoiQkCAL3zbuPxt5GXq98Xb6YZKK8rZyK9oohq2knuvx8jHU9iN3NYPBxQk9tCQhqGD/Pt+u4QLRYqLv/ATpefZWWJ5+U/frecNvySazPH89yP5kwAfR88gm2xkbiB2wiDkQQBG7IvYEYTQxWuS0ACKFELQgC3187lXNtvWw96Nmq2nSizDNtdNJKyLoM9v5BGtnkJU59evG4xYO0qdp2I0arPTjDAlqrwGbyuNtMUKuJXi2/SZPphB8mvzvHaY2kUzceB5vR5WpxSfoSFqYt5IVjL2C0eTYINVAUVRWhVWv58uQvu3xfl5+HvcuItUftu/xRWwppsyBcnpmBA2n83e8xHjlCxJw5dBQVY6mpkf0enjJzfCyPf30e2jD/mTB1vL4VdWIiMatWDXvMbbNv48nCJ/s9gOQkZBI1wOppqeRPiOdP71dhttndHm8qL0c73QNtVBCg4MeSFeaBv3od1+nO07SaWofo0/0VH8EozXNuNrmp+BhITGEhDoOB3lIv6pTdYCovR5B78nv6HFBrR07UIzzWO7XqFmMLr558Vb64fMRkM7HjzA4KJxYSGx7r8pj+xpeWcN9ayR12qD3oF9mja8cO2l96iYRv3ULm008haDS0PDPMwOFLAFtbG4bdu4lbty5gg7MvJqQStSAIPLR2GvWdJl4tPT/isf3aqKe1u1nLYUoBfPxHMHu3oba/QdKnBxoxwQWPj9xg2Jvqj0qDSpOnenxK1LJlsps0mcrL0E6diqCRcRURFi49KYykU9eWQnQ6xGW6fHtB2gKWj1/O347/jR6r+2EEgeD9c+9jsBiGlT0AtLm5CJGRGHuSfUvUzRVgMcieqM2nT9Pwk5+iy88n7aGH0KSmkvCNb9D5nzcxnxp5OPFYpfONN8BqJf764X9u/iakEjXAipwkFk9K5KkPqjFZh19VW2rOIfb2eqeNrv4J9LbC/j97FVOJvoSM6AwyYwYnhcpGAxnxOmIiguDa1nBEauhRh7k/tg+VTkfUihUYPvhAli4qURQxl5XLK3s4mbBY0qBtFtfvny+RmmNG2EjdnL+ZdnM7r5S/In98o8BpwHTxF/5AhLAwdLNnY2yL8E36cD6NyDj1xtHTQ+2WLQhaLRmP/7F/dZl0152oIiJofuop2e4VKoiiSOfWrUTkzUWbm+v+BD8RcolaEAS+v2YqTQYz/9w3vO41qvl8mQtg6tXw6Z/A2OHRKQ7RQam+dFA3ohOpdTwIq2lR7Btm670bWkzBamwN8pg02errsXd2ovXH5PfMhZLlZ6OLbq+eFqlzz00SmpMyh5WZK3nxxIt0WbpGPNbf1Bpq2d+wn/U56wfV4btCl5eHSd+Lo+UcGEc5mqu2FHQJkDh5dOdfhCiKNPzXo1hOnSbjD78fNHoqLDGRhG/dguHtdyRLh0sI07FjmKuqid/oehMxUIRcogZYMjmJy3OTeXbPKXrMrtuBTeVlo9NGV/9I8nDe55mmVtFWQZela8gqyGp3cLq5Jzj6dEeN9P/Bw4qPgUSvWiWZNMkgfzirbnRytI5fTH/jiwv5w4uys035mzBYDLxU9pKMwXnP9lOSAdN1U65ze6wuPw/sIqb28NE3vsjc6NL+r3/R9eabpGy5j6jly4e8n3T77ahiYmgOcgWI3HS8fsGAKZiEZKIG+N6aqbT2WPjfT8+6fN9cXj46bXTcXJixDj57RmoIcIMrfw+AmtYeLHZHcCo+nNqlCw9qd4QlJaGbNw/DB75bgprKykGlQjvND5Pf4zIhZrzrDcXaUlCFwbh8t5eZkTSDNVlreKnsJTpMnj1FyY3TgGn5+OWMix7n9vj+DcVWzejkD2OH5AGTKY/sYTxyhMZf/ZqolVeQdM89Lo9Rx8WRePttdO96H+Ox47LcN9g4jEa63nqL2C99CXV0kHol+gjZRD1vYgKF01N5/qPTdJkGl5OJoojJF2109Y/A0g2fPOH20BJ9Cdmx2aRFDS5yD+pUl4ajUn1s2uhWsjGFBZjLyrHW1/sUhqm8nPBJk1Dp/DR5PXOh6xmKtSXS2K1wz1zSvpv3XXqtvbx44kWZA/SM/Q370ffoWZ87tKPNFWHJyWgyMzF2xo1uRV3/ufRvGWZI2trbqX3gQTQpKWT85jcjVlglfutbqOPiaH7yTz7fNxToevddHD09xN8QXNkDQjhRAzy4ZiqdRit/+3iwk5itoQF7R8fotdHUGTDnBih5HrqH76qyOqwc0B8YNM3FSYXegCBATrAqPlKmgWZ0CTK6QDIC8nVCuamsTB7HvOHIXCTJPAN/Rg471Hnnr5yTkMPVk67mXyf/RYuxxQ+BjkxRdZFkwDShwP3Bfejy8jC2jHJFfb4UECBjvvfnDkC026l/+AfYW1rIeOIJt9Pl1dHRJN19Fz0f7aX3c8+myYcynVuL0GRNRLcw+EOTQzpRz86I46pZ6fx17xk6ei/s/suija58BGxmqVxvGMpay+i19brcpa9sNJCdFOXXScfD0nDUq/rpi9FOmkT45Ml0+yB/2NrasDU2ytuReDGudOrmk9LTkJdlZ/fm3YvZbuavx7yvo/eFDlMHH5z7gGsnXzvIgMkduvx8bAYr1ppq75u0akshZTpE+GZQ1PLsc/R8/DFpP/4RujmeDQ5O+MY3UCcl0fynsb2qttTU0FtaSvzG64MzEOQiQjpRg7Sq7rbYeP6j0/2vyaKNJudA3k1Q+lfoci0BlOolfdRVoq5oDFLFh6ERuvWj2kgcSEzBanpKRm/SNKwPuJyMz5e06IEGTU4pxEujoey4bNZNWcdrFa/R2NPo/gSZeOvMW1gd1n7faU/R5TsbX8Kg8YTnJ4qilKh9NGLq3vsxLU8/Tey6rxD/ta95fJ4qMpLkb99N77599Ozb71MMwaSjqFgyYFrvfvM3EIR8op6WHsNX5o7nfz89S0u3ZLJjKiuTRxtd+bDk57z3Dy7f3t+wn6kJU0mMSBz0uslq52xLT3A2EvWeWZu6I7qgEGw2uj/6aFTn95dHTp/u5kgf0OikLsWBK+raAxCZBAmTvL7cPXPvwSE6+Muxv8gY5PCIokhRVREzk2YOMWByR8S0aQjacIyt4aD3ovGltRpMHT41uljr66l/+GG0OTmMe/RRr1eU8V//OmFpaTT/6U9jcuCwaLPRWVxM9OWXuzRgCgYhn6gB7r8yF5PVznN7pM4npwe1zyRkw/xvwcG/D5l8bbFbONR0yGX99OnmHhwi5Aa14mOOT5fR5c1FnZQ0ao9qU3kZmowMt7qlz2QukjRp55QeH8rOMmMy2Zi7ka1VW6nv9m0j1RPK2sqobK9kY473HW1CeDgRs2ZjbNd5t6Ho40QX0WKh9sEHEa1WMv70BKpI78daqbRakr9zD8bPP6fn409GFUcw6fnkE2xNTcSFwCaikzGRqKekRLNxfiYv7auh4VwDNr1evk2syx8CQQUf/nbQy0ebj2K2m10mamfreFDGb+mPSl8wPuqPg0yaLMN0/42A3zoSLyZzMVh7pPmXxnZoqfBptXj33LtRoeLPR73rTh0NxVXFaNVarp589ajO1+XlYWoNQ6w97PlJtaWgjYXk0cmCjb/5LaYjRxn3y1+ineT9U4uT+OuvRzN+PM1PPDHmVtX9BkwrVwY7lH7GRKIGuL8wF7tDpPhVaQUoW5KIy4CFd8DhV6D1gldBib4ElaBiQfqCIadUNBrQqAWyk+R3JXNLwxGfNhIHElNQiKO7mx4vTZrs3d1Yamr805F4Mc4Ss9pSqDvY99roE3V6VDo3TruR7dXbOdd1zv0Jo8RkM7Hj9A6uzLpyWAMmd+jy8hDtIqaKKs8nFJ0vhYwF0ig6L+l86y3aX36ZxFtvJfaqL3l9/kCE8HCSN30X0/HjdO/2rbookPQbMF13XdAMmFwxZhL1hMRIvrpoAuf2S2U/smqjlz0oTQr58Df9L+1v2M+MxBku/8gq9QYmJ0cTHhbgj8/UCe1nfdannUQtl0yavJU/nO3nfq34cJKQDZHJkjZde0B6+vGx7OyuOXehUWl49siz8sTogl3ndmGwGkYlezjRzZMaeozNgmSy5A5ztzRHcxRfZObqahp++jN08+eT+tD3vT7fFXHXXYcmayLNf3oSUa6p6n6mc/sbYLMF1YDJFWMmUQNsXp3D5I46uuNT5NVGY9Jg8d1w9DVoOonRZuRoy9Eh01ycVDQayA1GxYe+z/dCpkStioiQTJp27/bq8fRCxccsWeIYEUGQPD1qS6SKj9SZoPVNckrWJXPT9Jt46/RbnOrwj+PbtqptZERnsDB99DW4mrQ0wlKTpHpqT5z06g+B6PDaiMnR00Pt/Q+g0unI+ONjsjkhCmFhpGzejPnkSQzvvSfLNf2JKIp0bH0dXV4e2pycYIcziDGVqMfH68gzNXE0Mp2aVpmtK1c8IBms7/kVh5oOYXPYhvhPA/SYbdS2G4PcOi6P9AEQU1AgmTT11aZ7gqm8HHVSEmGpKbLFMSKZC6VqhnP7ZOm2A7h99u3ownQ8c1h+H+XzhvPs1+9nQ84GtwZM7tDlL8DYqvWs8cW5kZgxVK4bDlEUafjpz7CcOSOZLclc5RD75S8TnjOF5iefQrS795gPJqajR7FUnyIuxFbT4EGiFgRhgiAIuwVBKBME4YQgCPcHIjBX2Lt7iG1t4GxCBk+8XyXvxaOSYOm9ULaNkuq3CBPCmJc6dIRRVVNf63iwhgVEp0lPADIRvXoVqFRemTSNOPndHzgf5a09svkrJ0QkcPPMm3mv5j0q2uR1fNtWvU0yYMrxvQZXl5+PtUeNrepz9wfXlkJSDkQmuj+2j/Z/vkzXjh2kbNlC1NKlPkTqGkGtJmXzfVhOnaLrrbdkv76cdLy+FUGnI/bLwTVgcoUnX/c24PuiKM4ElgKbBEHwY9/w8JgrToIoMmnpfLYdqqO6L2nKxrJNoI2j5OxO5qTMIVIztDSpUt9X8RGsGmqZZA8nYYmJfSZNniVqh8WCubrav63jFzN+vqRNg2xGQwDfmvktYjQxPH34admuaXfY2V69neUZy0mPSnd/ght0+X06dVkVjKTzOhtdvPh8jIcP0/jb3xK9ahVJ377b11CHJWbtGrTTp9P89NOINtdumMHG0dtL144dIWHA5Aq3iVoUxQZRFD/v+98GoBzI8HdgrnBqo9fesAqdRs3juyrlvYEugRMLbuKEo5fFqmiXU6ArGg1EaFRMSPS+vtQnrEZpQ0lG2cNJTEEB5vJyrHUjDJPtw1xZBTZbYErznGijIXWWVJKYJJ92GKeN49ZZt7L7/G6Ot8jj+PZZw2c09jZ63Yk4HBEzZ4BahbHRJnlwD0dHDfQ0eywN2draJLOl1FTG/+bX7sfZ+YCgUpGy5T6sNefo3L7db/fxha533wsZAyZXePXTEQQhG5gHDOkNFQTh24IgHBAE4UBzc7M80V2EUxtNyc7k9hWTePNoA+UN8hjCm2wmHjvwGN/Qv0Myar5S+iq8evOQSdCVjQZyUqNRqwLc/99YJnVR+tg67oqYQs9NmkzlfR2Jgaj4GMhlD8CqH42q7Gwkbp55M/HaeJ46LM90kuKqYuK18ayesFqW66kiIojImeR+huJ5zxtdRLud+ocext7WJpktxflWk+8J0atXEzFnDi1PPzOqun1/07l1K+FZWegWeK7vBxKPf+sFQYgGtgIPiKI4JDuKovi8KIoLRVFcmJLin00mU1lZvzZ69+WTiYkI4487fV9Vl+pLuf6N63nxxItsyNlA8df2kLX6Z1C9C55eDIf+2b+6rmw0BMfa1NlGLLP0ARCenS2ZNO12L3+Yyvomv0+YIHscIzLnBlj6HdkvG6WJ4o7Zd/BJ3SccavLN8a3d1M4H5703YHKHbuFijG3hiHUjNL7UloImSqqKcUPL08/Q8+mnpP3kx+hmB6ByB2lyU8qWLVjr6+nYujUg9/QUy9mz9B44QNz1oWHA5AqPErUgCBqkJP2yKIpF/g3JNf3aaN9KLi5Sw92XT+a9skaO1XaO6prdlm5+8dkvuOPdO3CIDl5Y+wKPLn+UWF0CrLgfvvOJ5Hu8fRO8tJ6u+ioau8xBqvg4Kj36x2f55fIxhQWSSVPXyE8o5rK+jUQ/PioHmq9P/zpJEUk8dci3VfVbp9/C5rCxIVce2cOJbt4CRLuA+aibYb8Z893O0Ozeu5eWZ58lbv164m+8UdY43RF12Qp0CxbQ8uxzOEymgN57JPoNmK4LDQMmV3hS9SEAfwXKRVF8zP8hucZc1aeNzrqwYrh9RTbxkRoe2+n9rv1HtR+xfvt6Xq96nW/N/BZF1xUN9Z1OzoFb34RrHoPag0T97XJuU7/D1NQA69MgbSSmz5VttNLFRBcU9Jk07R32GNFux1RZiTaQ+nQA0IXpuGvOXZToS/onznuLKIoUVRcxK2kWUxM8nwzvUXxOJ72yKpf7JliN0u+HG33aWldH/UMPo506lfT/+lnAV4/OVbWtqYmOV18N6L2Ho9+A6Yor0KSlBjucYfFkWbQCuAUoEAThcN8/Aa9fcdb5DtRGYyI03HPFFHZXNHOwxrMhoO2mdh7Z+wib3t9ETHgML139Eg8vehhd2DBOfCoVLLoTNu1DH7+ARzX/YMVHN3vWKSYXdptkdemHjUQnurw81MnJI3pUW86eRTQaiZgRlKIfv3LjtBtJjUzlqUNPjcqboqy1jKr2Kjbmyl+Dq8nIQB0XibHBAoaGoQc0HAGHbUR92mGxUPvAg4h2O5lPPO6/qTxuiFqymMilS2l5/i84er302fYD3R9/jK25OWQ3EZ14UvXxsSiKgiiKc0VRzO/7Z0cgghvIcNrorcuzSI4Od7uqFkWRt8+8zXXbruPds+9yb969vHbta8xN8TD5xWXyXMaveUS8D03HaXjuMvjwd557MPhCSyXYTH7Rp50IKhUxq1fR/dHeYTd7RjX5fYygVWu5Z+49HG4+zCf13ju+FVUVoVVruWrSVbLHJggCupnTJMtTV056HjjmNf3615iOHWPc//yS8Oxs2WP0hpQtW7C3ttL28stBjQOkTUR1UhLRIWTA5IoxIzSaysrRzpg+RBuNDA/j3lU5fFLdymenWl2e29jTyJbdW/jBRz8gIzqDV699le/mfxeN2rtW2cqmbirTrkbYVALTr4Xd/w3Pr5Jad/1Jvwe1/1bUIMkfju5uekpcmzSZysoRwsPRTp7s1ziCxYacDWREZ3i9qjbajOw4s4M1WWtGbcDkDt2i5VgMYdiqXEgz50ukvYto14/unf95k/ZX/kXi7bcTu3atX+Lzhsj584i64nLaXvgr9m6ZeyG8wNbaimH3HsmASaa2eX8xJhK1aLdjqqgYtsnim0smkh4bwWM7Kwb9gYmiyOuVr7N++3r21e/joYUP8c8v/3NUGqIoilQ2GiRr0+gUuPFF+Por0NMCfymAnT+TtEJ/0HAEwiIgKdc/1+8jatkyBJ2O7mGaX0yjnfw+RtCoNdwz9x5OtJ5g93nPHd921eyi29rtF9nDiW6h1Mhi+tzVVPYDw66mzVVVNPzsZ+gWLCD1ew/6LT5vSblvC/bOTtr+/vegxRCqBkyuGBOJ2lJTM6I2GqFRs6kgh9Kz7eytkoaXnu86z13v3cXPP/s5M5NmUrSuiFtn3YpaNboZh83dZtp7rYNL86ZfA5v2w7ybpYnmz66As34wSm84Cmmz3O7o+4pk0rTcpUmTKIryDWwIYb4y5StkxWbx9OGncYieOb4VVxeTGZ3JgjT/1eDqZs8GAXpPnh78RmcdGOpdGjHZu3uo3XI/qqgoMh6Tz2xJDnRzZhN9ZSFt//t37J2jq9ryBcmAaSu6/Hy0U6YE/P7eMiYStemEe230awsnkBGv4/fvlfP3E39n4xsbKWst47+W/RcvrH2BCbG+1f1W6qVHtCGlebp4WPckfGu71JDyv1+GN78HJnkacRBFyTXPj/r0QGIKCrE1NPTr0U6sdfU4OjsHVd1cioSpwrg3714q2yvZWbPT7fHnu85Tqi9lQ67vBkwjoYqMRJuZhKnOBL1tF95wzpO8qOJDMlv6CZaaGjL+8IeQrGhIue8+HAYDrS++GPB7m44cwXIqNA2YXDE2EnW5e200PEzFTSs0VIf9mt8f+D1Lxy1l23XbuGHqDbKUIVX0TXUZdvzW5FVw76ewbDMcfBGeWQaVMlg7tp8Fc6dfKz4G4jRputijOmgdiUHgquyrmBI3hWcOP4PdMbLjW3F1MSpBxbop6/wel27ODIytmsGNL7UHJFksbfBotvaXXsLw9jukPPgAUUvk80eRk4hp04j98tW0/eMlbG1t7k+QkY6tfQZMV4eeAZMrxkiiLhtRG7XarTxz+Bn+enYLYdo2Envu4PFVT5AWJZ/LXFWjgcSocJKjR+g4C4+CL/0S7twp+VO8ciMUfRt6XG9yeoSzbdjPG4lOwhIS0M0fatJkLu+b/D5V3hrhUEStUrNp3iZOd55mx5nhC5zsDjvbT21n+Xh5DJjcoVuyEodNhfnzDy+8WFsK4/Ih7MLvZe/nh2j87e+ILigg6a67/B6XLyRv3oxoMtH6wl8Ddk9Hby9db+0g9qqrUEcHYUrTKAj5RC2KIqay4bXRY83H+OqbX+XZI8+yNmst/2/236g5N5V3yxpljaOi0cDUtGjPVueZC+Gej2DlI3B8q9SGfrzIdbOCO/RHQVBLpkQBIqagEPPJk1hqL5g0mU6UET5ZhsnvY4TCiYVMT5zOs0eexepwXYL5af2nNPU2yWbA5A7d4hUAGA/1jSSzWaD+8CDZw9baSt2DD6IZN47xv/5VyLZEO9FOnkzcV66l/eWXsTY1BeSeXe+8i6O3N+RrpwcS8onaVt+njV6kTxttRn5X+jtufvtmuixdPFXwFL+54jd8fcEMclOj+ePOSuwOeYZqiqJIpd7gXet4mBZW/1BK2PET4PXb4d/fhC4XDQsj0XAUUqaDJsK783wgpkAyFBo4685UXh5Ya9MgoxJUbMrfxHnDef5z6j8ujymuLiZBmyCbAZM7wrOzUevUGCv7Zj3qj4Hd3F/xIdrt1D30EPb2djKfeBx1rH9KBeUmedMmRJuN1uf/EpD7dRRtJTw7G91830a6BZKQT9QmZ0figCRR0lDCxu0b+UfZP7gh9wa2X7edlROkgnW1SuCBK6dS1dTNf47UyxJDXYeRHot9dMMC0mbBnbtg7X/Dqffh6SVw8O+er671RwMmezgJz84mfMoUDH1dirbWVmxNTZdkR+JIrMxcyZzkOTx35Dks9sFNQG2mNnaf3801k6/xuh5/tAiCQMSUdIy1vWDpudDo0lfx0fzUU/R+to/0n/10TH2phk+cSPzGDXS8+irWenn+ZofDfOYMxgMHibt+Y8g/bQwk9BN12QVt1GAx8Oinj3Lne3eiElT87Ut/46fLfkp0+GCj76tnpzNjXCxPvF+Fze77UM3Kvo3EUbvmqcNg+X3SZmP6HPjPFvjHOmgbwV8YJIvV7saAbSQOJKaggN7SA9i7ui7MSPwCbCQORBAENudvpqGngaKqwV5kTgMmf9ZOu0I3ZzaWLg32UyVSoo7NgNjxdH/4IW8SP00AAA4GSURBVK3PPkfcxo3E33BDQGOSg+R77wWg5bk/+/U+nUXFoFaHtAGTK8ZAopa00Q+b97F+23qKq4u5fdbtvL7udRaluy7yV6kEvrdmKmdaeig65N4M3x2VjX3jt1J9dM1LmgK3/geufRzqDkmVIZ89DcNVFjjbhQNUmjeQmMI+k6YPP7qkW8fdsWz8MuanzucvR/+CySY5vomiSFFVEbOTZpOb4N8mpIvRLZNkFuNn70uleZkLsdTWUfeD/4d2+nTSf/bTgMYjF5rx44m/8UY6ioqwnD/vl3uINhud27ZJBkypoVeuOBIhn6h7y05Qlmhiy+4txEXE8cqXX+F7C783vIlSH1fOSCUvM44ndlVhsfm2qq7UG0iPjSAuUoZHXJUKFt4uNcpMXgnv/gj+uhaaXAyXdXpQp88Z+p6fiZg7F3VKMoYP3sdUXo4mM3PMaJ5yIggCm+dtpsnYxP9V/h8AJ1pPUN1RLbudqSfolq4GRIz7P4aOczjSFlD3wAPgNFuKCNxehtwk3XMPglpNy9PyDxwGyeLV1tw8JjoRLyZkE7Uoiuw49G8cTc3si21kU/4mXr3mVWYle1b9IAgC31s7jboOI68d8O0buqLRIP8w27gMuOnfcP1fpRFLz10Oe34j7eQ7aTgCCZMgIvAJUlCpiFm1mp6P9mI6evQLJ3sMZFH6IpaMW8ILx16g19pLUVUREeoIrp50dcBjUcfGok3WYqysAaDxPxWYjh9n/K9/RXiWf7zKA4UmLZWEm26i8403MJ92IwuOgo6tW1EnJ4e8AZMrQjJR63v0bP5gMy9v+wUAt67/Od/J+47XmzZX5CazMCuBpz6oxmQd3ah6u0OkqqmbaWl+GHgpCNLkkk0lMGs97PkfyeSprq/8qiHwG4kDiS5YjaOnB2t9/RdS9hjI5vzNtJnaePHEi7x95m3WZK0hJjwIAySAiJzxGFvD6ayJpuPN3STeeQcxV14ZlFjkJunuuxAiImh5Sp7RaE5sLS107/mQuOvWhVQrvaeEVKJ2iA5eq3iN9dvXU6ov5TaN9M03ZVHhqK4nCALfXzsNfZeJV/afG9U1alp7sNgcw3ckykFUMlz/grTCNrbDC1fCjoelgaVB0Kf7w+ozaQLGVBWBP8hPzefyjMt57shzdFu7gyJ7OInMz8dhUVG/P5bIhQtJfTB0zJZ8JSwpicSbb6br7bcxVco3vPqCAdPYqZ0eSMgk6k5zJ3e8ewe/2PcLZifPZuu6rcxo1faZpo9++OayKUksn5LEM3tO0WvxflS9cyMxIOO3pl0Nm/bB/Fuh5HnptfTgJWpVRATRl0lNFtovsPThZNO8TQBMiJnAwjTPpn37A91yafWsjtKS8cfHEML8a9YVaJLuuB1VVBQtT8qzqu43YJo3b8xa9IZMoo4NjyVBm8DPl/+cv6z5CxNiJkjz+WRYyX1/7VRaus3847Mar8+t7Pf48IP04YqIOPjK49IIsMXfhuwVgbnvMCR9+9skfeeeMbdL7g9mJc3iwQUP8vDCh4Nagxs+fyWJq3KZ8NtHCfPTIOlgoo6PJ/HWWzHs3InxxAmfr2c8fBjL6dNjchPRiTCasUPuWLhwoXjgwAiDOD3A3t1N5cJFpNy/pb/G0hdue7GEI+c7+OgHq4mJ8Fyj2vTK5xyr7eSjHwSm+0xBQQHsBgPVV64hMj+fCX9+zqdr1f/kJ3TteJvcjz4KaW8PQRAOiqLo8lEtZFbUF2M+eRKQ75H7e2um0t5r5cVPznp1XqXeMPpGFwUFhVGhjokh6Y476P7wQ3oPjX6CkqOnB8OOt8eUAZMrQjZR93fDybSJNTcznrUz0/jL3tN09no259Bic3CmpYepgZI9FBQU+km8+ZuoExNpefLJUV9jLBowuSJ0E3V5OerkZFm10QfXTMVgsvHCx6fdHwycaenB5hCl8VsKCgoBRRUVRdLdd9Pz6Wf0lJSM6hodRUWET5qEbt48maMLLKGbqMvKZG+ymDEulmvmjuNvH5+hrcf1pO2BVPjq8aGgoOATCTd9nbCUFJr/9CevBg4DmE+fwXjwIPFjzIDJFSGZqB0WC+ZTp/zSDffglbkYrXb+/OEpt8dW6g2oVQKTU8autqWgMJZRRUSQ9J17MB44SM+nn3p1bmdx0Zg0YHJFSCZqc2UV2Gx+abLISY1hfX4Gf//sLE0G04jHVjQayE6KRBs2uoG4CgoKvhN/442EjRtH8xOer6pFm42ObduIXrnykihhDMlE3T+fz09ty/dfmYvVLvLM7pFX1ZWNBkWfVlAIMqrwcJK/ey+mo0fp3rPHo3O6P9qLvbllTNdODyQ0E3VZGaroaDSZmX65flZSFDcuyOSV/eeo7zC6PMZosXOurVfRpxUUQoD49evRTJhA85NPIjrcu2H2GzBdcUUAovM/IZmozWXlREyfjqDyX3ibC3IQEXlqd7XL96ubuhHFALWOKygojIig0ZC86buYy8ox7Nw14rG25ma69+whfv11Y9KAyRUhl6hFux1TRQURs/xrApSZEMlNiyfyWul5zrf1Dnm/v+JDkT4UFEKCuK98hfDJk2l56klE+/BumJ1vvAF2O3EbLw3ZA0IwUVvOnEE0mQJiArRpdQ5qlcCf3q8a8l5lo4FwtYqsxEi/x6GgoOAeQa0mZfMmzFXVdO142+UxoijS8fpWdPPnj1kDJleEXKLuH2YbgEGqabER3LI0i62f13K6uXvQexV6A1NSowlTh9xHpKDwhSXmqqvQTp1Ky1NPIdqGumEaDx3GcubMJbOJ6CTkspCprBxBq0U7JTDfht9ZNYUIjZonLlpVVzUa/DMsQEFBYdQIKhUpW+7DUlND5xv/GfJ+x9bXESIjib3qqiBE5z9CL1GXl6OdOjVgHrvJ0VpuXZ7NG0fqqdBLunSXyUp9p0nRpxUUQpDowkIiZs2i5emnES0XOowdPT10vf0OsVdfhSrq0mpSC6lELYqiX1rH3XHPFZOJDg/j8V3SRImqvo1EpeJDQSH0EASBlPu3YK2ro6OouP/1rnfeQeztJf76G4IYnX8IqURtravH0dUV8Pl88ZHh3HHZJN4+rud4XScVekmvVmqoFRRCk6jLL0eXn0/Ls8/iMJsB6NjqNGDKD3J08hNSifpCR2Lg5/Pdefkk4nQa/rizkspGA5HhajLidQGPQ0FBwT3OVbWtsZGOV1/DfPo0xs8/J/6G68e8AZMrPErUgiBcJQhChSAI1YIgPOKvYMzl5aBWo5061V+3GJbYCA3fvmIy759s4p3jenLTYlCpLr0fuILCpULk0qVELl5My/PP0/7yK5IB07p1wQ7LL7hN1IIgqIGngauBmcBNgiD4ZclrOlGGdvIkVBER/ri8W25bnk1SVDj6LpNS8aGgEOI4V9X2lhbaX36Z6FWrLgkDJld4sqJeDFSLonhaFEUL8G/AL76BpvLyoE67jtKGce+qKYCiTysojAUiFywg6rLLAC652umBeFIDlwGcH/DftcCSiw8SBOHbwLcBJk6c6HUgosVC1PLlRK1Y7vW5cnLz0iyaDGaumTsuqHEoKCh4RtqPfkTH669fMgZMrnA7hVwQhBuAq0RRvKvvv28BloiiuHm4c+SYQq6goKDwRcLXKeR1wIQB/53Z95qCgoKCQgDwJFGXArmCIEwSBCEc+Drwhn/DUlBQUFBw4lajFkXRJgjCZuBdQA38TRTFE36PTEFBQUEB8GwzEVEUdwA7/ByLgoKCgoILQqozUUFBQUFhKEqiVlBQUAhxlEStoKCgEOIoiVpBQUEhxHHb8DKqiwpCM1AzytOTgRYZwxnLKJ/FYJTPYzDK53GBS+GzyBJF0aVZiV8StS8IgnBguO6cLxrKZzEY5fMYjPJ5XOBS/ywU6UNBQUEhxFEStYKCgkKIE4qJ+vlgBxBCKJ/FYJTPYzDK53GBS/qzCDmNWkFBQUFhMKG4olZQUFBQGICSqBUUFBRCnJBJ1IEaoDsWEARhgiAIuwVBKBME4YQgCPcHO6ZgIwiCWhCEQ4IgvBnsWIKNIAjxgiC8LgjCSUEQygVBWBbsmIKJIAgP9v2dHBcE4V+CIARn6KofCYlEHcgBumMEG/B9URRnAkuBTV/wzwPgfqA82EGECE8A74iiOB3I4wv8uQiCkAFsARaKojgbyYr568GNSn5CIlETwAG6YwFRFBtEUfy8738bkP4QM4IbVfAQBCETuAZ4IdixBBtBEOKAK4C/AoiiaBFFsSO4UQWdMEAnCEIYEAnUBzke2QmVRO1qgO4XNjENRBCEbGAesD+4kQSVx4EfAI5gBxICTAKagRf7pKAXBEGICnZQwUIUxTrg98A5oAHoFEXxveBGJT+hkqgVXCAIQjSwFXhAFMWuYMcTDARBuBZoEkXxYLBjCRHCgPnAs6IozgN6gC/sno4gCAlIT9+TgPFAlCAINwc3KvkJlUStDNC9CEEQNEhJ+mVRFIuCHU8QWQGsEwThLJIkViAIwj+DG1JQqQVqRVF0PmG9jpS4v6hcCZwRRbFZFEUrUAQsD3JMshMqiVoZoDsAQRAEJA2yXBTFx4IdTzARRfGHoihmiqKYjfR78YEoipfcislTRFHUA+cFQZjW91IhUBbEkILNOWCpIAiRfX83hVyCm6sezUz0N8oA3SGsAG4BjgmCcLjvtR/1za5UULgPeLlvUXMauD3I8QQNURT3C4LwOvA5UrXUIS7BdnKlhVxBQUEhxAkV6UNBQUFBYRiURK2goKAQ4iiJWkFBQSHEURK1goKCQoijJGoFBQWFEEdJ1AoKCgohjpKoFRQUFEKc/x+d3iDMRApX3wAAAABJRU5ErkJggg==\n",
+            "image/png": "iVBORw0KGgoAAAANSUhEUgAAAWoAAAD4CAYAAADFAawfAAAABHNCSVQICAgIfAhkiAAAAAlwSFlzAAALEgAACxIB0t1+/AAAADh0RVh0U29mdHdhcmUAbWF0cGxvdGxpYiB2ZXJzaW9uMy4yLjIsIGh0dHA6Ly9tYXRwbG90bGliLm9yZy+WH4yJAAAgAElEQVR4nOydeUBU5frHP2eGYRj2fVeRVVEB99zNpWzRtG5mWf2qm2XZLbW97r3VbbFuZlmWLbfbZlld08xswyXTSkEUUEBARGVkB2UfGGbO74/DACrLzDALBZ9/Suac874M8Mz7ft/n+T6CKIr0008//fTTe5HZewL99NNPP/10TX+g7qeffvrp5fQH6n766aefXk5/oO6nn3766eX0B+p++umnn16OgzUe6uvrK4aFhVnj0f30008/f0pSUlLKRVH06+g1qwTqsLAwDh48aI1H99NPP/38KREE4VRnr/VLH/30008/vZz+QN1PP/3008vpD9T99NNPP70cq2jUHaHValGr1Wg0GlsNaRZOTk6EhoaiUCjsPZV++umnH8CGgVqtVuPm5kZYWBiCINhqWJMQRZGKigrUajWDBw+293T66aeffgAbSh8ajQYfH59eG6QBBEHAx8en16/6++mnn76FTTXq3hykDfwR5thPP/30LfoPE3spdY3NfHrgFE3NevtOpOoMZG617xwAzbFj1Ozcid1tefN2Q+kx+86hn/OpyIOUj0Bv578VK9LnAvXXX3+NIAgcO9a7/9i+O1LEk1uO8vz2TPtO5LfX4ctboa7CrtMoef4F1Mvuo2DJXWjPnLHPJPR6+N//wY6n7TN+P+eja4Z9r8H6ibDtftj7ir1nZDX6XKDeuHEjkydPZuPGjfaeSpfklNQA8NHvp/gmrdB+EylKk/57xn6VpqJejyYrC2VMDPWHDpE3dx6VGz5FtPUKqjwHNFVt70k/9qP4CPxnBux4CiJnQew1sPt5acfzJ6RPBera2lr27dvH+++/z+eff27v6XRJdkktQwLdGDPIi8e+Sie3JXDbFL1e+oMAUCfbfvwWtGo1+tpavG66iYht3+A8ahQlzz3HqZtvofFEvu0mYngPagqhrtx24/bTRnMj7HoO3p0O1YVw/YdwwwaYvx78YuCrv0py3Z8Mm6XnteeZbRlkFlZb9Jmxwe48NXdYl9ds3bqVOXPmEB0djY+PDykpKYwePdqi87AUOcU1TIz04ZHLh3D1G3u559NDbF02CRelDX9kZ/OhqVb6fzsGak1mFgBOsbEoQkIY8N67VG3dSsmqF8mfPx/fZcvwueN2BGvnvrd/D4rSIHKmdcfr53wKkmDrfVCeDfE3wuUvgLO39JqjCyz8BN67FP53G9y2HRwc7TpdS9KnVtQbN25k0aJFACxatKjXyh9VDVqKqzVEB7gR6OHE64tGcqKslsc2H7HtYVpRqvTf0LGgTgG9znZjt0OTmQlyOcroKEDKzPGcP5+I7d/ieumllL36KvkLb5CusybqgxAyRvr/fvnDdjTWwvePwfuXgbYeFn8FC95uC9IG/KJh3hugToLEf9pnrlbCLivq7la+1qCyspJdu3Zx5MgRBEFAp9MhCAIvv/xyr0vJM8gcMQFuAEyM9OXBy2J4+cdsxgzy4v8mhtlmIkXpIFPAyFukw5qybAiItc3Y7dBkZaGMiECmVJ73dQdfX0LXvkb1Tz9R/Oyz5F+/EJ877sD3vmUXXdvzSVRDaSZMfwzqSqE43bLP76dj8nbBtgfg3GkYuwRmPQVKt86vH36ttPI+sB4GjJP+/Segz6yoN23axC233MKpU6c4efIkBQUFDB48mL1799p7aheR3RKoowPbfiHvmRbBzCH+PLc9k0Onz9pmIsXp4D8EwiZL/7aT/KHJysJp6NBOX3e/7DIivv0Wj2uuoeK998i/Zj71KSmWnUThIUCUdheBcdKHWD/Wo+EsfL0MPlkAcke4/Xu4anXXQdrA7H9B6Dj45m9QlmP9udqAPhOoN27cyIIFC8772nXXXdcr5Y+c4hpclQ4Eezi1fk0mE1izMIEAdyfu+/QQlXVN1p2EKErBKCgevMNB5WWXQK0tLUVXXo7TsK5X8nIPD4JfeJ4B7/8HUavl1OKbKf7Xs+hq6ywzEcP3HjIaghKgMk9aZfdjebK2wZvjIW0jTF4BS3+FQRONv9/BUTpkdFBKqaVNFvodsCN9JlDv3r2bOXPmnPe1+++/n/Xr19tpRp2TXVJDVIDrRZKMh7OC9YtHU17XxAOfH0ant6JeXV0I9eUQGA+C0KJT2z5QG3TnrlbU7XGdNInwb7bidestnN24kRPz5lJriV1TQTL4xoDKE4LipK+VHO35c/tpo6ZECqxf3Ayu/rBkF8x6GhRO3d15MR4hcN37UHYMti2XFh5/YPpMoP4jkVNS26pPX8iIUA+emTeMvbnlrN2Za71JGDRYQ1AKHSv90jecs96YHdCYJWV8KI0M1AAyFxcCn3iCQZ99ikzlTMGSuyh89DGaz5opGYmi9CEVOlb6d2DLe9Ivf1gGUYTUjfDmOMj+AWb+E5bshuCEnj034lK49Ek48iUcfN8yc7UT/YG6l1Fe20hlXRPRnQRqgEVjB3DdqFDe2JXLz9ml1plIUTogQMBw6d+GIFV4yDrjdYImMwvFoIHIXV1Nvtd55EgGb9mMzz1Lqdq+nRNXz6X6hx9Nz5ypPAENlTCg5T1wCwQXv/4DRUtw7jRsuA6+XirlQS/dB1MeBLmFUi2nPAhRl8EPj0uZS39Q+gN1LyOnuCXjI7DzQC0IAs/NH05MgBvLv0hFfbbe8hMpSgOfSFC2BMiQUYAgSQA2RDpIND/TROboiP8DDzB40/9QBAZyZvlyztx/P9pSEz7gDJKP4cNKECTtvn9FbT56PSS9B29NgNP74YqX4fYfpBQ7SyKTwYJ3wDVQKv+vr7Ts821Ef6DuZbRmfHSxogZQOcpZf/NodDqRZZ8eorHZwjnOxeltsgeAkwf4DbGpTq2rqkKrVhutT3eF05AhhH3xOf4PPUjtL3s5cfVczn212bjVtToZHN2k799AYByUZUmVcv2YRnkufHglfPeQlEJ37+8w/i4pqFoDZ29Y+BHUlsDmJX9I86b+QN3LyCmpwctZga9r91VVg31dePn6ONLUVTz3bZblJlFfCVUFbVqsgQEtB4o2OpjRZEnGWU6xPQ/UAIKDAz533sngr7fgFB1N0ZNPUvDXv9KkVnd9ozpZ2lHI5G1fC4oDfbOUW92Pcei0knHS+klQmiWVfd+8GbwGWX/skFEw50U4vgN+edn641mY/kDdy8guriE6wM3oIpw5w4NYMmUwn+w/xdZUC3kctB4kxp//9dCxoDkHFcctM043aFoOEi2xom6PcvBgBn78EYFPP0VDWjon5s6j8uOPEXUd7Eqa6qD4aJvsYcDw3vTLH8ZRlAbvzYCd/4KYObAsCRJukmQkWzHmDoi7AX5eBcd32m5cC9CnArVcLichIYH4+HhGjRrFb7/9Zu8pnYcoiuSW1HapT3fEI3OGMDbMi8e+OtLqutcjDOXRHQVqsJn8ocnMxMHfHwdfX4s/W5DJ8Fq0iPBvt+E8dgwlL6zi1OKbaTx+wYdQYSqIuosDtWcYKN37S8m7Q6uBHc/Au5dCTbHkx7HwY3ALsP1cBAGuflWSsL66E6q62Un1IvpUoFapVKSmppKWlsaqVat4/PHH7T2l8yiq0lDT2NytPn0hCrmMdTeNwkXpwNINKdQ2NvdwIungHnqxl4JvjBScbBWoszItvpq+EEVQEAPeeYfgl/9N08mT5C+4lvL16xG1WumCCw8SDchkEDiiP/OjK07vh7cnw741konSfUkQO8++c3J0gRs+kWSYL/8Pmq1cOGYh+lSgbk91dTVeXl72nsZ5GA4STV1RAwS4O/HGjSM5WV7Ho1+l98y86cKDRAMymVSZZ4NArW9ooOlEPkoL6dNdIQgCHnPnEr79W9xmz6Js7evk/+V6Go5mSN+rdzi4+Fx8Y2AclGTYzayq19JYA989DP+dIx223rwZ5r8pVbf2Bnyj4Jp1ksf6T3+392yMwi6mTHz/WJvPsaUIHAFXvNjlJQ0NDSQkJKDRaCgqKmLXrl2WnUMPMaTmRfubHqgBJkT48NDlMfz7B8m86fZJZnRSb6qTTuWHX9fx66FjYe9qydFMaXpus7E05uSAXo9TrO1MoBx8fAhZswb3q66i+Jl/cXLhQnyGN+N73eSOVzRB8ZKbW8VxKQe4H+mwbttySVYYfzfM+IdVf0/MZth8KFgG+9+UMk9G/MXeM+oSo1bUgiCsEAQhQxCEo4IgbBQEwYyaTvtjkD6OHTvGDz/8wK233mr/HnztyC6pIcBdiYez+cn+S6dGMGuoP89vzyLllBmVeMVHAfHijA8DA8aBqIfCw2bP0RjaSsdt79bnNnMm4d9uw3Pu5VSky8h/K5P65A52EYZdR79OLWUKbblHKl5RqOCOH+GKl3pnkDYw+xkYcAl80+IM2YvpdkUtCEIIcD8QK4pigyAIXwKLgA/NHrWbla8tmDBhAuXl5ZSVleHv72/v6QCQW1Jrsj59ITKZwCvXJzB33T7u++wQ3/5tMj6uJlh+Xlg6fiEhLY0W1MkweEqP5toVmswsZB4eKEKCrTZGV8jd3Qm6ZRLu1Z9QdMyfU7fciueNi/B/8MG2KknfaJArpUAdt9Au8+wVZHwt5UQ3nIUpD8HUh83z57A1cgVc/wG8MxW+uEXyFumlHyzGatQOgEoQBAfAGbBjEz/LcOzYMXQ6HT4+52uPoiiir62ludy2rZZ0epHc0ppWj4+apho+zviYRp3pBRUezgreWjyKiromHvg81TTzpqI0UHmDe0jHrzt7SxWLVtapDdamhjTFXcdK2H3MSuXynVGQjEuInPBvvsH7tts498WXnLh6Lg1pLStouULy5+6jB4oV1RW89u6lFG++A9yDJX+Omf/4YwRpA+7BknlTRa7ke92DHfYPR4t5c/dxmnWWL6jpNlCLongGWA2cBoqAKlEUf7rwOkEQ7hIE4aAgCAfLysosPlFLYNCoExISuOGGG/joo4+Qy+XnXSM2NKCrrkZ9/wNtJ/82oKCyHo1W3+pBvS1vGy8ffJlVB1aZ9bzhIR48e80w9h0v57UdJnjyFqVJ2mtX+a2h1i18EbVaGnNycBo6lNJqDUs/SeGODw+ydEMKpdUaq4zZIS2FLjI3DwIee5SwjZ8h6pope2Nd2zWGUvJeJKHZAlEUeex/D/G+spx5Awfx5dR70QcOt/e0zCN8mmTedHQTJP/H7Md8euAUm1LUyGWWzw3vNlALguAFXAMMBoIBF0EQbr7wOlEU3xVFcYwoimP8/PwsPlFLoNPpSE1NbU3Ru+qqqy66Rq+RAkHDoUOUrrZd+/kLS8eTipMA+Cr3K7Ye32rWM28YO5DrR4fyxq7jxq1Gm5ukirHOZA8DoWOhrgzOnTJrXt3ReOIEYlMTaU7+zFqzh13Zpdw9LZxmvcibu21TbENzo7RSDh3T+iVVfDxu0y+l4ciRtg7ogXFSEdC507aZVy/hnb1HOSwcZnRDI45iJM8mPc9ff/wrp6qt8zthdSavhOg5LeZNB02+vVqjZf+JCmbHBlilY5Qx0scsIF8UxTJRFLXAZsAEF+8/FvqGBhAEvBYvpvKjj6j+4UebjGvI+Ijyd0Uv6kkuTmZexDzGBY7j2f3Pkl1p3mHHs/OHMzTIneVfpFJQ2Y15U9kx0Gs7P0g0YMgptpJBU2Gy1KvxuWwdMYFufP/AFB6/YijXjw5lY1IBZ841WGXc8yhKA13TRfnTqoQE9FVVNJ08KX3BUBTUh+SPQ6fPsvbg+zTKddxW70Xp8dt5Yuw/ya7M5rpvruPDox/SrO9hLr+tkcmkPozuQVJ+dV2FSbfvyS5DqxOZHWudQh5jAvVp4BJBEJwF6aNiJmBBY4nehajRICgUBDz6CE7xcRQ9+SSN+flWHzentJYB3ipclA5kV2ZT3VTNhOAJvDT1Jdwd3Vn580pqmkyvOnRSyFm/eBR6vciyz7oxb2o9SOzGB9g/FhQuFtepdXqRD3/N56svdtEoV7Bk8XS+uGsCEX7SAc/fZkrNbdftsqIPt4FOCl1UCVJgbkht0akDhoEg7zOl5BW1jdz72V4UXvuYVd9IdPAlNDWLeOkn8/X8r5kYPJFXUl7h5u9uNntxYTdUXlLVZF0pbL7TpPz4HVkl+Lg4MmqgdXLFjdGoDwCbgEPAkZZ73rXKbOyMqNejbwnUgqMjoa++iqBQcOb+B9DXW8FKtB05xW0HiQbZY1zgOHxVvqyetpoztWf456//NCudMMzXhdUL40lXV/GvbV2YCBWlgaOrVODRFXIHyeTGgoH6eGkNC9/5nae3ZRLfUIxq6BBumRSBrJ3eF+KpYtG4AfzvoJrTFdb9eaBOBo+Bkvd0OxwHD0bm5tZ2oKhQSdkffWBFrdOLLP8ilSplIsiaWFZZScDQyXioFPyUWYK/sz9rL13Ly9NepqiuiEXfLuLN1Ddp0v0xqv8ACB4JV/xbaqq7599G3aLV6dl9rJQZQ/ytok+DkVkfoig+JYriEFEUh4uieIsoin9Kb0exqQlEEUEh5TErgoMJXr2axuPHKX7mGavlXDc168kra0vNO1B0gDD3MPydpbTBUQGjWDF6BTtO7+DjzI/NGuPyYYHcPTWcTw+cZsvhTjwOitKlRgHG2E2GjpGCk7ZnMoRWp2fdrlyuXLuPvLJa1vxlBIPOnsF9RMed6pddGolcJli3uw1Isk47fdqAIJOhioujITW17YtBcX0il3rtzlz2nchH5fM7c9yjiNRqkQ8cx4wh/uw+VkqzTo8gCMwJm8PWa7YyZ/Ac3k57m4XbFpJW9gd6f0bfJpW873kJcnd0e3lSfiXVmmZmWUn2gD5cQt4R+gYp6BgCNYDr5En4LltG1dZvOPfFl1YZ92RFHc16kegAN7R6LSklKYwPGn/eNbfG3srsQbN5NeVVUkrM61Tx8OUxjBvszeObj5BdfIGMotdLPQC7O0g0EDpWsvnsQYA6eqaKeet+ZfVPOcweFkDiimlc7Seir6vrtCIxwN2JWy4ZxJbDao6X1po9dpdUF0K1+mJ/jxZUCQk05ua2Nc4NjIOaIqjtndlOluDn7FLe2JXLsNgUdGi5V+cCrgHgOZDZsQGcrdeeV2Dl6eTJqimreHPmm9Q113HLd7fwUtJL1GutvBOyBIIAV62RJL7Nd8K5gi4vT8wsQekgY0qU5c3DDPQH6naIGg3IZAgO59cB+d57Dy6TJ1Py/PM0HLF8Q1ND0IwOcCOzIpP65nrGBp4fJARB4F8T/0WoWygP7XmI8gbT87wd5DLW3TgSV6WCezakUKNpl35YeQKaai92zOuMHjjpabQ6Xvz+GNe8+SvltY28c8to3rxpFH5uynbWpp1XJC6dHoGTQm69VbXh1H/AuA5fViXEg16P5mjL70LrgeIfaNVoAuqz9Sz/IpXIQB1F+l3MDZ9LWGGL9asgMDXaD0e5jMTMkovunRo6lS3ztrAwZiEbsjZw7TfXsr9ovx2+CxNxdJb0al2z1BmmkwYRoiiSmFnClChfnB2t58jRpwJ1cXExixYtIiIigtGjR3PllVeSk9OWY6xv0CBTKi/KIRZkMoJf/jdyX1/OPPAAunOWbfCaW1KDXCYQ7udCUpGkT18YqAFcHV1ZM30NtU21PLznYbNO1v3dnVh300hOVdafb95U1LKV7y7jo3Uy/uA5CAqSTBo/Kb+SK9fu5e09efxlVCg7Vkzj8mFtOrAmIxMcHFBGR3X6DF9XJbdNDGNbWiHHiqtNGt8o1Ekgd5T8YzpAFSe9R63yh+G6P6H80disY9mnh9DpREbGpaAX9SyNXgSVea3SkKvSgQkRPiRmlXQoD7o6uvL3S/7OB5d/gIPMgSU/LeGp356iuskKPztL4hsJ89+CMynw45MdXpJZVM2Zcw1Wy/Yw0GcCtSiKLFiwgOnTp5OXl0dKSgqrVq2ipKSk9XVR04CgUnV4v4OXF6FrX0NbVsaZRx5py6O1ANklNYT5OOOkkJNUnES0VzTeTt4dXhvtFc0/JvyDgyUHeePwG2aNd0m4D49cHsN3R4r5768npS8Wp4NMcX67qe4IHWt0zmmNRss/vj7Kwnd+p0mnZ8Nfx/PSX+Iu8jXRZGWhjIhA5th1h5u7pobjpnTg1UQTinmMRX1QWiU7dFx6L/fwwDE8vO1AUeUpfWj9CTM/nv02kzR1FU/MCyRR/Q0LohYQeq6lQUVo245jdmwApyrqye1CjhoTOIZNczdxx/A72Hp8K/O/ns+u073LGO0iYufBhPsg+T1I/99FL+/ILEUQYMaQ/kBtEXbv3o1CoWDp0qWtX4uPj2fKFMmvQmxqQtTrkTl1Xv6qiosj4PHHqPtlLxXvvGOxueW0NAto0jVxuPQw4wI73nIbmBcxj79E/4X/Hv0vu0/vNmvMu6aGc1lsAKu+y+LgyUopyPgPBYfuW4C1MmAc1BRCVdedZXZnl3L5q7+w4cAp7pg0mJ9WTGVyB3qeKIpS6bgRjnmezo78dcpgfswo4Yi6yvg5d4dOKxlOhXb9M1DFx9OQlta2ggyK+9Nlfnx9+Awb9p/mrqnhHGvcjIDAXXF3SXKXIIfgtjROw4qyI/mjPU4OTqwYvYJPr/oUbydvHtj9gNlSns2Y9TQMnADb7ofSY+e9lJhVzKiBXvi5meCnYwZ2sTl9KekljlUe6/5CExjiPYRHxz3a6etHjx5l9OjRnb4utlQkyjpZURvwuvFGGg4dpuz1N1DFx+MysWe1PxqtjpMVdcyLDyatLI1GXWO3gRrgsXGPkVGewZP7nuSLq79ggPsAk8YVBIGXr49n3rp9LPs0hd8d0pANubhSs0sMWRHqZPC42BvkbF0Tz36byebDZ4j0d2XT0omMHtR5nmlzaRm6igqjmwXcMXkwH/x6kjWJ2Xxwe/fvmVGUHIVmTYcZH+1RxcdTtWUL2oICHAcOlFbgWdtAUw1O7paZix3JKanh8c1HGBfmzaKJKq79ZiuLhiwi0CVQkrsChkkm/C0EuDsRH+pBYmYJyy6N7Pb5w3yGsfHqjXxw9APeTnub/UX7eXTso1wdfrVVKvt6hFwBf2kxb/rSYN7kRuG5Bo6eqebROSbsQs2kz6you0PfoAFBQFB2/ckoCAJB/3oGx4hwzjz4ENri4h6Ne7y0FlGUmgUkFSchE2SMDuz8A8WAUq5kzfQ1CILAyj0r0TSb7oHhoVKwfvFonBqKkTVUojdWnzYQMEJyj7vgQFEURb5NL2TWmj18k1bI/TMi2X7/5C6DNIAmMwMwvpmtu5OCu6aGszu7zDxL144o6KSjywWoRkqryVb5I9BwoGhhn3U7UNvYzNINKbgoHVh300jeO/IOCpmCO0e0FIGcOdThQevs2ABSC84Z7ceikCm4K+4uNs3dRJh7GE/se4J7d95LUW2Rpb+lnuMeBH/5r+Q9/s39IIrsyJJ2D9bWp8FOK+quVr7WYtiwYWzatKnT1/WaBmRKJYIROcQyZ2dCX3+dk3+5njPLVzDo448QutFUOyOnncfHFylJxHrH4u5o3Ios1C2UVVNWsWznMlYlreKZic+YPH5ssDvPXyLCQdhY4Mni8d3f04qDo7T9bReoS6o1/OPro/yUWcKIEA823DmeoUHGfT+GjA/lEONXKLdNDOO/+/J5NTGHDXeaMvlOUCeDWxB4hHZ5mTIyEsHZmYbUNDzmzm1LayxOh7BJPZ+HnRBFkUc3pXOyvI5P77yEGv0Ztp/Yzm3DbsNX5QslmdBU0+EH2azYAFb/lMOOrFJuGj/Q6DHDPcP5aM5HfJ79OWsPrWX+1vmsGL2ChTELkQm9aC05eIrUCGHnMzDwEhIzEwj3dSHS3/rWqL3oXbAuM2bMoLGxkXffbSuqTE9PZ+/evUBL6XgX+vSFKMPDCXr+ORpSUylZvdrseWWX1OAolxHgAenl6YwN6noldyFTQ6eyZMQSNuduZkvuFrPmMNm1ED0Czx+UszOra43xIkLHQmEqYnMjXySfZtaaPezJKePxK4aw5d6JRgdpgMasLBwHDWrzezYCF6UD90yPYN/xcvafMM2foUPULYUu3Wy/Bbkc1YgRbZkfboHg4v+HP1D84NeTbD9SxMOXD2FChA9vpb6FykHF7cNvly5Qt2T5dBCoYwLcGOCtIjHT9F2mXCZn8dDFbLlmC/F+8Tx/4Hlu/+F2Tlad7MF3YwUmLYfoKxB/fBJN/n6brKahDwVqQRDYsmULO3bsICIigmHDhvH4448TGBiIXqtFbG5G5tS1Pn0h7ldcgdctt3D240+o/v57s+aVU1xDhL8rR8rTadY3Mz7Q9FXhsoRljA8az/MHnjdP+y9KA59IwoL8WWGMeVN7QseCrpF/vrORR786wtAgd35YPpW7p0XgIDft10uTkWlWj8SbLxmEv5uSNT/l9Kx6tLYMzuZ3K3sYUMXHo8nObi2UIij+D32gmHKqkhe+y2LW0ACWTgsnuzKbn079xOKhi/FyapGt1MmSX3kHNgOCIDB7aCC/5lVQZ2aD5RDXEN6Z/Q7PTnqW3HO5XPfNdbx/5P3eY/Ikk8GC9dQ7BbBW/hpXhNtGlOgzgRogODiYL7/8kry8PDIyMti+fTtRUVGtB4mCynTD84CHH0KVkEDRk3+n8cQJk+/PKaklOsCVpOIkHAQHRvqPNPkZcpmcl6a8hIfSg5U/rzQ9P7UoHVlQPG/fPBoRuOfTFDTa7g1pdHqRjUVSDrRz6WGemz+cz5dcwmBfl27u7OBZ586hLSw0q/WWk0LOfTMiSTpZyd7cHmQPnGlJNewm48OAKiEBmptb24YRFCfZxGpt6JltIcprG1n26WGCPVW8sjAeQRBYl7oON4Ub/zfs/9ouVB9sLXTpiNmxATQ16/klx/wqTUEQmB85n63XbGVK6BReO/QaN22/qfeYPKm8eNPvKXyEGuKTHrZJc+M+Fag7w7Ai6io1rzMER0dCXnsVQankzAOmmTfVaLScOddAdIB0kDjCbwTOCmeT5wDgo/LhlWmvUFRbxN/3/d34lWV9pVQuHRTHQB9n1ixM4OiZap7pymUttYkAACAASURBVLwJSVu/bv1vPL6jgkq5Hw8MqeLmSwadZ6JkCppj0k7A3Ga2N4wdQLCHE68k9mBVrU4GmYPR1ZmqeEPhi+FAMQ5EHZR2/d71NnR6kQc+P8zZ+ibW3zwKD5WCo+VH+bngZ24ddiseSg/pwoZzkhVuFzuOsWFeeDorSDRVQusAP2c/Xrv0NdZMX0NpfSmLvl3E64deN6vrkSXR6vR8csqDb4JXIJzYLXmCWJn+QE2LPu3oiHBBtxdjUQQGErz6ZRqP51H01NNGBwpDccBAH4GMigyj0vK6IsE/gZVjVrK7YDcfZHxg3E2GarqW4DQ7NoCl0yLYmHSar1IuNm9qatbz+s5crnp9L6cq6njthgS8YibibKb/iAFNZkvpuBnSB4DSQc79M6NIKzjHLnNbdhUkSaZUjsZ9WDr4+KAYMKBNp/6DelO/tiOHX49X8Ow1wxkWLAXldanr8FR6cvPQdj1CzrT8jAd0Hqgd5DJmxPizq8WkyRLMHjSbrfO3cmX4lbx35D2u33Y9qaWp3d9oJQ6cqKRG04zHxDsgYbHksmeEeVNP6A/UtJSOd5M/3R2ukybh+7f7qN62jXOff27UPYZmAY2KPPSi/iIjJnO4eejNXDboMtYeWktysRE+HEXtVoMtPHRZNJeEe/Pk10fOK9FOKzjHvHX7WJOYw5zhQSSunMb8kSEIoWOlDic15q+iNJmZOAQE4ODdcUWmMVw3OpSB3s688lMOelP6REKXaWddoUpIoCE1Vfpw9goDpccfqpR897FS3th1nIVjQlk4VsrFP1x6mF/P/Mrtw2/H1bHdwa76ICBA8KgunzkrNoBz9VoOWiplEvBQevD85Od5e9bbaJo13Pr9rbyY9KJdTJ4SM4txUsiYEu0PV66Wcso332nVLj99PlCLzc2I2iaTMj46w3fpUlymTqHkhVU0pHe/qsouqcHZUU5eTSqOMkfi/EzMY+4AQRB4ZuIzDHQbyMN7HqasvhutsDgdPAZITWtbcJDLeP3Gkbg7KbhnwyFKazS88F0WC976lbP1Tbx36xjeuHEkvobu5gZN94zpLYwMGJrZ9gSFXMbyWVFkFlXzY4aJmQelWaCtM/og0YAqPp7msjKai4sl3TZwxB8m86OgUjJbig1y51/XtPU7XHd4Hd5O3iyKWXT+DepkqXq1m4KerkyaesqkkElsuWYLi4Ys4rOsz7j2m2v5rfA3i4/TGQYTpsmRfqgc5W3mTXodfHlrp+ZNPaXPB2pDj0RTMz46QpDJCPn3v3Hw80O9fDnNZ7teUeSU1BDl70pycRIj/UeilFumDNVg3lTfXM/Dv3Rj3lSU3qERk7+bE+tuGsXpynomv7ibd385wQ1jB5C4ctrFKUlBcZJPiIkGTQb0DQ005eebrU+355qEECL8XFiTmGNa9/XWtLOuKxIvRBVv6PhikD/ioCTDJgdMPUGj1XHvp4fQiyLrbx6Fk0KS/Q4UHSCpOIklI5acf16i17elLnaDq9KBiZE+JGZ2bNLUU1wULjwx/gk+nPMhCpmCuxPv5unfnkYvWr7794VkFlVTWKXhsvZ/Az4RMH+9ZD3ww+NWGbfPB+q20nHLtLiXe3oSsnYturJyCh95tEvzpuziWsL8IftsNuOCLFQC3UKUVxT/uOQfpJSk8Pqh1zu+qLFWqrTq5PBs3GBvnp43jOhAVz67czyrro3D3Ulx8YUKlbSSNKMpKEBjdjbo9Wbr0+2RywSWz4omt7SWb9MLjb9RfRCcfcFrsEnjOQ2JQVAq2w4Ug+KhuQHKbdAurAf869tMjpyp4pXr4xnkI2XpiKLIusPr8Hf25/qY68+/oTJPauJrZEbM7NgATlfWk1NiJc9wpIYam+ZtYvHQxXyV+5VN7FMTM0skE6ah/ue/MPRqmHg/FByQ/q4sTJ8K1HK5nISEBIYNG0Z8fDyvvPIKzXX1CA6Kizyoe4JqxHACnnyCur17KV+/vsNrKuuaKK9txMntJECPDxI7Ym7EXBZGL+SDjA/YeXrnxReUHAXELpsF3HLJIL792xQmRnZjij5gHBQekvx7TaShJb2tp9KHgatGBDEk0I3XduQaf6ClTu4y7awzBIUCp+HD25WSt7yXvVin3nxIzWcHTnP3tHAua2cx+2vhr6SWpXJ33N0X7+466SHZGbOGSivOHRbI/ugKpVzJitErcHd05+vcr606FkiBetRArzbZrz0zn4K/JoLS8pWKfSpQq1QqUlNTycjIIDExke+//55nX/63xVbT7fG84Qbc582lfN2b1O779aLXDaXjtcIxVA4qhvl23Hqqpzw67lGG+Qzj7/v+zunqCw47DFqqqR4fHRE6FrT1UJph8q2NWVnIPDxwCA7u+TwAmUxgxexo8svr2Hy4a2c/QEpRLM8xWfYwoIqPR5ORgb6pSeqf6ODUazM/jhVX88SWI4wf7M3Dl8W0ft2wmg5xDWFB5IKLbyxIkg5KfaONGifA3Yn4AZ78ZAWd+kKUciVXh1/NztM7qWq0oJPiBZw510BGYXXn1YhyB6MzhkylTwXq9vj7+/PO22/z9oYN0I0RkzkIgkDQ00+jjIyg8KGH0BadbzRjCNT5dWmMDhiNQtaBpGABHOWOvDL9FWSCjBU/r6ChuV2Pw+I0cPYBdwsEyPZOeiaiyczCKXaoRV3TLosNYESIB6/vzKWpuZtV9ZlD0n9NPEg0oEqIR9RqaczKkv5Y/WN75Yq6RqPlng2HcHNS8MZNI8+rHN1dsJuMigzujrsbhbyD30X1QQgdbVw/zRZmD/UnreAcJUaaNPWEBVELaNI3sf3EdquNsSPTdiZMF2IXU6biF16gMcuyNqfKoUMIfOIJk+4ZHByMTq+nvLYWy6zlzkfm7EzI2tc5ef31qJcvJ+yTT1rNm7KLa3Bzqaeg9iQLY66zwuhthLiGtJo3Pb//eZ6d9KwUFIvSJE3VEgHScxC4+El/0GPvNPo2UaulMScHr1tu6fkc2iEIAisvi+b2D5L5X0oBi8cP6vxidTIIMqmzuhmo4tuc9FTx8dJ7mrEZRNEy760FEEWRRzalc7qyns/uHI+/W9suUi/qeTP1TQa6DWRuxNyLb26slXZKQx42aczZsYEtJk0lXb//FmCI9xCGeg9ly/Et3DT0JquMkZhZQrifCxF+1jdhupA+u6KGds1srbCiNqAMH0zQ88+jSUun5N8vt349p6SGoEBpW26qEZM5TA2dyl1xd7E1byubczdDc5Nkgm4J2QOkgBQ6zuQVdWNeHqJWazF9uj3To/0YNdCTN3Ye77okXp0srYKVbmaNowjwxyEo6PzMD00VnDtl1vOswfv78vn+aDGPXB7D+HCf81776dRP5JzN4Z6Ee3CQdbB2KzwEot7kHUd0gCsDvZ2tkqbXEQuiFnCs8hhZFVkWf3a1Rsv+ExV2WU2DnVbUpq58rcXx7GzkMhkBIReb3lsS9zmX0/B/t1L50ceoRibgfuWV5JTUEhqVh5vgxhAv6xuPA9wbfy/pZem8cOAFhopyYvVa47uOG0PoGMjeLmm+zsYVrrRWJA7reWrehQiCwEOXxXDTfw6wMek0t0/qIKNDr5d2AcM70GVNQBUf366UvCWLpihdKoKxMwdPVvLi98e4LDaAu6aeb6ak0+t4K/UtIjwiuCLsio4fYPjwDeneJ709giAwOzaAT34/RW1jM65K64abKwdfyerk1WzO3cyTPh33ODSXn7PLaNaL56fl2ZA+u6IuKyvjvkceYemttyIzQXczF/+HHkI1ahRF//gnRelZVDVoqeIYYwPGIpeZV7puKnKZnJemvoSXkxcrU1ZTJRMgKKH7G42ltTO58Wl6mqwsBJUKx0HW2RpPjPTlknBv3tydR0NTB6vqilxorDI67awzVAnxaAsL0ZaWQkCs1KqqFxwoltc2suyzQ4R4qXj5+viLzgG+y/+O/Kp87k24t/PfQ/VB8Iky+sO3PbNjA2jS9cykyVg8lB7MHDST7fnbLe4HkphZgo+LIwkDum5+YS36VKBuaGhoTc+bNWsWMy+5hH8+9phNxhYUCkJeXYNMpaLioZWohGKqtMUWz5/uDm8nb1ZPW02Jtpq/+weg97RggAwZJWm9JsgfmsxMnGJizPZZMYYHL4uhvLaRj38/efGLJqaddUZr4UtampRX7hdj9wpFnV7k/o2HOVevZf3i0Xiozj8k1Oq1rE9bT4xXDLMGzer4IaIoZXyY+f6MGSSZNO2wkfxxbdS11DTVsPNUB+moZtLUrOfnY6XMHOqP3EzTsZ7SpwK1TqdrTc87fOAAy2+7DbmzddJpOkIREEDIK6uRqwt4IPVLEEWr5E93R4J/Ag/p3PhZ5ch/Mz+03IMdXSTfA7VxFYqiXk9jVpZFCl26YmyYN1Oj/Xh7Tx61F/okFySBkwf4dN/nryucYmNBoUDTPp/azpkfaxKz+S2vgufmDyc2+OKy72152yioKeC+kfd13knl7EmoL+/SiKkrWk2asi1n0tQV4wLHEeIawubjmy32zAP5FdQ0NjM7NrD7i61EnwrU7Wm1Nu2hGZOpuFxyCSkzr2da/mkWpKuI9OxZgDALvY6bivK5XBnIG4ffIKnIvNLvDgkdC+oUo0qotadPo6+vt0jpeHesnB3N2XotH+zLP/8Fg79yD+UvmVKJU+zQdhWKcVBbDLVmOvn1kJ1ZJby5O49FYwdw/ZiLGx836Zp4O+1tRviOYFrotM4fZJCxerDjmN1i0pR80nImTZ0hE2RcE3kNB4oOcKbWiBx6I9iRWYKTQsbk7oq+rEifDdSiRgMymdm9DnvCpiEzOBShYOGPdWiMMG+yOBV5CNo6nom8kUHug3j4l4cprbdQQAkdJ/XUK8/p9tLWHolWyPi4kIQBnswaGsC7e09QVa+VvthYI3lH91D2MKCKj6fh6FHE5ua2snw7yB+nK+pZ8UUqw4LdeXpex4VUm3M3U1RXxH0J93Wdv65OAoUL+Jn/M5oa7Yejg3VMmjpifsR8BAS+Pt7zSkWDCdOUqBYTJjth00BtDYMWc9E3NCBTOl30S2rtOer1IrlnT/HGXD06Hw/Uy1d0a95kcVoOuVxCx7Jm2hoamht4eM/DaPXanj/bEPSMMGjSZGaCgwPKqKiej2sEK2dHU6Np5j/7WjrxnEkBRLMrEi9EFR+PqNGgyc6WvE8Aimzrm6zR6rj3M8k3ev3i0a1mS+dd06zh3fR3GeU/ignBE7p+oDpZOnuQm5+x4aJ0YFKED4lZxTaJAUGuQUwInsDXx79G10NzrIxCyYTJXml5BmwWqJ2cnKioqOgVwVoURUSN5qLScVEUqaiowMkClqedceZcA1pFDnUqAfeXn0VXXk7hQw8j6mzotlaUBnJH8BtCpFckT014ikOlh1ibsrbnz/aJAJWXUQeKmswslJGRyGy0q4kNdueqEUH8d18+lXVN7dLOLBOonRPaCl9w8pBS82yc+fHMtgyOnqlmzcIEBvp0fP7yZfaXlDWUcd/IblbT2gYoPmKRHcfs2EAKKhvIbqnItTYLohZQXFfMgaIDPXqOwYRp5hD/7i+2IjbLow4NDUWtVlNWZv00ne4Qm5tpLi1F3tCArOp8bwAnJydCQ0OtNnZ2cQ1ylxN4K/0IGzeTc3//O8VPPUX5W+vx+9t9Vhv3PIrTJV/hllLhq8Kv4nDpYT7K/Ih4/3hmD5pt/rMFoUWn7jpFTxRFNFlZuE6fbv5YZrB8VhTfHS3inV/yePzsQfCNAZWnRZ7tEByM3M9XOlC86aaWA0XbBepNKWo2JhVwz/QIZnWyAqzX1vP+0fcZHzSesYHdBODCVNA3WyRQzxrqzxNbJL13SKDxnenNZcaAGXgoPdhyfAsTQyaa/ZzEzBJGD/TCpyMTJhtis0CtUCgYPNg0C0lrUf3DD5xZvoKwrzahsoE+2p5jxVXInfMYFzgdQRDwXHg9DYcOUf7WW6gS4nGdMsW6ExBFaUU99PxS4UfGPkJmRSb/+PUfRHlGEeYRZv4YoWMhN1GqznPy6PCS5pISdJWVVqlI7IqoADeuiQ/mo9/yedQ1GVlMJ0UeZiAIAqr4eOrbt+bK+qbL98FSZBVV8+SWI0wI9+HB2Z0bJ3127DMqNZXcl2DEosBCqYsA/i0mTYmZJdw3w/pSl6PckavDr+bL7C85pzmHp5PpH8bqs/VkFlXz+BW2KUjrij55mKjJsK022p7U4mPIHOqYFHoJIP1xBz79FMqoKAofehhtoQkeyuZQpYaGsxeVjjvKHVk9bTUOMgdW7ll5vnmTqYSOAcS2Hnsd0NMeiT3hgVnRBOuKkTVUmJ121hnOCQloT52Wzh1aeygesegYF1Kt0XLPhhQ8VApev/F8s6X21DbV8mHGh0wOmUyCvxGFTupkSb5x9bPIPC+LDSBNXWUTkyaABZEL0Oq1bM83z6hpZ5Z0wG5vfRr6aqDOykIZFWUzbbQ9x6qk1Vb7/GmZSkXo62sRdTrUy1dIdpnWwqCZdtAsINg1mBenvMjxs8d5bv9z5p8nhIwGhC7lD01WJggCyhjbr1YG+7qwJLwCgDJPC5bQc0HhS6s3tfXkD1EUeeR/6RScbWDdTaPwc+t8i/5J1idUNVZx30gjJTZD6qKFMAQ8W2V/xHjHEOsTy5bcLWb9LidmlhDh50K4HUyYLqTPBWqDNmrrLTdAs05PpT4TV1kAwa7n+/U5hoUR9MLzaNLTKX3Riu3ni9IBQSpM6YDJIZO5O/5uvsn7hk25m8wbw8kD/IZ0eaCoycrCcdAg5K4u5o3RQ672PkOt6MTaNMv+CTgNGwZyuWTQ5BYArgFWPVD8z958fsgo5rE5Qxg3uPMS76rGKj7O+JgZA2YwzMcI7/MqNdQUWjRQR/m7MsjHdiZNIK2qs89mk1VpmlFTVYPBhMl+RS7tMeq3VBAET0EQNgmCcEwQhCxBELrJ6em9NJeWoauosEugziuvQabKI9pjZIevu192Gd63387Zzz6jatu31plEUZpk/u7YeYBcGreUicETWXVgFRkVpjcCACT5Q50saeIdoMnMtIvsYcCt7BAlbsP4IqWQgkrLdbKWOTujjIlu6/gSFG+1FXVSfiUv/nCMOcMCuXNK1+c/H2V8RJ22jmUjlxn3cAvq0wYEQWD20AB+z6u4uELUSlwZfiVKuVJyjDSBn7NLadaLvUL2AONX1GuBH0RRHALEA5b3EbQRmkwp8NgjSOw5mYog1zAxZHyn1/ivXIFq9GiK/vlPGo8ft/wkitO7dcyTy+S8OOVFvJ28efDnB83rmhE6VtLCK/Iueqn57FmaC4tsUujSIU31UHyUgNgpCILA6zst29/QOSEBTfoRKeUyMA7KjkmpbhaktEbDfZ8dYoCXin9fH9dlml2lppINWRu4POxyor2M69CC+qDUqSZgePfXmoAtTZoA3B3dmTVoFt/lf4em2XhtPDGzBF9XRxIGWCYjqKd0G6gFQfAApgLvA4ii2CSK4jlrT8xaaLKy7KaN7i+Ucjqviuo8s0NQKAhZswaZiwvq+x9o7ZJuEerKofqMUR7UXk5evDL9FUrqS3hi3xOmd3ge0KLBdyB/NB6TmkbYonS8Q4pSQdThGjGBm8cPYvPhM+SX11ns8ar4ePR1dTQez5M+FEWdVAFpIc7WNXHfp4ep1mhZf/PojhsOt+O/R/5Lo66RexLuMX6QgiTJWdHBsuc4o1tMmmwtf9Q01XTcN7QDmpr17MkuY+aQALuZMF2IMSvqwUAZ8IEgCIcFQfiPIAgX7ZsFQbhLEISDgiAc7A250p3RaEdt9HhNKvLmQELdu95OKQL8CXr2XzSdOEHtnl8sN4GidttxI4j3i+fhMQ/zi/oX3j/yvmlj+caA0r1Dg6a2jA87BWpD1WToGO6ZHoGjXMbaHd2XvBtL24FiqkVLyUVRZHt6EbNf3cOh02d56bo4hgZ1nZNcVl/G59mfc3X41YR7hHd5bSvNjdLvioUzYqDFpGmIP7uOlaK1gUkTwNjAsYS4hrDl+Bajrm8zYeodsgcYF6gdgFHAelEURwJ1wEXeoKIoviuK4hhRFMf4+VkmnccaaDLso41q9VrO6bPxdTAuOLlOmYLcw4PaXZaza2w91DKUNxvBjUNu5IqwK1iXuo79RfuNH0vW0tqqgxW1JjMTh8BAHLzs4+2LOhm8w8HFFz83Jf83MYytaYWtfSx7imLQIOSenpJO7TlIOlztoZNeSbWGuz9JYdlnhwj2VLHtb5O5JqH7hhfvHXmPZn0zS+OWGj9Y8VHQNVpUn27PZbEBVDVoST5ZaZXnX4hMkDE/cj4Hig6grlF3e31iZgkqhZzJUfYzYboQYwK1GlCLomioxdyEFLj/cOjOnUNbWGgXbfRQcTqi0ESsp3FvneDggOv06dT+vEcy+bEERengMdAkA3hBEHh64tOEuYfx6C+PUlJnwpY1dByUZEDT+bKCvbJuAOlwU518XhC6e2o4Lo4OvGahVbWh8KUhLU2q1AyMMzvzQxRFvkg+zaw1e9iTU8YTVw5h8z0Tu11JAxTVFrEpZxPzI+czwP1iB71OMeyCrBSop0TZ1qQJYH6kcUZNoiiyI7OEKVG+Hfqk2ItuA7UoisVAgSAIht7yMwHLCW42RGNHbfSnE78iigKTQjs/SLwQ15kz0FVVUZ9yyDKTMOIgsSOcFc68Ov1VGpobeGjPQ8abN4WOlXrtnWmbv76+nqb8fPvJHlUFUFtyXhDycnHkjklhfHekmIxCMw5OO0CVEE/T8Tx01dVSoC7JAJ1pH7inK+q5+f0DPPrVEWKD3Plx+VTumhrRaUHLhbyT/g4Ad8fdbdrk1cngHmqZ7vQd4KJ0YHKkL4mZJTbz/gl0CWRi8ES25m3t0qipt5gwXYixWR9/Az4VBCEdSABesN6UrIc9tdHkkiT0jYGMDDW+P6PrpEkIjo7U7trV8wk01kDFcaP16QsJ9wznmYnPkFqWypqDa4y7yeBK107+0GRngyjaLzWvk7Szv04Jx93JgVcTLbOqVhkMmtKPSO95s0Zq+2UEOr3I+/vyufy1X0grqOL5BcPZuOQSwnyNP1cpqClg6/GtXBd1HUGuQaZNXp1sMUfBzpgdG4D6rO1MmqDNqKkrCe+nzBJkAsywswnThRgVqEVRTG3Rn+NEUZwviqKNfTktg7200UZdI6dqMxHrIwnzMf6PTebigvOES6jZtavnK4/io9J/e9B1/IrBV3DjkBvZkLWBH0/+2P0Nzt5S55R2FYqaTGkzZjfpQ30QHFQXFfx4qBTcNTWcHVmlpBb0PKnJacQIEISWA0VDhWL3OnVuSQ1/efs3nv02kwkRPiSunMri8YOQmZh98Hba28hlcpbELTFt4jUlcO601WQPAwY3usQM28kflw64FE+lZ5eHiomZJYweZH8TpgvpU5WJmqwsu6ym00rT0KPFTxGLo4Npb7nbjJloCwpozO1hrm9r6XjPSqYfHvMwcb5x/PPXf5Jfld/9DaFjJc2z5YNGk5WF3NMThyATV3mWoiAJgke2Oge257ZJg/F2ceSVn7J7PIzc1RVlZKTU8cUnSspJ7iLzo6lZz+s7c7nq9X2cLK9j7aIE3v+/MQR5mN6B6ETVCb498S03xNyAv7OJK0PDjmOAdVvE+bs7kTDAk8Qs2wVqg1HTrtO7OKe5+MNYfbaerKLqXid7QB8K1PqGBkkbtcNK7kDxARBlxHp1XJHYFa6XTgfoufxRlA7OvuDWswCpkCtYPW01jnJHVv68knptN1V9oWOgrgzOnQKgMVPqkdilD7K1aG6UPrA6STtzVTqwdFo4e3PLLZKRoEpIoCE9HVGQSSv4Tg4U0wrOMW/dPtYk5nD58EB2rJzGNQkhZr9Hb6e+jVKu5I7hd5h+szoZZIoe7byMZXZsAOnqKoqrbGPSBNKhYmdGTYYGvL2lbLw9fSZQN2Zng15vF210f2ESOk0IwwJN170U/v44xcdRs7OngTpN0kotECCDXIN4acpL5J3L49n9z3Ytyxi20OqDiE1NaHJz7VeRWJQOuqYut/W3XBKGn5uS1T9m91huUiXEo6+qounkqbZS8nbPbGjSseq7LBa89Stn65t479YxvHHjyB5tu3PO5vDDyR9YPHQxPiof0x+gTpZ2XQrrNc8wcJnBpMmGq+oY7xiG+Qxjc+7mi36+iVklRPq7MtiEswBb0WcCdYOdtNF6bT0ZFUdorosgOtDNrGe4zZiJ5sgRtCVm9jVsboSyrB7LHu2ZGDKRe+Lv4dsT3/K/nP91fqH/MFA4Q0ESjXl5oNXiNNROGR9GpJ2pHOUsmx7BgfxKfsur6NFwrYUvqanSCrWxSurqDew/UcEVa3/hnV9OcMPYgSSunGaRLfdbqW/honDhtmG3mX6zrlnK0LGyPm0g0t+VMBubNIFUqZhzNofMyrbktaoGLQdOVPZK2QP6UKButJM2eqj0EDpRh64+gpgAMwP1zBkA1O7ebd4kSrOkTh0W3s7eHX83k0Im8WLSi2SUd2LeJHeAYKnwxe4ViepkKY/creut7aJxAwnycOKVn3q2qnYMD0fm5iblU7d8SDacPsyTW46w6N39iMBnS8az6toR3ZaBG0NGRQY7T+/k1thb8VCa0aigNAOaG2wWqAVBYHZsAL/nlVOjsUC/TiO5IvwKlHIlW3LbDhUNJkyzhvYHaruisZM2mlSchAw5Dk2DGeDdcQ+77nCMiEAxcCA15lYpmlg6biwyQcaLk1/EV+XLyp9XdnhAA0g6dXE6mowjCM7OOIYNsug8jEZ90Ki0MyeFnL/NiOLQ6XP8nG2+HYIgk6GKi5MCtf8w9IKcz7dtZ2PSaZZMGcwPD0xlYoTlqt/ePPwm7o7u3Bx7s3kPsIJjXnfMGhqAVifyS065zcZ0d3Rn9qDZfHeizajpp8wSfF2VjOwlJkwX0icCtajV0piTYxdtNKkoCZUYQZS/t9kGL4Ig4DZjBvW/70dXa4Z5gI0HUwAAIABJREFUUHE6OLqBl+VboXk6efLKtFcobSjl8X2Pd2zeNGAc6JvRpKXgFBODILPDr111kVTsYmQQun5MKAO8VaxJzOnRqloVH09jTg4PfXaIbF0wscJJNt87iSevikXlaLnKt9TSVPae2cvtw2/HzdG8nRsFyeDiD54DLTav7hg9yAsvZwWJmcU2GxNajJq0New4vaPVhGnWUH+T0yBtRZ8I1I15eYh20EarGqvIqsyisWYw0WbKHgbcZs5A1Gqp27fP9JuL0iV/DysFyBF+I3h07KPsO7OP99Lfu/iCkDGIIjQeP2lf2QOMTjtTyGXcPyOKI2eq+MlMDVUURdLcQ0Gv58S+g4iBcYxzKrCKdeabqW/i7eTNTUNuMv8h6mTp/bHhrlMyaQqwqUkTwJjAMYS6hvJ17tfsPyH5Y/dWfRr6SKC2lzaaUpKCXtRTXTnIbH3agGrkSOSenqbLH3odlBy16EFiR9wQcwNXDr6SN1Pf5PfC389/0S2AJmEA+katfSsS5Y4mGVItGBlCuK8La37KQa83bVVdXKVhyccHWZ4ulY2/MEQgduRkhNoSqajEgiQXJ7O/aD93DL8DZ4V58hr1lVCZZ/WKxI6YHRtAtaaZ5HzbmDRBO6Om4gN8fTQdlULOpMjeY8J0IX0jUGdl2UUbTS5OxlGmRKcZ2OMVdatJ055fELUmHLxUHAdtvcX16QsRBIGnJjxFuEc4j/7yKMV1529lG8UIwM4ViUHx4GB86puDXMYDs6LILqlh+5Eio+4RRZGNSaeZvWYP+46Xs3zBaBSDB+NyPKtds1vLdXwRRZF1h9fhp/LjhpgbzH+QHfRpA1OjfVE6yMzeuZjLNZHXICDwc+F3TI3uXSZMF9I3AnVmpl200QPFBwhyGgqig9mpee1xnTkDfVUV9YcOG3+ToRrOBgUMzgpn1ly6hkZdo2TepGv7QNHUuIFMROlv5oqvJ+i0UHjYrCA0Ny6YmAA3Xt2RQ3M3W/OT5XXc9N4BHt98hOEhHvy4fCp3TgnHucVJTzR0SylKNee76JDfC3/nUOkhlsQtwcmhB7nP6mQQ5FLVpo1xdpRMmnZk2c6kCSSjpjifcTQ6HWDGkN67moY+EKhFvZ5GO5SOV2oqyT2bi4s+BlelA8EePS8gcJ04scWkyQT5ozgN5Erwi+n+WgsQ7hHOM5OeIa0sjTUpbeZNmpJGlB5ahBLLBSmjKTlqdtqZTCawYnYUJ8rq2Jpa2OE1Or3Ie7+cYM7aXzh6popV147gsyXjGdTi66JKSEBXWYm2vFo60LVQD0VRFFmXuo4glyCui7quZw9TJ0vVk1300rQms1pMmo4V286kCcBbNxmZogp375M2HddU/vSBWnv6NPr6eptro8nF0layvmow0QGuFkkLlLm44DJhAjU7TTBpKkoH/6EdeltYizlhc1g8dDEbsjbwQ/4PUuf3E2dw8tZ32ZncahhMoczc1l8+LJBhwe6s3Zl70YFXdnEN1771K89/lyVZd66cxo3jBp7381YlGApfWvKpLSR9/KL+hSPlR7g77m4c5T1omaXXgTrFLrKHgZlD/REEbF78knNyIHLRhR0F22w6rqn86QO1JqvlINHG2mhSURIuChcKir2JsYDsYcB15gy0ajWNOUaYNIliW+m4jXlw9IPE+8Xz1G9PcSI3Cd3ZsziFBdonUBckgWsgeISadbsgCDx4WTSnK+vZlCJ1CGlq1vNqYg5Xv7EX9dkG3rhxJO/dOobADnZOyshIBGdnqUIxKF6qTmzomUOfXtSzLnUdoa6hzIuc16NnUZYNTTVWN2LqCn+3FpMmGwbqgsp6jhU1MMJjBrsKdnFW03tNQf/8gTozExQKlJGRNh03qTiJET4jOVevJ8rfcoHa7dJLQRCMkz+qCkBzzuoZHx1hMG9SypX8Z9OTADgNj4fCVGhusu1k1MmSEVMPdjWXxviTMMCTN3bmkpRfydVv7GXtzlyuGhFE4sppzI0P7nTXJDg4oBoxQip8CTQcKB4xey4AO0/v5FjlMe5NuBeFrIe7JTseJLZndmwAR85UUVRl2Y7tnbGjxWPkr/E30KxvZvuJi42aegu9J1A31sC2ByDLslsQTWYWyqhIBEfLdlPuipK6Ek5WnyTUSUoFs+SK2sHPD1WckSZNrQeJtl9Rg3RY89LUl1CdKEIUQDlmmtSLr6RnQcok6srhbH6Pg5BhVV1YpWHhO79To2nmv7eN4bVFI/F26f53SxUfj+bYMfReLWcFPZA/9KKet1LfYrDHYK4cfKXZz2lFnQQqb6mPpB0xmDTtsNGqOjGzhCh/V6aHxzPcZ/j/t/fm4VHVZ///68xkMpnsewIJJEDCDgn7pgKJUK0WAbWtrda91oKorfZr18f++vTpbrWutbY+rdVWH0nAKi6goLhAArInZGEJZJnsyySZfc7vj5MJCZlkZjJnluB5XZeXdeYsdyfJPZ/z/tz3+6aoeqhRU6gQOolaEwk1n8EH/y1pZjIgimJQ5vOV6CXzH61N+qP0tTTvYqILCzEdP4610c0vdMMRcFpsBoll45ex2pRNfQL8X1jfmKvzAZQ/ZFwtXpaTzE2LJ3Lrsizee/AKCqZ73iChy88Dmw1TTZMkw/iwoViqL6W6o5q759yNWiVDSVntAenzCYb17ACmpEjOdTvLR2k+5gWdvVb2n2njyr4vhw25G6hqr6KsNTSnDIZOolapYfUPofkkHC+S5ZK2xkbsbW0B70gs0ZcQp42jvT2JxKhwkqPlXc3HFKwGPDBp0h+F5KkQHoSSuAGk1/XSMymV3xz/M8cSxgdWp64tBVUYjMv3+VKCIPCrjXP4+XWzifHSROmCk17fnoEPK+qiqiJiwmNYk7Vm1Nfox9gh/c0FWfYA6fO9ckZqQEyadlc0YXeI/d2IV0+6mgh1BEVV8uQeuQmdRA0w4zpImw17fuX1IFBXXOhIDPxG4qK0RVQ19chW8TGQ8ClT0GRNdC9/NBwNSP30SNja27E16Fl4xVdJ1aXy/XgdHXUlgQugtlT6nQryl1VYUhKaCRMuOOk1V4DVey2209zJrppdXDPpGt/qpp3UHZT+HYSORFesmZmO1S7yYeXozbA8YWd5IykxWvIzpXZ+5xffjjM7MNoCo5F7Q2glapUKVv9YamU9+m+fL2cqLwNBIGJaYGqIAWoNtdT31LM4fTGVjd2yyx7gNGkqpHffCCZN3c1gqA/KRuJAzH1VN/Fz5vHYqsdoEew8Em7EYQiACY/DHlB/ZXfo8vIwHj6MmDYHRDs0ev+Y/faZt7E4LGzI3SBPULUHAAEyFshzPR9ZkJVAYlS4X6s/zDa7SxOmDbkb6LZ2s6tml9/uPVpCK1EDTLta8i/e8xufqwNM5eWEZ2ejigpcEb9Tn86Kmku32eaXRA0DTZr2uj5A7x9rU29xlkdqZ8xgVvIsHsm9iU8idfx5/2/8f/OmcrB0B7XsbCC6vDxsTU3Y1H2T6PXuh91eTHF1MdMTpzMzSSY5r7ZUqrOPiJXnej6iVgkUTE9ltx9NmvadbnNpwrQwbSETYiawrXqbX+7rC6GXqAUBCn4Mnefg0Es+XcpUVhbwjcT9DftJikjC1CO1pMpZ8TEQ3bx5qBMShpc/+is+PDch8gemE2WEjRvXP/n9xgVbuLa7l2frdvFp3af+vXn/RmJoPNbr8iWd3HimGSLiPZpKPpCKtgrKWstYn7NenoAcfQ1IIfL5OHGaNJX4yaRpZ5kenUY9xAtcEATW56ynRF/C+a7zfrn3aAm9RA0wpRAmLIWPfg/W0Q2+tLW3Y6tvIGJW4DYSRVGkVF/K4nGLqWzqBmCqjDXUAxHU6j6Tpg9dmzTpj0q+wroEv9zfUy6e/C6ER/JTzQSmiBr+396h5k2yUnsAIpP84sM9GiKmTUXQaqUNxfQ5Xld+FFcXo1FpuHbytfIE1HZKqrMPEWnIyeW5kkmTP+QPURTZVdY0rAnTuinrUAkqiquLXZwdPEIzUTtX1YZ6OPjiqC5hPnkSCGxH4pmuMzQbm/v0aQPpsRHERfqvdTu6YDWOri56D34+9M0Q2Eh09PRgOXt2yM8gMnMxjzU2YXVY+f6e7w8yb5KV2hLIDKy/8kgI4eFEzJrVt6GYB01lHm+aW+wW3jz9JoUTC0c3ZssV/U8coSENOXGaNO0sk9+k6VhdJ/ou07CTxtOj0lk+fjnbT23HLlOZsByEZqIGmHSF9M/ex8Di/VQTZ8VHIKe6lDRI+vSS9CVUNhrITYv26/2iV6xA0GqHelSbuqTVkgwlab5gqqgAURxadZO5iElGA//fjDs52nKU3x/4vfw3N7ZDS2XIPdbr8vMxlZXhSJ4FNpMUowd8cP4DOs2d8m0igpSotbFSCWeIsWZmGnUdRsob5DVp2lXWiEqAgumpwx6zMXcjTb1NfFrvZ2nOC0I3UQOs/gn0NEGJi6khbjCVDdZGA0GJvoRxUeMYF5VBVWO3z8MC3KGKjCRq2TK6LzZpajwu/TvIFR/95ZEXf1lOkB6119pU3DLzFl45+Qpvn3lb3pv3l52F1mO9Li8P0WLBbOj7EvdQpy6uKmZc1DiWjlsqXzDnS6Vqj2CMRnND4Yw0v5g0vVfWyMLsxBG7SVdlriJBmxBS8kfo/YQGMnEJ5KyBT56QWsy94GJt1N84RIekT6cv5ny7EbPNIYsHtTuiCwuw1tVhrhywMgugB/VImMrLUCckEJZ+0WNmfBZEpUBtKQ8ueJB5qfMk86aO0/Ld/Hyp1JWZMV++a8pAv5NeTRuE6TxqfGnobuCz+s9Yn7MelSDTn6y5W5o6HiIVMReTEiMNmt1ZLt8exvm2Xk7qDf2t6sOhUWu4dsq17D6/mzZT4KbOjERoJ2qA1T8CYxvse87jUxy9vVjOnAmoPl3VXkWHuYPF4xZT0eep6+8VNVwwaTK8P0D+aDgiJcIY1zpcoHC27w9p+BEEaaVbW4pGpeF3V/wOXZiOB/c8SK+1V56b15ZC6kzQ+v9n4A2atDTCxo3DeOSY1NrvwYbitlNSudh1OdfJF0j9IRAdIffEMZA1M9M5XtdFfYc8DSjO1bknsxE35GwIKaOm0E/UGfNh2jXw6ZOS7ugBppPDaKN+xFk/vTh9MVWNUqL2t0YNEJacjC4vj+4PBrST649Km1VB3EQTLRbMVdXD/wwyF0ljwnrbSItK47dX/JazXWd59NNHfd9Acjig7kDI6dNOdH0TX/pbyR3D1ws7RAfbq7ezZNwSMqIz5Auitq87NEQaXVyxZqakIztd7nzFacLkHOgwErkJucxJnkNRVWgYNYV+ogZpVW3uhM+e9uhwU7nU8RXIFXVJQwlZsVmkR6VT0WhgQqKOyPCwgNw7uqDggkmTzSx5NwRZ9jBXV4PVOrz85FzJ9Zn6Lxm3hM35m3n77Nv86+S/fLt5axWYOkN2tajLy8NaV4dNNxnMXdBxdthjS/Ql1HXXsSFHxk1EkD73pFyITJT3ujLSb9Ikg07d0Wuh5GybV5PGN+RuoLqjmhOtJ3y+v6+MjUSdPhtmbYB9z0JPq9vDTeXlrrVRP2Fz2DjQeIBF6VJiqGw0BET2cBJTWABA9wcfSCVfDlvwNxLL3VTdjJ8nacgDDJrunHMnKzNX8rsDv+NIs/dde/2EaNmZk36Dppa+Da0R5A+nAVNhVqF8AYhiX6NLaH6ROREEgTUz09h3upUuH02a9lQ0DzJh8oSrsq8KGaOmsZGoAVb9UJqm/cnjbg81lw2jjfqJ8tZyuq3dLElfgsXm4HRzj99ax10RPnky4VlZUpdiQ4i0jpeVo4qMJDxrmMnv2mhInTUoUasEFb+87JekRabx0IcPjX7iRm0pRMRBUmCHRXhKxKyZoNFgrGmXnP2G2VDsNHfyfs37XDPpGrRqz6enu6X9LPQ0h6w0NJA1M9Mkk6YK30yadpY1khqjJa/PhMkTYsJjWJu9lrfPvB10o6axk6hTpsGcr0qleobhH4VEiwVTVVVQ9OmF6Qs509KDzSH6rXXcFYIgEF1YSM/+/djPHJRqY+OzA3Z/V5jKytBOnz7y5PcJi6QyugEabZw2jj+s+gOtxlYe2fvI6JoOzpdCxsKQLDsDUGm1RMyYgfHocUiZPuyKeseZHVgcFjbmbpQ3AOcMyRCt+BjI/IkJJPlo0mS22dlT0UThjLRBJkyesD5nfUgYNYXmb/JwrPwB2C3w8WPDHmI+dQqs1sA2uuhLyInPIVmXTGXfRmIgV9TQJ39YrfTsOyi1JwcxSYl2O6aKCvflkZmLJI22pWLQy7OSZvHDJT/k0/pP+fPRP3t3c7NBkn9CPAnp8vIwHj+OmDJ72Frq4qpiZiTOYEaSzL/LtaWgiYKUwPrgjIZ+k6aK0Zs0fXaqlR6L3W1ZnisWpi1kYszEoNdUj61EnTQF5n0TDvwNOmtdHnLBgzowNdRWu5VDTYdYnC4lhspGA2qVwOSUwDn2gdTxpk5IwHBcH/SNREvNOcTeXvebuf0bikMHCdyQewPrpqzjuSPP8XHdx57fvO5zQAz5x3pdfh6iyYTZPl5q6rrI9vVk20nK28rlM2AaSG2JVE2lDsxmt69cOTMNg8nG/tOjq2neWdZIZLiaZVOSvD7XadRUqi8NqlGTx4laEAS1IAiHBEF4058BueWKh6XNkI9ctx2byt1oozJzrOUYRpuRxeOkRF2hN5CdFIk2TIYRSV4gqNVEL51Hd51GWqUFEVNZX9WNO/kpKUdykXORqAVB4CdLf0JuQi6P7H2Ehu4Gz27uvFYIl50B6PKk9v7e5r7fk4vkj+KqYsJV4Vwz+Rp5b2w1SoN1Q3wjcSBOk6bRlOmJosiu8kauyE1xacLkCaFg1OTNivp+oNxfgXhM/ERYcKtkgdp+dsjbHmmjMrJfvx8BgYVp0gqustEQUH16IDGzUnFYVfQ2B3elZCrvm/w+ZcrIBzobX4aZoagL0/HYqsewO+x8/8PvY7F74E9eWwrJ04LuGugOTcZ41MnJmM72rRIHyB9mu1l+AyYnDUekqqAxlKgjw8O4PHd0Jk3H6jpp7DJ7Ve1xMWlRaawYv4Lt1cEzavIomwmCkAlcA7zg33A85PKHpN3yD3836GXR4cB88mRAW8dLGkqYnjidOG0cRoudmrbegOvTTqJSexHUIoaDVUG5vxNzeTkRubmeTX7PXCTVfZs6Xb6dFZvFL1b8gmMtx3js4PB7E8CYKTsD6YlBl5+H8ViZNP17wBCB3ed202XpkteAycn5vkaXEJeGLsZp0lTW0OXVeTvLGvt1bl/YmLuRJmMTn9R/Muwx7a+9Rv2Pf4xo8W3giSs8XXY+DvwAGFbNFwTh24IgHBAE4UBzs3/nnRE7DhbeCUdegZbq/pctNTU4PNFGZcJkM3Gk+QhLxi0B4FRzN6IYmNZxV6jaThCVpaX7gz1B66YSRRFTWTlaT6tuJiwCxD5t2TVXZl3J16Z9jX+d/BdnO88Of632M9DbOmaSkC4vD0tNDbaYGYOkj6KqIsZHje//vZKV2lLJayXat8QVaAqmj86kaWdZIwuzEkgYwYTJE1ZmriQxInHY6S+iKNL+z5cxV1Z5tkDxEreJWhCEa4EmURQPjnScKIrPi6K4UBTFhSkpKbIFOCyXPQhhEfDhr/tf8lgblYnDzYexOqz9G4lOj4/cYCRqUQT9UWIW5GCtr8dcUeH+HD9ga2jA3tHh+ZdlxgJAcDuZ/N68e9GqtTxz5JnhD3JKKCFe8eGkv/GlNxU6asDYTn13Pfsa9slrwDSQ2gNj5vMZSEqMlvkTE7xK1E4TJl9kDycatTSwYTijJtPxE5grK4m/XuZSyj48+U1YAawTBOEs8G+gQBCEf/olGm+IToEl98Cx1/uHhJrLyz3TRmWipKEEtaBmfprk0FbZaCBcrSI7KQgTrzvOgamT6JUrh5o0BRBnR6LH8lNEnFQj7yZRJ+mS+Mb0b/DOmXeoah9G2qkthfBoqTZ5DKCbPRvUaoxNfS/oj7G9ejsgswGTk85aaRjHGJCGXHHljDRO1HdR56FJ03temDB5gtOo6c1TQ+spOoq2Imi1xF4j8+ZvH24TtSiKPxRFMVMUxWzg68AHoije7JdovGX5FukPc8+vAKk0z2NtVAb26/czO3k2URqpFK+i0cCU1GjC1EGoeuzrbgubvnyoSVMAMZWVez/5vc9JDzdyzW2zbiNSE8kzh4dZVdeWSmVnqsBW3IwWVWQk2mlTMZ5pAcBRf4Rt1dtYOm4p46PHy3/DEJsh6S3OhPu+h9Ufu8oamZrmmQmTJ+Qk5DA3eS7F1cWDpEWHyUTXm28R86W1qGP88zQ9tuqoLyYyEZZtgvI3EOsPYyr3Qhv1kR5rDydaTvTLHgCVegPTAuCY55KGI5J3RupMogsLMJ04gVXvx3mEw2AqLyd80iRUkV48VWQukpwRW0+NeFh8RDy3zLyFXed2Ud56UQGSpVcamBCi/h7DocvLw3TiJGLUOPbX7aW+p94/m4ggyR5hEZAW3IHHoyUnNZrJHpo0jcaEyROcRk3HW473v2Z47z0cBgPx198g670G4lWiFkVxjyiKMk3WlIll34WIeGzbf469vT1gG4kHGw9iF+399dMGk5X6TlNw9GmQNqOSp0F4JDGFkoGP4YNhJpT7kVFNfh+h8eVibpl5C7HhsTx9+CInxYbDY67sDKRE7ejpwayZRnFXJbHhsRRMLPDPzWpLpfFsYYF54vQHnpo07a5o6jNhkteY7arsq9CF6SiqvmDU1LG1CM2ECUQu8t+TytheUYOkca7YgulzqWwmYkZgSvNKGkrQqDTkp0iNC5WN0tTxYFV8SB7UUkeidvJkwrOz6X4/sIna1t6OTa/3vjwyZRqEx3iUqGPDY7lt1m18WPvhYIe9MfpYH5kv/f60dcbwfpiNa7K+JK8BkxObBeoPj7nP52KcJk173Jg0OU2Y5mbIW4ceHR7Nmqw1/UZNlnPn6N2/n/jrN/q1d2PsJ2qAxfdg6pZ+IBHTvdBGfaBEX0J+aj4RYREA/R4fQWl26W4CQ8Og1vHowgJ6SkqwG+QdDjoSo666Uakhc8EFM3s3fHPGN0nQJvD0oQGr6vMlkDAJopK9u3eQ0WRloY6L43RNCxZBYGOCn7pK9cfAbh6TFR8DmeeBSZPZZufDimaunOm9CZMnbMjZQI+1h501O+koLgaVirj1fmj1H8Clkai10ZjIJTzWiqr5sN9v12nu5GTbyUH6dIXeQGS4mox4nd/vPwRnDe4Aa9OYwkLJpGnv3oCF0Z+oRyM/ZS6CxhMeTZyP1ERy55w7+azhMw7oD1xodBmDSUgQBCLy87BXNzDDbGF69yitXd3R/8QxtqShi3E2r+w52YTF5rqt49M+E6Y1M+TVp50sSFvAxJiJbKsoorN4G1GXrUDjZ+/7SyNRA6aGXiJSwuCD/3ZbPeArB/QHEBEHbyQ2GshNi/HLN7hbnF1t6Rc2iXR5eagTEzEEsPrDXF6OZvx41PGee/72k7lImuFXf8ijw7867ask65J56vBTiB3nobtxzCahnqkZpDZZuKHT7vFUcq+pLYHYDIj1QzVJgFkzMw2D2UbJGdcmTbt8MGHyBEEQ2JC7Acu+Umx6vV83EZ1cEola0kYbiVh4BdR8Aqf3+PV+JfoSdGE65iRfSIyVjd1MTQ1WxcdRqdtMdyFBCmo10atW0f3RR4hW36ZjeIpXHYkX40yy5z2TP3RhOu6eczcHGw+yr/zffdcYm/rr3nipkHpld6ZHU8lHxRhprfeEy3NTiNCo2Fk2tKrJ4ZBMmFZOHb0Jkyesm7KOwqMilpgIYlav8tt9nFwSidrsbLJYczPEZsLuX/p1VV2iL2F+6nw0ag0Ard1mWrrNQTNjouGIy9FbMYUFOLq66D1wwO8h2Lt7sNTUjL7qJjIREqdcMLX3gBum3kB6VDpPnf0PYpgO0oLrGjgazHYz/1YfRBRA1ZUoNW/ZZf5iNTRKDVGXSKLWhau5LCfFpUmTHCZMnpBo1rCoCj6ercYe5v80ekkk6n5tdPZcWPmwtHqoes8v92oxtlDdUd0/HxEuVHwExYzJ1Cl5XLgYvRW1fDlCRIQ0osvPmCtOSpPffam68bDxxUm4Opx75t7DUWsHe8dPh74vzrHE+zXv0yx048jOwKi3SRt+LZXy3uQS0acHsnZmGvWdJk7UDzZpksuEyR1db7yB2i7y1iwTn9Z/6td7wSWTqMsJGz9O0kbzvwkJ2X5bVR/QX5ia7SSoFR/6vsL79KGJWqXTEbV8OYYP3ve7SVP/wIZZPiTqCYskE/2Ocx6fcl321WRabTyltQXNiMoXiquLyYjOIHHBUozVDdKvrNw6dW0pqDRBn6MpJwUzUl2aNO0sa2RRdgLxkf6rFRdFkY6tRWjnzKZnQhLFVf73qb40EnV5+YXaXbUGVj4i/bKflH/GwX79fmI0MUxPvOAnUdFoIE6nITXGD/Wv7nBqmsNMHY8pLMBW34D55Em/hmEqL0edmEhYqg8rGS8aX5xoGsv4Tkcn5bZO3j8XHH+T0VLXXce+hn1cl3Mdkfn5OAzdWIzRI04lHxW1B6TfD02EvNcNIsnRQ02azrX2UtFo4Eo/VXs4MR0/jrmykoTrb+Ark7/CnvN7aDW2+vWeYz5RO3p6sJw9O1gbnftVSMqF3f8zaHCqHJQ0lLAgbQFhqgvm/FWNBqamRQds6vkgGo5AVCrEuC4P6jdp8nOXoqlchsnvqbNAE+lVoqa2lGu6e8iOzuTpw0/jEOX9efuT7dXbERBYP2X9BSc9y0R5NxTtNqj//JKSPZysmZlGWcMFk6adfR4ga2XuRryYjq1bESIiiL3my2zI3YBNtPHmaf8OvhrzidpUUTFUG1WpYdUj0pDTE0XDn+wl+h495wzn+tvGQXoMqtAbgjYsgIajIz7ShiUno8vP92uXosNiwSzH5Hd1GIyf73WiDoubwHfnb6G6o5qaye6YAAAgAElEQVR3z77rWwwBwu6ws616G8vGL2Nc9DjCp0xBFR2NsTNGak6Ra4HRdAKsvZdsogapHA9gZ5meaWkxTPSje6XDaKTrzbeI7TNgmhI/hbkpcymuKvar9Db2E3X/MNuLksSsjZA6U3LWs9tkuVeJXiodG1g/3dhlpstkC44+bTVJ01GGkT2cxBQWYCorw9rg4dxBLzFXVYHNJs9kncyF0peP1eTZ8X1lZ1/K/hI58Tk8c/gZbA55ft7+ZL9+Pw09DWzIkQyYBJUK3dy5GOvM0mT29jPy3OgS3Eh0MiUlmskpkklTR6+F0rPtfq/2MLz3Ho7ubuKuv77/tY05GznVeYpjLcf8dt+xn6jLyyRtNO2iH5BKBat/BK3VcOw1We61v2E/8dp4chNy+1+r6NtIDMqKuukEiHa3U8ejC/xr0tRfHimHIVbmInBYPdtQ62qAzvOQuQiVoGJz/mbOdp3lrdNv+R6HnymuKiZOGzfIgEmXn4e5thmHVZBP/jhfKklj8RPluV6I4TRp2n64vs+Eyb+JumNrEZqJE4lcdOGL70vZX5KMmqrke3q/mEsgUY+gjU6/VpIF9vza59pUURQp0ZewKH3RoMkblfogJmoXreOu0E6eRPikSX6TP0xl5aiiotBMlCEZeLOhWHdg0DkFEwuYkTiDZ488i9URmCaf0dBpljY+r5l0DeHqC9UJuvx8cIgYOyLk21B0NroEY/8kAKydmYbNIfKH9ypIi9UyR2YTpoFYzp2jt6SE+I0bB+Wb6PBo1mat5Z2z79Br7fXLvcd0ohYtFsxV1cNro4IAq38ijTk65NtQmlpDLfoePUvSB8+xq2w0kBytJdHHmWyjQn8UtHFSOaIbYgoL6Ckt9YtJk6msDO0MmSa/x6RJqz9PDJrOl4A6vF/6EQSBzfM2U9ddN+xsu1DgzdNvYnVY2Zg7eGxTxByp09VozJBnRd3bBm2n+uZSXprkT5BMmrpMNgpn+MeEyUlHUZFkwLRhqAHThtwLRk3+IGQStcFk5d5/HqTo81qPzzFXV4PVOrI2mrtGWlF89DvPdU8X7NfvBxi0kQhSop6WHsTW8fQ5Hq2WogsK/GLSJNrtmCoq5LWXzVzkWYdi7QHpaSLsQlnk5RmXMzdlLn8+8mfMdrN8McmEKIoUVxUzI3EG0xIHOz2GJSQQnp2NsT1Skn583ZyqHfzEITdWvZ6G/3oUa1OT+4P9hFolUDhDKgn1p+wh2u2SAdPll6G5WGYF5qfOJys2i+Jq/9RUh0yijtaGca6tl8d3VWG1e7bjbfJEGxUEKPgJdNXB538fdXwlDSWk6FLIjs3uf83hECWPj2DIHnabNNHEzUaik36TJpnlD0tNDaLRKO/AhsxF0s+rs274Y+xWycDpoiQkCAL3zbuPxt5GXq98Xb6YZKK8rZyK9oohq2knuvx8jHU9iN3NYPBxQk9tCQhqGD/Pt+u4QLRYqLv/ATpefZWWJ5+U/frecNvySazPH89yP5kwAfR88gm2xkbiB2wiDkQQBG7IvYEYTQxWuS0ACKFELQgC3187lXNtvWw96Nmq2nSizDNtdNJKyLoM9v5BGtnkJU59evG4xYO0qdp2I0arPTjDAlqrwGbyuNtMUKuJXi2/SZPphB8mvzvHaY2kUzceB5vR5WpxSfoSFqYt5IVjL2C0eTYINVAUVRWhVWv58uQvu3xfl5+HvcuItUftu/xRWwppsyBcnpmBA2n83e8xHjlCxJw5dBQVY6mpkf0enjJzfCyPf30e2jD/mTB1vL4VdWIiMatWDXvMbbNv48nCJ/s9gOQkZBI1wOppqeRPiOdP71dhttndHm8qL0c73QNtVBCg4MeSFeaBv3od1+nO07SaWofo0/0VH8EozXNuNrmp+BhITGEhDoOB3lIv6pTdYCovR5B78nv6HFBrR07UIzzWO7XqFmMLr558Vb64fMRkM7HjzA4KJxYSGx7r8pj+xpeWcN9ayR12qD3oF9mja8cO2l96iYRv3ULm008haDS0PDPMwOFLAFtbG4bdu4lbty5gg7MvJqQStSAIPLR2GvWdJl4tPT/isf3aqKe1u1nLYUoBfPxHMHu3oba/QdKnBxoxwQWPj9xg2Jvqj0qDSpOnenxK1LJlsps0mcrL0E6diqCRcRURFi49KYykU9eWQnQ6xGW6fHtB2gKWj1/O347/jR6r+2EEgeD9c+9jsBiGlT0AtLm5CJGRGHuSfUvUzRVgMcieqM2nT9Pwk5+iy88n7aGH0KSmkvCNb9D5nzcxnxp5OPFYpfONN8BqJf764X9u/iakEjXAipwkFk9K5KkPqjFZh19VW2rOIfb2eqeNrv4J9LbC/j97FVOJvoSM6AwyYwYnhcpGAxnxOmIiguDa1nBEauhRh7k/tg+VTkfUihUYPvhAli4qURQxl5XLK3s4mbBY0qBtFtfvny+RmmNG2EjdnL+ZdnM7r5S/In98o8BpwHTxF/5AhLAwdLNnY2yL8E36cD6NyDj1xtHTQ+2WLQhaLRmP/7F/dZl0152oIiJofuop2e4VKoiiSOfWrUTkzUWbm+v+BD8RcolaEAS+v2YqTQYz/9w3vO41qvl8mQtg6tXw6Z/A2OHRKQ7RQam+dFA3ohOpdTwIq2lR7Btm670bWkzBamwN8pg02errsXd2ovXH5PfMhZLlZ6OLbq+eFqlzz00SmpMyh5WZK3nxxIt0WbpGPNbf1Bpq2d+wn/U56wfV4btCl5eHSd+Lo+UcGEc5mqu2FHQJkDh5dOdfhCiKNPzXo1hOnSbjD78fNHoqLDGRhG/dguHtdyRLh0sI07FjmKuqid/oehMxUIRcogZYMjmJy3OTeXbPKXrMrtuBTeVlo9NGV/9I8nDe55mmVtFWQZela8gqyGp3cLq5Jzj6dEeN9P/Bw4qPgUSvWiWZNMkgfzirbnRytI5fTH/jiwv5w4uys035mzBYDLxU9pKMwXnP9lOSAdN1U65ze6wuPw/sIqb28NE3vsjc6NL+r3/R9eabpGy5j6jly4e8n3T77ahiYmgOcgWI3HS8fsGAKZiEZKIG+N6aqbT2WPjfT8+6fN9cXj46bXTcXJixDj57RmoIcIMrfw+AmtYeLHZHcCo+nNqlCw9qd4QlJaGbNw/DB75bgprKykGlQjvND5Pf4zIhZrzrDcXaUlCFwbh8t5eZkTSDNVlreKnsJTpMnj1FyY3TgGn5+OWMix7n9vj+DcVWzejkD2OH5AGTKY/sYTxyhMZf/ZqolVeQdM89Lo9Rx8WRePttdO96H+Ox47LcN9g4jEa63nqL2C99CXV0kHol+gjZRD1vYgKF01N5/qPTdJkGl5OJoojJF2109Y/A0g2fPOH20BJ9Cdmx2aRFDS5yD+pUl4ajUn1s2uhWsjGFBZjLyrHW1/sUhqm8nPBJk1Dp/DR5PXOh6xmKtSXS2K1wz1zSvpv3XXqtvbx44kWZA/SM/Q370ffoWZ87tKPNFWHJyWgyMzF2xo1uRV3/ufRvGWZI2trbqX3gQTQpKWT85jcjVlglfutbqOPiaH7yTz7fNxToevddHD09xN8QXNkDQjhRAzy4ZiqdRit/+3iwk5itoQF7R8fotdHUGTDnBih5HrqH76qyOqwc0B8YNM3FSYXegCBATrAqPlKmgWZ0CTK6QDIC8nVCuamsTB7HvOHIXCTJPAN/Rg471Hnnr5yTkMPVk67mXyf/RYuxxQ+BjkxRdZFkwDShwP3Bfejy8jC2jHJFfb4UECBjvvfnDkC026l/+AfYW1rIeOIJt9Pl1dHRJN19Fz0f7aX3c8+myYcynVuL0GRNRLcw+EOTQzpRz86I46pZ6fx17xk6ei/s/suija58BGxmqVxvGMpay+i19brcpa9sNJCdFOXXScfD0nDUq/rpi9FOmkT45Ml0+yB/2NrasDU2ytuReDGudOrmk9LTkJdlZ/fm3YvZbuavx7yvo/eFDlMHH5z7gGsnXzvIgMkduvx8bAYr1ppq75u0akshZTpE+GZQ1PLsc/R8/DFpP/4RujmeDQ5O+MY3UCcl0fynsb2qttTU0FtaSvzG64MzEOQiQjpRg7Sq7rbYeP6j0/2vyaKNJudA3k1Q+lfoci0BlOolfdRVoq5oDFLFh6ERuvWj2kgcSEzBanpKRm/SNKwPuJyMz5e06IEGTU4pxEujoey4bNZNWcdrFa/R2NPo/gSZeOvMW1gd1n7faU/R5TsbX8Kg8YTnJ4qilKh9NGLq3vsxLU8/Tey6rxD/ta95fJ4qMpLkb99N77599Ozb71MMwaSjqFgyYFrvfvM3EIR8op6WHsNX5o7nfz89S0u3ZLJjKiuTRxtd+bDk57z3Dy7f3t+wn6kJU0mMSBz0uslq52xLT3A2EvWeWZu6I7qgEGw2uj/6aFTn95dHTp/u5kgf0OikLsWBK+raAxCZBAmTvL7cPXPvwSE6+Muxv8gY5PCIokhRVREzk2YOMWByR8S0aQjacIyt4aD3ovGltRpMHT41uljr66l/+GG0OTmMe/RRr1eU8V//OmFpaTT/6U9jcuCwaLPRWVxM9OWXuzRgCgYhn6gB7r8yF5PVznN7pM4npwe1zyRkw/xvwcG/D5l8bbFbONR0yGX99OnmHhwi5Aa14mOOT5fR5c1FnZQ0ao9qU3kZmowMt7qlz2QukjRp55QeH8rOMmMy2Zi7ka1VW6nv9m0j1RPK2sqobK9kY473HW1CeDgRs2ZjbNd5t6Ho40QX0WKh9sEHEa1WMv70BKpI78daqbRakr9zD8bPP6fn409GFUcw6fnkE2xNTcSFwCaikzGRqKekRLNxfiYv7auh4VwDNr1evk2syx8CQQUf/nbQy0ebj2K2m10mamfreFDGb+mPSl8wPuqPg0yaLMN0/42A3zoSLyZzMVh7pPmXxnZoqfBptXj33LtRoeLPR73rTh0NxVXFaNVarp589ajO1+XlYWoNQ6w97PlJtaWgjYXk0cmCjb/5LaYjRxn3y1+ineT9U4uT+OuvRzN+PM1PPDHmVtX9BkwrVwY7lH7GRKIGuL8wF7tDpPhVaQUoW5KIy4CFd8DhV6D1gldBib4ElaBiQfqCIadUNBrQqAWyk+R3JXNLwxGfNhIHElNQiKO7mx4vTZrs3d1Yamr805F4Mc4Ss9pSqDvY99roE3V6VDo3TruR7dXbOdd1zv0Jo8RkM7Hj9A6uzLpyWAMmd+jy8hDtIqaKKs8nFJ0vhYwF0ig6L+l86y3aX36ZxFtvJfaqL3l9/kCE8HCSN30X0/HjdO/2rbookPQbMF13XdAMmFwxZhL1hMRIvrpoAuf2S2U/smqjlz0oTQr58Df9L+1v2M+MxBku/8gq9QYmJ0cTHhbgj8/UCe1nfdannUQtl0yavJU/nO3nfq34cJKQDZHJkjZde0B6+vGx7OyuOXehUWl49siz8sTogl3ndmGwGkYlezjRzZMaeozNgmSy5A5ztzRHcxRfZObqahp++jN08+eT+tD3vT7fFXHXXYcmayLNf3oSUa6p6n6mc/sbYLMF1YDJFWMmUQNsXp3D5I46uuNT5NVGY9Jg8d1w9DVoOonRZuRoy9Eh01ycVDQayA1GxYe+z/dCpkStioiQTJp27/bq8fRCxccsWeIYEUGQPD1qS6SKj9SZoPVNckrWJXPT9Jt46/RbnOrwj+PbtqptZERnsDB99DW4mrQ0wlKTpHpqT5z06g+B6PDaiMnR00Pt/Q+g0unI+ONjsjkhCmFhpGzejPnkSQzvvSfLNf2JKIp0bH0dXV4e2pycYIcziDGVqMfH68gzNXE0Mp2aVpmtK1c8IBms7/kVh5oOYXPYhvhPA/SYbdS2G4PcOi6P9AEQU1AgmTT11aZ7gqm8HHVSEmGpKbLFMSKZC6VqhnP7ZOm2A7h99u3ownQ8c1h+H+XzhvPs1+9nQ84GtwZM7tDlL8DYqvWs8cW5kZgxVK4bDlEUafjpz7CcOSOZLclc5RD75S8TnjOF5iefQrS795gPJqajR7FUnyIuxFbT4EGiFgRhgiAIuwVBKBME4YQgCPcHIjBX2Lt7iG1t4GxCBk+8XyXvxaOSYOm9ULaNkuq3CBPCmJc6dIRRVVNf63iwhgVEp0lPADIRvXoVqFRemTSNOPndHzgf5a09svkrJ0QkcPPMm3mv5j0q2uR1fNtWvU0yYMrxvQZXl5+PtUeNrepz9wfXlkJSDkQmuj+2j/Z/vkzXjh2kbNlC1NKlPkTqGkGtJmXzfVhOnaLrrbdkv76cdLy+FUGnI/bLwTVgcoUnX/c24PuiKM4ElgKbBEHwY9/w8JgrToIoMmnpfLYdqqO6L2nKxrJNoI2j5OxO5qTMIVIztDSpUt9X8RGsGmqZZA8nYYmJfSZNniVqh8WCubrav63jFzN+vqRNg2xGQwDfmvktYjQxPH34admuaXfY2V69neUZy0mPSnd/ght0+X06dVkVjKTzOhtdvPh8jIcP0/jb3xK9ahVJ377b11CHJWbtGrTTp9P89NOINtdumMHG0dtL144dIWHA5Aq3iVoUxQZRFD/v+98GoBzI8HdgrnBqo9fesAqdRs3juyrlvYEugRMLbuKEo5fFqmiXU6ArGg1EaFRMSPS+vtQnrEZpQ0lG2cNJTEEB5vJyrHUjDJPtw1xZBTZbYErznGijIXWWVJKYJJ92GKeN49ZZt7L7/G6Ot8jj+PZZw2c09jZ63Yk4HBEzZ4BahbHRJnlwD0dHDfQ0eywN2draJLOl1FTG/+bX7sfZ+YCgUpGy5T6sNefo3L7db/fxha533wsZAyZXePXTEQQhG5gHDOkNFQTh24IgHBAE4UBzc7M80V2EUxtNyc7k9hWTePNoA+UN8hjCm2wmHjvwGN/Qv0Myar5S+iq8evOQSdCVjQZyUqNRqwLc/99YJnVR+tg67oqYQs9NmkzlfR2Jgaj4GMhlD8CqH42q7Gwkbp55M/HaeJ46LM90kuKqYuK18ayesFqW66kiIojImeR+huJ5zxtdRLud+ocext7WJpktxflWk+8J0atXEzFnDi1PPzOqun1/07l1K+FZWegWeK7vBxKPf+sFQYgGtgIPiKI4JDuKovi8KIoLRVFcmJLin00mU1lZvzZ69+WTiYkI4487fV9Vl+pLuf6N63nxxItsyNlA8df2kLX6Z1C9C55eDIf+2b+6rmw0BMfa1NlGLLP0ARCenS2ZNO12L3+Yyvomv0+YIHscIzLnBlj6HdkvG6WJ4o7Zd/BJ3SccavLN8a3d1M4H5703YHKHbuFijG3hiHUjNL7UloImSqqKcUPL08/Q8+mnpP3kx+hmB6ByB2lyU8qWLVjr6+nYujUg9/QUy9mz9B44QNz1oWHA5AqPErUgCBqkJP2yKIpF/g3JNf3aaN9KLi5Sw92XT+a9skaO1XaO6prdlm5+8dkvuOPdO3CIDl5Y+wKPLn+UWF0CrLgfvvOJ5Hu8fRO8tJ6u+ioau8xBqvg4Kj36x2f55fIxhQWSSVPXyE8o5rK+jUQ/PioHmq9P/zpJEUk8dci3VfVbp9/C5rCxIVce2cOJbt4CRLuA+aibYb8Z893O0Ozeu5eWZ58lbv164m+8UdY43RF12Qp0CxbQ8uxzOEymgN57JPoNmK4LDQMmV3hS9SEAfwXKRVF8zP8hucZc1aeNzrqwYrh9RTbxkRoe2+n9rv1HtR+xfvt6Xq96nW/N/BZF1xUN9Z1OzoFb34RrHoPag0T97XJuU7/D1NQA69MgbSSmz5VttNLFRBcU9Jk07R32GNFux1RZiTaQ+nQA0IXpuGvOXZToS/onznuLKIoUVRcxK2kWUxM8nwzvUXxOJ72yKpf7JliN0u+HG33aWldH/UMPo506lfT/+lnAV4/OVbWtqYmOV18N6L2Ho9+A6Yor0KSlBjucYfFkWbQCuAUoEAThcN8/Aa9fcdb5DtRGYyI03HPFFHZXNHOwxrMhoO2mdh7Z+wib3t9ETHgML139Eg8vehhd2DBOfCoVLLoTNu1DH7+ARzX/YMVHN3vWKSYXdptkdemHjUQnurw81MnJI3pUW86eRTQaiZgRlKIfv3LjtBtJjUzlqUNPjcqboqy1jKr2Kjbmyl+Dq8nIQB0XibHBAoaGoQc0HAGHbUR92mGxUPvAg4h2O5lPPO6/qTxuiFqymMilS2l5/i84er302fYD3R9/jK25OWQ3EZ14UvXxsSiKgiiKc0VRzO/7Z0cgghvIcNrorcuzSI4Od7uqFkWRt8+8zXXbruPds+9yb969vHbta8xN8TD5xWXyXMaveUS8D03HaXjuMvjwd557MPhCSyXYTH7Rp50IKhUxq1fR/dHeYTd7RjX5fYygVWu5Z+49HG4+zCf13ju+FVUVoVVruWrSVbLHJggCupnTJMtTV056HjjmNf3615iOHWPc//yS8Oxs2WP0hpQtW7C3ttL28stBjQOkTUR1UhLRIWTA5IoxIzSaysrRzpg+RBuNDA/j3lU5fFLdymenWl2e29jTyJbdW/jBRz8gIzqDV699le/mfxeN2rtW2cqmbirTrkbYVALTr4Xd/w3Pr5Jad/1Jvwe1/1bUIMkfju5uekpcmzSZysoRwsPRTp7s1ziCxYacDWREZ3i9qjbajOw4s4M1WWtGbcDkDt2i5VgMYdiqXEgz50ukvYto14/unf95k/ZX/kXi7bcTu3atX+Lzhsj584i64nLaXvgr9m6ZeyG8wNbaimH3HsmASaa2eX8xJhK1aLdjqqgYtsnim0smkh4bwWM7Kwb9gYmiyOuVr7N++3r21e/joYUP8c8v/3NUGqIoilQ2GiRr0+gUuPFF+Por0NMCfymAnT+TtEJ/0HAEwiIgKdc/1+8jatkyBJ2O7mGaX0yjnfw+RtCoNdwz9x5OtJ5g93nPHd921eyi29rtF9nDiW6h1Mhi+tzVVPYDw66mzVVVNPzsZ+gWLCD1ew/6LT5vSblvC/bOTtr+/vegxRCqBkyuGBOJ2lJTM6I2GqFRs6kgh9Kz7eytkoaXnu86z13v3cXPP/s5M5NmUrSuiFtn3YpaNboZh83dZtp7rYNL86ZfA5v2w7ybpYnmz66As34wSm84Cmmz3O7o+4pk0rTcpUmTKIryDWwIYb4y5StkxWbx9OGncYieOb4VVxeTGZ3JgjT/1eDqZs8GAXpPnh78RmcdGOpdGjHZu3uo3XI/qqgoMh6Tz2xJDnRzZhN9ZSFt//t37J2jq9ryBcmAaSu6/Hy0U6YE/P7eMiYStemEe230awsnkBGv4/fvlfP3E39n4xsbKWst47+W/RcvrH2BCbG+1f1W6qVHtCGlebp4WPckfGu71JDyv1+GN78HJnkacRBFyTXPj/r0QGIKCrE1NPTr0U6sdfU4OjsHVd1cioSpwrg3714q2yvZWbPT7fHnu85Tqi9lQ67vBkwjoYqMRJuZhKnOBL1tF95wzpO8qOJDMlv6CZaaGjL+8IeQrGhIue8+HAYDrS++GPB7m44cwXIqNA2YXDE2EnW5e200PEzFTSs0VIf9mt8f+D1Lxy1l23XbuGHqDbKUIVX0TXUZdvzW5FVw76ewbDMcfBGeWQaVMlg7tp8Fc6dfKz4G4jRputijOmgdiUHgquyrmBI3hWcOP4PdMbLjW3F1MSpBxbop6/wel27ODIytmsGNL7UHJFksbfBotvaXXsLw9jukPPgAUUvk80eRk4hp04j98tW0/eMlbG1t7k+QkY6tfQZMV4eeAZMrxkiiLhtRG7XarTxz+Bn+enYLYdo2Envu4PFVT5AWJZ/LXFWjgcSocJKjR+g4C4+CL/0S7twp+VO8ciMUfRt6XG9yeoSzbdjPG4lOwhIS0M0fatJkLu+b/D5V3hrhUEStUrNp3iZOd55mx5nhC5zsDjvbT21n+Xh5DJjcoVuyEodNhfnzDy+8WFsK4/Ih7MLvZe/nh2j87e+ILigg6a67/B6XLyRv3oxoMtH6wl8Ddk9Hby9db+0g9qqrUEcHYUrTKAj5RC2KIqay4bXRY83H+OqbX+XZI8+yNmst/2/236g5N5V3yxpljaOi0cDUtGjPVueZC+Gej2DlI3B8q9SGfrzIdbOCO/RHQVBLpkQBIqagEPPJk1hqL5g0mU6UET5ZhsnvY4TCiYVMT5zOs0eexepwXYL5af2nNPU2yWbA5A7d4hUAGA/1jSSzWaD+8CDZw9baSt2DD6IZN47xv/5VyLZEO9FOnkzcV66l/eWXsTY1BeSeXe+8i6O3N+RrpwcS8onaVt+njV6kTxttRn5X+jtufvtmuixdPFXwFL+54jd8fcEMclOj+ePOSuwOeYZqiqJIpd7gXet4mBZW/1BK2PET4PXb4d/fhC4XDQsj0XAUUqaDJsK783wgpkAyFBo4685UXh5Ya9MgoxJUbMrfxHnDef5z6j8ujymuLiZBmyCbAZM7wrOzUevUGCv7Zj3qj4Hd3F/xIdrt1D30EPb2djKfeBx1rH9KBeUmedMmRJuN1uf/EpD7dRRtJTw7G91830a6BZKQT9QmZ0figCRR0lDCxu0b+UfZP7gh9wa2X7edlROkgnW1SuCBK6dS1dTNf47UyxJDXYeRHot9dMMC0mbBnbtg7X/Dqffh6SVw8O+er671RwMmezgJz84mfMoUDH1dirbWVmxNTZdkR+JIrMxcyZzkOTx35Dks9sFNQG2mNnaf3801k6/xuh5/tAiCQMSUdIy1vWDpudDo0lfx0fzUU/R+to/0n/10TH2phk+cSPzGDXS8+irWenn+ZofDfOYMxgMHibt+Y8g/bQwk9BN12QVt1GAx8Oinj3Lne3eiElT87Ut/46fLfkp0+GCj76tnpzNjXCxPvF+Fze77UM3Kvo3EUbvmqcNg+X3SZmP6HPjPFvjHOmgbwV8YJIvV7saAbSQOJKaggN7SA9i7ui7MSPwCbCQORBAENudvpqGngaKqwV5kTgMmf9ZOu0I3ZzaWLg32UyVSoo7NgNjxdH/4IW8SP00AAA4GSURBVK3PPkfcxo3E33BDQGOSg+R77wWg5bk/+/U+nUXFoFaHtAGTK8ZAopa00Q+b97F+23qKq4u5fdbtvL7udRaluy7yV6kEvrdmKmdaeig65N4M3x2VjX3jt1J9dM1LmgK3/geufRzqDkmVIZ89DcNVFjjbhQNUmjeQmMI+k6YPP7qkW8fdsWz8MuanzucvR/+CySY5vomiSFFVEbOTZpOb4N8mpIvRLZNkFuNn70uleZkLsdTWUfeD/4d2+nTSf/bTgMYjF5rx44m/8UY6ioqwnD/vl3uINhud27ZJBkypoVeuOBIhn6h7y05Qlmhiy+4txEXE8cqXX+F7C783vIlSH1fOSCUvM44ndlVhsfm2qq7UG0iPjSAuUoZHXJUKFt4uNcpMXgnv/gj+uhaaXAyXdXpQp88Z+p6fiZg7F3VKMoYP3sdUXo4mM3PMaJ5yIggCm+dtpsnYxP9V/h8AJ1pPUN1RLbudqSfolq4GRIz7P4aOczjSFlD3wAPgNFuKCNxehtwk3XMPglpNy9PyDxwGyeLV1tw8JjoRLyZkE7Uoiuw49G8cTc3si21kU/4mXr3mVWYle1b9IAgC31s7jboOI68d8O0buqLRIP8w27gMuOnfcP1fpRFLz10Oe34j7eQ7aTgCCZMgIvAJUlCpiFm1mp6P9mI6evQLJ3sMZFH6IpaMW8ILx16g19pLUVUREeoIrp50dcBjUcfGok3WYqysAaDxPxWYjh9n/K9/RXiWf7zKA4UmLZWEm26i8403MJ92IwuOgo6tW1EnJ4e8AZMrQjJR63v0bP5gMy9v+wUAt67/Od/J+47XmzZX5CazMCuBpz6oxmQd3ah6u0OkqqmbaWl+GHgpCNLkkk0lMGs97PkfyeSprq/8qiHwG4kDiS5YjaOnB2t9/RdS9hjI5vzNtJnaePHEi7x95m3WZK0hJjwIAySAiJzxGFvD6ayJpuPN3STeeQcxV14ZlFjkJunuuxAiImh5Sp7RaE5sLS107/mQuOvWhVQrvaeEVKJ2iA5eq3iN9dvXU6ov5TaN9M03ZVHhqK4nCALfXzsNfZeJV/afG9U1alp7sNgcw3ckykFUMlz/grTCNrbDC1fCjoelgaVB0Kf7w+ozaQLGVBWBP8hPzefyjMt57shzdFu7gyJ7OInMz8dhUVG/P5bIhQtJfTB0zJZ8JSwpicSbb6br7bcxVco3vPqCAdPYqZ0eSMgk6k5zJ3e8ewe/2PcLZifPZuu6rcxo1faZpo9++OayKUksn5LEM3tO0WvxflS9cyMxIOO3pl0Nm/bB/Fuh5HnptfTgJWpVRATRl0lNFtovsPThZNO8TQBMiJnAwjTPpn37A91yafWsjtKS8cfHEML8a9YVaJLuuB1VVBQtT8qzqu43YJo3b8xa9IZMoo4NjyVBm8DPl/+cv6z5CxNiJkjz+WRYyX1/7VRaus3847Mar8+t7Pf48IP04YqIOPjK49IIsMXfhuwVgbnvMCR9+9skfeeeMbdL7g9mJc3iwQUP8vDCh4Nagxs+fyWJq3KZ8NtHCfPTIOlgoo6PJ/HWWzHs3InxxAmfr2c8fBjL6dNjchPRiTCasUPuWLhwoXjgwAiDOD3A3t1N5cJFpNy/pb/G0hdue7GEI+c7+OgHq4mJ8Fyj2vTK5xyr7eSjHwSm+0xBQQHsBgPVV64hMj+fCX9+zqdr1f/kJ3TteJvcjz4KaW8PQRAOiqLo8lEtZFbUF2M+eRKQ75H7e2um0t5r5cVPznp1XqXeMPpGFwUFhVGhjokh6Y476P7wQ3oPjX6CkqOnB8OOt8eUAZMrQjZR93fDybSJNTcznrUz0/jL3tN09no259Bic3CmpYepgZI9FBQU+km8+ZuoExNpefLJUV9jLBowuSJ0E3V5OerkZFm10QfXTMVgsvHCx6fdHwycaenB5hCl8VsKCgoBRRUVRdLdd9Pz6Wf0lJSM6hodRUWET5qEbt48maMLLKGbqMvKZG+ymDEulmvmjuNvH5+hrcf1pO2BVPjq8aGgoOATCTd9nbCUFJr/9CevBg4DmE+fwXjwIPFjzIDJFSGZqB0WC+ZTp/zSDffglbkYrXb+/OEpt8dW6g2oVQKTU8autqWgMJZRRUSQ9J17MB44SM+nn3p1bmdx0Zg0YHJFSCZqc2UV2Gx+abLISY1hfX4Gf//sLE0G04jHVjQayE6KRBs2uoG4CgoKvhN/442EjRtH8xOer6pFm42ObduIXrnykihhDMlE3T+fz09ty/dfmYvVLvLM7pFX1ZWNBkWfVlAIMqrwcJK/ey+mo0fp3rPHo3O6P9qLvbllTNdODyQ0E3VZGaroaDSZmX65flZSFDcuyOSV/eeo7zC6PMZosXOurVfRpxUUQoD49evRTJhA85NPIjrcu2H2GzBdcUUAovM/IZmozWXlREyfjqDyX3ibC3IQEXlqd7XL96ubuhHFALWOKygojIig0ZC86buYy8ox7Nw14rG25ma69+whfv11Y9KAyRUhl6hFux1TRQURs/xrApSZEMlNiyfyWul5zrf1Dnm/v+JDkT4UFEKCuK98hfDJk2l56klE+/BumJ1vvAF2O3EbLw3ZA0IwUVvOnEE0mQJiArRpdQ5qlcCf3q8a8l5lo4FwtYqsxEi/x6GgoOAeQa0mZfMmzFXVdO142+UxoijS8fpWdPPnj1kDJleEXKLuH2YbgEGqabER3LI0i62f13K6uXvQexV6A1NSowlTh9xHpKDwhSXmqqvQTp1Ky1NPIdqGumEaDx3GcubMJbOJ6CTkspCprBxBq0U7JTDfht9ZNYUIjZonLlpVVzUa/DMsQEFBYdQIKhUpW+7DUlND5xv/GfJ+x9bXESIjib3qqiBE5z9CL1GXl6OdOjVgHrvJ0VpuXZ7NG0fqqdBLunSXyUp9p0nRpxUUQpDowkIiZs2i5emnES0XOowdPT10vf0OsVdfhSrq0mpSC6lELYqiX1rH3XHPFZOJDg/j8V3SRImqvo1EpeJDQSH0EASBlPu3YK2ro6OouP/1rnfeQeztJf76G4IYnX8IqURtravH0dUV8Pl88ZHh3HHZJN4+rud4XScVekmvVmqoFRRCk6jLL0eXn0/Ls8/iMJsB6NjqNGDKD3J08hNSifpCR2Lg5/Pdefkk4nQa/rizkspGA5HhajLidQGPQ0FBwT3OVbWtsZGOV1/DfPo0xs8/J/6G68e8AZMrPErUgiBcJQhChSAI1YIgPOKvYMzl5aBWo5061V+3GJbYCA3fvmIy759s4p3jenLTYlCpLr0fuILCpULk0qVELl5My/PP0/7yK5IB07p1wQ7LL7hN1IIgqIGngauBmcBNgiD4ZclrOlGGdvIkVBER/ri8W25bnk1SVDj6LpNS8aGgEOI4V9X2lhbaX36Z6FWrLgkDJld4sqJeDFSLonhaFEUL8G/AL76BpvLyoE67jtKGce+qKYCiTysojAUiFywg6rLLAC652umBeFIDlwGcH/DftcCSiw8SBOHbwLcBJk6c6HUgosVC1PLlRK1Y7vW5cnLz0iyaDGaumTsuqHEoKCh4RtqPfkTH669fMgZMrnA7hVwQhBuAq0RRvKvvv28BloiiuHm4c+SYQq6goKDwRcLXKeR1wIQB/53Z95qCgoKCQgDwJFGXArmCIEwSBCEc+Drwhn/DUlBQUFBw4lajFkXRJgjCZuBdQA38TRTFE36PTEFBQUEB8GwzEVEUdwA7/ByLgoKCgoILQqozUUFBQUFhKEqiVlBQUAhxlEStoKCgEOIoiVpBQUEhxHHb8DKqiwpCM1AzytOTgRYZwxnLKJ/FYJTPYzDK53GBS+GzyBJF0aVZiV8StS8IgnBguO6cLxrKZzEY5fMYjPJ5XOBS/ywU6UNBQUEhxFEStYKCgkKIE4qJ+vlgBxBCKJ/FYJTPYzDK53GBS/qzCDmNWkFBQUFhMKG4olZQUFBQGICSqBUUFBRCnJBJ1IEaoDsWEARhgiAIuwVBKBME4YQgCPcHO6ZgIwiCWhCEQ4IgvBnsWIKNIAjxgiC8LgjCSUEQygVBWBbsmIKJIAgP9v2dHBcE4V+CIARn6KofCYlEHcgBumMEG/B9URRnAkuBTV/wzwPgfqA82EGECE8A74iiOB3I4wv8uQiCkAFsARaKojgbyYr568GNSn5CIlETwAG6YwFRFBtEUfy8738bkP4QM4IbVfAQBCETuAZ4IdixBBtBEOKAK4C/AoiiaBFFsSO4UQWdMEAnCEIYEAnUBzke2QmVRO1qgO4XNjENRBCEbGAesD+4kQSVx4EfAI5gBxICTAKagRf7pKAXBEGICnZQwUIUxTrg98A5oAHoFEXxveBGJT+hkqgVXCAIQjSwFXhAFMWuYMcTDARBuBZoEkXxYLBjCRHCgPnAs6IozgN6gC/sno4gCAlIT9+TgPFAlCAINwc3KvkJlUStDNC9CEEQNEhJ+mVRFIuCHU8QWQGsEwThLJIkViAIwj+DG1JQqQVqRVF0PmG9jpS4v6hcCZwRRbFZFEUrUAQsD3JMshMqiVoZoDsAQRAEJA2yXBTFx4IdTzARRfGHoihmiqKYjfR78YEoipfcislTRFHUA+cFQZjW91IhUBbEkILNOWCpIAiRfX83hVyCm6sezUz0N8oA3SGsAG4BjgmCcLjvtR/1za5UULgPeLlvUXMauD3I8QQNURT3C4LwOvA5UrXUIS7BdnKlhVxBQUEhxAkV6UNBQUFBYRiURK2goKAQ4iiJWkFBQSHEURK1goKCQoijJGoFBQWFEEdJ1AoKCgohjpKoFRQUFEKc/x+d3iDMRApX3wAAAABJRU5ErkJggg==",
             "text/plain": [
               "<Figure size 432x288 with 1 Axes>"
             ]
           },
           "metadata": {
             "needs_background": "light"
-          }
+          },
+          "output_type": "display_data"
         }
+      ],
+      "source": [
+        "df = pd.DataFrame(np.random.randint(10, size=(10,4)), columns=list(\"ABCD\"))\n",
+        "\n",
+        "df.plot.line()\n",
+        "plt.show()"
       ]
     },
     {
@@ -5908,32 +5885,32 @@
     },
     {
       "cell_type": "code",
+      "execution_count": 101,
       "metadata": {
         "colab": {
           "base_uri": "https://localhost:8080/",
           "height": 248
         },
         "id": "pitDKaGf-ycy",
-        "outputId": "d26136bd-9bfa-4a15-f9e5-10d3bb590814"
+        "outputId": "b1eead33-f3c7-4dcb-96ce-1eee0526752c"
       },
+      "outputs": [
+        {
+          "data": {
+            "image/png": "iVBORw0KGgoAAAANSUhEUgAAAPUAAADnCAYAAADGrxD1AAAABHNCSVQICAgIfAhkiAAAAAlwSFlzAAALEgAACxIB0t1+/AAAADh0RVh0U29mdHdhcmUAbWF0cGxvdGxpYiB2ZXJzaW9uMy4yLjIsIGh0dHA6Ly9tYXRwbG90bGliLm9yZy+WH4yJAAAYcUlEQVR4nO3de5gU1ZnH8e/p6QugOIIiyCVThIgGxUjwtkpkEzer2JrNYlBUtNVoVrNulBVj5cLuGBPSycao+2zUJAZXs/EKRpOUiQLxvuIF3ceaQcAxtDIoch/uAzNd+0c1yWQcmO7pqjpV1e/nefpRxp46r0z/5lTVqXOOchwHIUR8JHQXIITwloRaiJiRUAsRMxJqIWJGQi1EzEiohYgZCbUQMSOhFiJmJNRCxIyEWoiYSeouQAhdlixZclgymbwbOIbwdnBFoKmjo+OKiRMnri3nGyTUomYlk8m7hw0b9skhQ4ZsSiQSoZwEUSwW1bp168atWbPmbuAL5XxPWH87CRGEY4YMGbIlrIEGSCQSzpAhQ9pwzybK+x4f6xEi7BJhDvRepRrLzqqEWoiYkWtqIUoM05ro5fEK+eySct43b968g2bNmvWxYrHIjBkz1s+ZM2dNNe1KTy2ERh0dHcycOfNjTzzxxIoVK1Y0z58/f/CSJUv6VXNMCbUQGj3zzDMHNDQ0tI8bN253v379nKlTp26cN2/ewdUcU0IthEarVq1KjxgxYvfeP48cOXL36tWr09UcU0ItRMxIqIXQaNSoUX/VM7e2tv5Vz90XEmohNJo8efL2QqHQb9myZeldu3apRx99dPC55567uZpjypCWECXlDkF5KZVKccstt7x35plnju3s7OTCCy9cf/zxx++q5pgSap8opc4EbgfqgLsdx8lrLkmE1Pnnn992/vnnt3l1PDn99oFSqg74CTAFGAdcoJQap7cqUSsk1P44EWhxHOdPjuPsBh4E/kFzTaJGSKj9MQJY1eXPraWvCeE7uaaOIcO0FGAA44HhwEDgoC6vgT38+4FAO7AN2NrltQn4EFhTen0IrAaWF/LZjqD+n0T5JNT+WA2M6vLnkaWvec4wrQOBY7u9xuMGtS+Glvm+XYZpvQks6fJqLuSze/rYrvCIhNofrwJHKKVG44Z5OnBhtQc1TCsBnAL8HfAp3ACPBlS1x+6Dfrj3Dk7s8rX2HoJuS48eLAm1DxzH6VBKXQM8iTukNddxnOa+HMswrX64If4icA5wmGeFei8DnFB67bXJMK3HgYeBhaHuyRvrPZ16SWNbr+Pe06ZNMxYtWlR/yCGHdLz99tt9+ox0J6H2ieM4TwBP9OV7DdM6GDgbN8hn4F7vRtUg4NLSa2/AHwEWhDrgAbn88svXX3vttWsvu+yy0V4dU0IdEoZpDQWm4QZ5MvH82UjAu5kyZcq25cuXVzUrq7s4fnAixTCtE4BrgfOAlOZygtQ94POAWwr57HKdRcWBhFoDw7SSwJdww3yy5nLCYBBwJfBlw7TmA3MK+ez/aa4psiTUASrd9Loc+DrQoLmcMErgXoJMM0zr98D3Cvnsi5prihwJdQAM0zoAuBq4HhimuZyomAJMMUzrOdye+0ndBUWFhNpHhmnVAdcAs4FDNJcTVacBpxmm9RrwfeDXhXzWn7W6yxiC8to555wzevHixQM3bdqUHDp06LGmab4/c+bM9dUcU0Ltk9INsJ8CE3TXEhPHA/OB1w3TuqqQz76quyAv/Pa3v13p9TEl1B4zTKsemANchUyY8cOngcWGaf0U+GYhn61qlZA4kg+dhwzTugBYBnwV+bv1UwL3HsUyw7Rm6C4mbKSn9oBhWp8A7gA+r7uWGjMU+KVhWhcCVxbyWV8mzUSN9CZVMEwrbZjWvwE2EmidpgBNhmldoruQMJBQ95FhWg3Ay8BNuDOWhF4HA/capvW4YVo1PWwooe4Dw7Q+C7wGHKe7FvERXwDeMEzrJN2F6CLX1BUyTOta4EfI312YDQOeMUzrskI++2C53zT+3vGeTr20c3av494tLS2piy66aPT69etTSilyudy62bNnr62mXflglqn0iOddQE53LaIs/YAHDNMaB/y7bw+sVKm07nfrpEmTdmzatCkxYcKEcWedddaWiRMn9nntbzn9LoNhWiOB55BAR9Fs4GHDtAboLqQnDQ0NeyZNmrQDYNCgQcUxY8bsfO+992SDPD8ZpnUq7vXzCb29V4TWl4DnDNMK9Yquy5cvTy9dunTA5MmTt1VzHAn1fhim9RXgacpfjE+E10TgFcO0vF2yyCNtbW2JqVOnjsnn86sGDx5crOZYEup9MEzrOtxnt2tp4YK4Gw48b5jWNN2FdNXe3q6y2eyYadOmbczlclU/9iqh7oFhWlcBt+quQ/iiP/CgYVrTdRcCUCwWmT59esPYsWN3NTY2fujFMeXudzeGaV2K+8iniK8EcF97p7Op6xfLGYLy2oIFCw587LHHDjniiCN2HnXUUeMAbrrpptXVbJgnoe6i9Nv7F+hZR1sEK7WlvThk6649mwb2S1V1Y6oaZ5xxxjbHcTz9ZSKn3yWGaf0j8Evk76RmOA7q3Q07PrG9vaO/7lq8JB9gwDCtKbg7U8qZS40pOk5dYcP2sTv3dGZ01+KVmg+1YVqnA48Cnq69LMLPwcFxHDqLTrKwfvvY9o7OUI50FItFBZQ9zFXToTZM6xTgN8gsq5r07uY9dOzYguM47Okspleu3z52T2cxVGdrxWJRrVu3rh5oKvd7lOOE8pFY3xmmNRx4HXmwpGYdlEnwLycNouHgFKp0bzSZYPeg/nUfqgp6Rp8VgaaOjo4rJk6cWNZEj5oMtWFaKdwnxU7VXYsIpQcK+WzVu5TqUqun37cggRb7doFhWpGdvFNzPXVpPatf6a5DhN42YEIhn23RXUilairUhmkdgXsdHeWtYUVwXgNOidqOnDVz+l26jr4fCbQo3/HAd3UXUamaCTVwM+4PSYhK3FB6liEyauL02zCtzwELqK1fYsI7HwDHFvLZqva4CkrsP+SGaR0I3EsN/L8K3xwO3KO7iHLVwgf9G8BI3UWIyDvbMK2v6i6iHLE+/S4tuL8MeQxUeKMNOKKQz67TXcj+xL2n/gESaOGdetwbrqEW2566NFnjRd11iNjpxH0oxdZdyL7Esqc2TEsBt+muQ8RSHSH/bMUy1MAMZJ1u4Z/PGab1Bd1F7EvsTr9LOzGsAEK9cLuIvDeB48K4nU8ce+qvI4EW/jsWOF93ET2JVU9d2lZlBRDKfZNE7KwAxhXy2U7dhXQVt576a0igRXDGEsJNE2PTUxumlQFagUN11yJqyju4D6SEJkhx6qnPQwItgjcG+JzuIrqKU6gj8VyuiKUrdRfQVSxOvw3TmoC7ookQOuwGhhfy2Q26C4H49NTSSwud0sAluovYK/KhNkzrYCCyy7mK2AjNKXjkQw1cigxjCf0+aZhWKJadjnSoSxM3rtZdhxAlV+guACIeatyhhLG6ixCi5DzDtOp1FxH1UJ+ruwAhuhhACO7vRD3Uf6+7ACG6uVh3AZEdpzZMawwQuS1RROx1AIML+exWXQVEuaeWXlqEURI4TWcBEmohvPdZnY1HMtSGaSUJ2UP0QnQhoe6Dk4GDdBchxD4cZ5jWIF2NRzXUcuotwiwBTNbZeBRJqEXYaTsFj1yoS6c1svyvCDtt93wiF2rgM0SzblFbjjZMa4iOhqMYjmN0FyBEGRTwtzoajmKoj9ZdgBBl0tIBRTHU43QXIESZDB2NRirUhmklgCN11yFEmUbraDRSocb9S+qvuwghymToaDRqof647gKEqMBww7RSQTcatVA36C5AiArUAaOCblRCLYS/Ar+ujlqoDd0FCFEhI+gGoxZq6alF1BhBNxi1UMsGeCJqjKAbjFqoA7+TKESVPhZ0gxJqIfx1QNANSqiF8JeMU/ciqbsAISoU/lArpSYppX7iRzFlkJ5aRE066AbL6vmUUhNwtxOZBqwEHvWzqP2QnlpETeAd0T5DopQaC1xQeq0HHsLd0UPn8qfSU/tgav9HFj7VsOTTuuuIp8QWyAba4v56vmXA88DZjuO0ACilZgZS1b5JT+2xGXULFp884Mn6BerQwbpriadiW9At7u+aeirwAfC0UurnSqnTcZdo0UlC7aFTEk3NNyfv+VRTJr1Ddy0xtifoBvcZasdxHnMcZzpwFPA0cB1wmFLqTqVU4Ev0lnblEB4x1Aer/if1/cOUov+ydOD3cmpJR9AN9nr323Gc7Y7j3O84zjnASOAN4EbfK+umkM92ALuCbjeO6tm2+cn0jXsSyhkC8F4qGfgDEjUkPD11TxzH2eQ4zs8cxzndr4J6sVpTu7GRomP3M5l/LWRUx58XnNhUV3eYzppibl3QDUbt4RMJdZWs9DdeHaS2Hbf3zx3Q0QHDddYUc61BNxi1UAf+FxQnd6V+/OzYxOpTu37t3VSyFaXkfoV/Au+IohZq6an76Nq6+S+cWffaRzZta86kAz89rDHSU/dCQt0HZyZefv265PyTevpvTZmMDGf5S0LdCzn9rtDRamXLnanbxyjV89N4y9Ip3c8exJ2cfvdCeuoKDGPjh4+nZ/dXivp9vWdVMiXDWf6SnroX0lOXaQC7ti/KzNqYVMUR+3vf5rqElp0Za0Q77ryJQEUt1GuATt1FhF2CYufCzKzmA9SuT+7vfXtgTwfsN/SiKu/bOdsJutFIhbr0VNka3XWE3UPp77w4XG08sbf3rUylWlGqLoiaatRbOhqNVKhLluguIMxuTs599oTEitPKee9SGc7y22IdjUYx1C/oLiCsLqxbuHhG3cLPlPv+pkx6p5/1CF7W0WgUQ/287gLC6OREc/P3knM/pVT5P9Pl6bQMZ/nHQUJdtiWA9DBdGOqDVfen5hymVGXb/K5KyuwsHy2zc3bgCyRABENdyGf3oOk3YBh1n0ZZic11iaF+1CQATdfTEMFQl8h1NT1PoyzXbmjvlNlZftLW8UQ11HJdzUenUVbiT+nUapSK6s8/CqSnrtBL1PhDKHembv3INMpKvJVOB/6kUw3ZDjTpajySoS7ks1uBN3XXocvX6h59YUrdqx+ZRlkJW4az/PS0nbO1dTqRDHVJTZ6Cn5l4+fWZyXk9TqOshAxn+eoRnY1HOdQLdRcQtN6mUVaiNZU80IuaxEfsBh7XWUCUQ/0ksFl3EUEpZxplJdoSMpzlkwW6xqf3imyoC/nsbvTt6RWocqdRlqs0nHW4F8cSH/Gw7gIiG+qS+3UX4DdFsbggc0Ov0ygr8U461SrDWb7QfuoN0Q/108R8KuZD6ZufH6E29DqNshLNMpzlF+2n3hDxUBfy2SLwgO46/HJzcu6zJyaWVzV01ZOmTEZ2OvGH1rvee0U61CV36y7AD5VOo6zE8kwqDj/3sAnFqTfEINSFfHYp8L+66/BSX6ZRVmJ1MjnQj+PWuHl2zg7FaEzkQ13yM90FeKWv0ygrsSWRkL2zvHe77gL2ikuoHyYGY9bVTKMs1y6ldspwlucW2zn7Fd1F7BWLUBfy2Z3AvbrrqEaKjt1PZ67v0zTKSrzjLjYoj4h66zbdBXQVi1CX/IAIr4jyu/Q3Xx2stvZpGmUlmjPpDX63UWPeBebrLqKr2IS6kM9+APyX7jr64s7Urc8emWjt8zTKSjRl0u1BtFNDfmjn7A7dRXQVm1CX5IEtuouohBfTKCuxIi3DWR5aA8zVXUR3sfoBF/LZjcAtuusol1fTKCshw1meutXO2aF7kCdWoS75MRD6Req9nEZZiS0yO8sra4E7dRfRk9iFupDPbsM9DQ+toWxc+3h6dj+vplGWa6dSO4owLMg2Y8y0c/ZW3UX0JHahLrmDkO6QOYBd2/+YmbUhqYojg267JZVaLcNZnlgM/LfuIvYllqEu5LO7gJt119GdH9MoK7FUhrO8UASu0bGbZbliGeqSuUCL7iK68mMaZSWaMunQ3dSJoLvtnB3qTRpjG+rStrfX6a5jr+8k7/FlGmUllqfTsm1tdTYC39RdRG9iG2qAQj5rAT/XXccFdYtevrhugS/TKCvxfrLuIN01RNy37Zwd+kuYWIe6ZCbwjq7GT040N89J/mK8X9MoK7E1kZA73333BvBT3UWUQ/sHzW+FfHY7cDEadvToMo1yQNBtd7dDqe1FpWSMum86gKvtnF3UXUg5Yh9qgEI++xIBj10HMY2yEi3pVCiH+CLiW3bOjsxOqzUR6pKbcPe29l1Q0ygr0ZROb9RdQ0Q9AfyH7iIqUTOhLu1rfTHg+7BOUNMoKyGzs/qkFbgkzGPSPamZUAMU8tm3ANPPNu5I3RbYNMpKvJ1OJ3XXEDEdwPQo3O3urqZCXfKf+LQP1zV1v37hrLpXtI5F78v7yTqZnVWZ2XbOflF3EX1Rc6Eu5LMOMAP4k5fHPSPxyhvXJx8JdBplJbYlErIuWfn+gLuSTiTVXKgBCvnsh8AZeDRF82i1suWu1G0fD3oaZbm2KbW1qJSsIFqe1cDFUbuO7qomQw1QyGdbgLOA7dUcR9c0ykq0pFOrddcQEZuAKXbOjvS2RDUbaoBCPvsa8CXcmyIV60/7jkWZWet1TKOsRFMms0l3DRGwHcjaOdvWXUi1ajrUAIV89g/Alyv9PkWxuDAzq+lAtWucD2V5qimT3q27hpDbDUy1c/ZLugvxQs2HGqCQz94HfKOS73kw/V2t0ygr0ZJKyeysfSsCF9k5+yndhXhFQl1SyGfzuMNdvbopec9zJyWWhXLoqifvJ5MyO2vf/snO2fN0F+ElCfVfm0kv25FeULfo5UvqFkwKqB5PbEsoGc7q2Q12zo7drqkS6i5K+13PYB87LoRpGmW5tiq1xVEqFJNKQmaOnbN/pLsIP0TmwxmUQj67GziPbsu/Nqg1rWGZRlmJFen0+7prCBkHt4f+lu5C/CKh7kEhny0W8tmvAv8GcBDb2p5K39gelmmUlViakdlZXezBfbAklj30XhLq/SjkszcDX/ljZlZLRu0Zo7uevpDhrD/bBpxt5+xf6S7EbxLqXhTy2Z8fqrZ8m4jt0bXX2+mUzM5yd6Y8JU7DVvsjoS5HY9sfgFOAlbpLqdQHdcnQPr4akBeBE+PwpFi5JNTlamxrBiYCj+supRLbE2q47ho0uhc43c7Za/f3JqXUKKXU00qppUqpZqXUtQHV5wvlOJGdjKJPY/11wA8hnLOy9tqSUG2nNoyqxZ56M+4uGmVdPyulDgcOdxzndaXUQNxlr77oOM5SP4v0i/TUfdHYdhtwKiE/HV+RTtfi7KxFwPhKbog5jvOB4zivl/59K/AWMMKn+nwnoe6rxrZXgU8DD+kuZV+a0unNumsI0C7cJwI/b+fsPq+cqpQygAlAZFYP7U7ujFajsW0zMJ3G+vtxd9oM1W/35toZznoDmGHn7KpOl5VSB+I+TXid4ziRHO0A6am90dj2G2AccBfuE0uh0JJOhfqa3wOdwBzgJA8CncIN9K8cx3nUi+J0kRtlXmus/wzu/l1H6i7lbxpGNm1LJI7RXYdP/oj7uOfr1R5IuXt23wtsdBwnNJsq9pWE2g+N9SngKmA2oO3R0mONURsdpQbrat8nNnCjnbN/79UBlVKTgOdLx967tc43Hcd5wqs2giSh9lNj/UDgRtwbOIFOBGlLJDZPahh5cJBt+qwV95fkfVHZ00oXCXUQGuuHA98BLgUCWYXklX6Z5i8fPvToINryWRvwfeB2O2f7vrtKHEiog9RYPxq4AbgM6OdnU3PrB7546+BBodsppAKbgbuBfBR3ydBJQq1DY/1Q4J+Bq4FD/Wji+sMOffapAwZEZsmlLt7AHR68387ZO3QXE0USap0a6/sBFwFXACd7eegvjjj8xXfSqaj01O3Aw8Adds5erLuYqJNQh0Vj/Vjca+6LgarXET+5YWTz9kQi7NfUK3HH9udGfQH9MJFQh01jfQI4HXettCxwSF8Oc6wxarOjVBjvfr+LO9PtMeBZuZPtPQm1D5RSc4GzgbWO4/T94Q834CfhhjsLlLXn9aZEYuNpDSPDMj5dBF7F3XTucTtnv6G5ntiTUPtAKXUa7vI591UV6u4a60fgbux3Cm7Yx9HDo76L+2War9Q3nNUJtOA+zPEUsNDO2bLtT4BkQocPHMd5rjTbx1uNbauBuaXX3odbTsQN+Im4If94cyYT1OysDcCb3V7Nds7eGVD7ogcS6ihrbNuKO3940V++Vp9eW1dnAJ8ADGB06Z/DgP77eKW7HNXBXY9tA7Cxy2tDl3+uAN60c3YtztcOPTn99kmpp/6dp6ffPhl/7/gEfwn3Fjtnd2ouSVRBQu2TKIVaxIvMpxYiZiTUPlBKPQC8BByplGpVSlW8/7UQfSWn30LEjPTUQsSMhFqImJFQCxEzEmohYkZCLUTMSKiFiBkJtRAxI6EWImYk1ELEjIRaiJiRUAsRMxJqIWJGQi1EzEiohYgZCbUQMSOhFiJmJNRCxIyEWoiYkVALETMSaiFiRkItRMxIqIWIGQm1EDEjoRYiZv4fDvLUQfTZMhEAAAAASUVORK5CYII=",
+            "text/plain": [
+              "<Figure size 432x288 with 1 Axes>"
+            ]
+          },
+          "metadata": {},
+          "output_type": "display_data"
+        }
+      ],
       "source": [
         "df = pd.DataFrame(np.random.randint(10, size=(3,4)), columns=list(\"ABCD\"))\n",
         "\n",
         "df.plot.pie(y=\"A\")\n",
         "plt.show()"
-      ],
-      "execution_count": 447,
-      "outputs": [
-        {
-          "output_type": "display_data",
-          "data": {
-            "image/png": "iVBORw0KGgoAAAANSUhEUgAAAPUAAADnCAYAAADGrxD1AAAABHNCSVQICAgIfAhkiAAAAAlwSFlzAAALEgAACxIB0t1+/AAAADh0RVh0U29mdHdhcmUAbWF0cGxvdGxpYiB2ZXJzaW9uMy4yLjIsIGh0dHA6Ly9tYXRwbG90bGliLm9yZy+WH4yJAAAYcUlEQVR4nO3de5gU1ZnH8e/p6QugOIIiyCVThIgGxUjwtkpkEzer2JrNYlBUtNVoVrNulBVj5cLuGBPSycao+2zUJAZXs/EKRpOUiQLxvuIF3ceaQcAxtDIoch/uAzNd+0c1yWQcmO7pqjpV1e/nefpRxp46r0z/5lTVqXOOchwHIUR8JHQXIITwloRaiJiRUAsRMxJqIWJGQi1EzEiohYgZCbUQMSOhFiJmJNRCxIyEWoiYSeouQAhdlixZclgymbwbOIbwdnBFoKmjo+OKiRMnri3nGyTUomYlk8m7hw0b9skhQ4ZsSiQSoZwEUSwW1bp168atWbPmbuAL5XxPWH87CRGEY4YMGbIlrIEGSCQSzpAhQ9pwzybK+x4f6xEi7BJhDvRepRrLzqqEWoiYkWtqIUoM05ro5fEK+eySct43b968g2bNmvWxYrHIjBkz1s+ZM2dNNe1KTy2ERh0dHcycOfNjTzzxxIoVK1Y0z58/f/CSJUv6VXNMCbUQGj3zzDMHNDQ0tI8bN253v379nKlTp26cN2/ewdUcU0IthEarVq1KjxgxYvfeP48cOXL36tWr09UcU0ItRMxIqIXQaNSoUX/VM7e2tv5Vz90XEmohNJo8efL2QqHQb9myZeldu3apRx99dPC55567uZpjypCWECXlDkF5KZVKccstt7x35plnju3s7OTCCy9cf/zxx++q5pgSap8opc4EbgfqgLsdx8lrLkmE1Pnnn992/vnnt3l1PDn99oFSqg74CTAFGAdcoJQap7cqUSsk1P44EWhxHOdPjuPsBh4E/kFzTaJGSKj9MQJY1eXPraWvCeE7uaaOIcO0FGAA44HhwEDgoC6vgT38+4FAO7AN2NrltQn4EFhTen0IrAaWF/LZjqD+n0T5JNT+WA2M6vLnkaWvec4wrQOBY7u9xuMGtS+Glvm+XYZpvQks6fJqLuSze/rYrvCIhNofrwJHKKVG44Z5OnBhtQc1TCsBnAL8HfAp3ACPBlS1x+6Dfrj3Dk7s8rX2HoJuS48eLAm1DxzH6VBKXQM8iTukNddxnOa+HMswrX64If4icA5wmGeFei8DnFB67bXJMK3HgYeBhaHuyRvrPZ16SWNbr+Pe06ZNMxYtWlR/yCGHdLz99tt9+ox0J6H2ieM4TwBP9OV7DdM6GDgbN8hn4F7vRtUg4NLSa2/AHwEWhDrgAbn88svXX3vttWsvu+yy0V4dU0IdEoZpDQWm4QZ5MvH82UjAu5kyZcq25cuXVzUrq7s4fnAixTCtE4BrgfOAlOZygtQ94POAWwr57HKdRcWBhFoDw7SSwJdww3yy5nLCYBBwJfBlw7TmA3MK+ez/aa4psiTUASrd9Loc+DrQoLmcMErgXoJMM0zr98D3Cvnsi5prihwJdQAM0zoAuBq4HhimuZyomAJMMUzrOdye+0ndBUWFhNpHhmnVAdcAs4FDNJcTVacBpxmm9RrwfeDXhXzWn7W6yxiC8to555wzevHixQM3bdqUHDp06LGmab4/c+bM9dUcU0Ltk9INsJ8CE3TXEhPHA/OB1w3TuqqQz76quyAv/Pa3v13p9TEl1B4zTKsemANchUyY8cOngcWGaf0U+GYhn61qlZA4kg+dhwzTugBYBnwV+bv1UwL3HsUyw7Rm6C4mbKSn9oBhWp8A7gA+r7uWGjMU+KVhWhcCVxbyWV8mzUSN9CZVMEwrbZjWvwE2EmidpgBNhmldoruQMJBQ95FhWg3Ay8BNuDOWhF4HA/capvW4YVo1PWwooe4Dw7Q+C7wGHKe7FvERXwDeMEzrJN2F6CLX1BUyTOta4EfI312YDQOeMUzrskI++2C53zT+3vGeTr20c3av494tLS2piy66aPT69etTSilyudy62bNnr62mXflglqn0iOddQE53LaIs/YAHDNMaB/y7bw+sVKm07nfrpEmTdmzatCkxYcKEcWedddaWiRMn9nntbzn9LoNhWiOB55BAR9Fs4GHDtAboLqQnDQ0NeyZNmrQDYNCgQcUxY8bsfO+992SDPD8ZpnUq7vXzCb29V4TWl4DnDNMK9Yquy5cvTy9dunTA5MmTt1VzHAn1fhim9RXgacpfjE+E10TgFcO0vF2yyCNtbW2JqVOnjsnn86sGDx5crOZYEup9MEzrOtxnt2tp4YK4Gw48b5jWNN2FdNXe3q6y2eyYadOmbczlclU/9iqh7oFhWlcBt+quQ/iiP/CgYVrTdRcCUCwWmT59esPYsWN3NTY2fujFMeXudzeGaV2K+8iniK8EcF97p7Op6xfLGYLy2oIFCw587LHHDjniiCN2HnXUUeMAbrrpptXVbJgnoe6i9Nv7F+hZR1sEK7WlvThk6649mwb2S1V1Y6oaZ5xxxjbHcTz9ZSKn3yWGaf0j8Evk76RmOA7q3Q07PrG9vaO/7lq8JB9gwDCtKbg7U8qZS40pOk5dYcP2sTv3dGZ01+KVmg+1YVqnA48Cnq69LMLPwcFxHDqLTrKwfvvY9o7OUI50FItFBZQ9zFXToTZM6xTgN8gsq5r07uY9dOzYguM47Okspleu3z52T2cxVGdrxWJRrVu3rh5oKvd7lOOE8pFY3xmmNRx4HXmwpGYdlEnwLycNouHgFKp0bzSZYPeg/nUfqgp6Rp8VgaaOjo4rJk6cWNZEj5oMtWFaKdwnxU7VXYsIpQcK+WzVu5TqUqun37cggRb7doFhWpGdvFNzPXVpPatf6a5DhN42YEIhn23RXUilairUhmkdgXsdHeWtYUVwXgNOidqOnDVz+l26jr4fCbQo3/HAd3UXUamaCTVwM+4PSYhK3FB6liEyauL02zCtzwELqK1fYsI7HwDHFvLZqva4CkrsP+SGaR0I3EsN/L8K3xwO3KO7iHLVwgf9G8BI3UWIyDvbMK2v6i6iHLE+/S4tuL8MeQxUeKMNOKKQz67TXcj+xL2n/gESaOGdetwbrqEW2566NFnjRd11iNjpxH0oxdZdyL7Esqc2TEsBt+muQ8RSHSH/bMUy1MAMZJ1u4Z/PGab1Bd1F7EvsTr9LOzGsAEK9cLuIvDeB48K4nU8ce+qvI4EW/jsWOF93ET2JVU9d2lZlBRDKfZNE7KwAxhXy2U7dhXQVt576a0igRXDGEsJNE2PTUxumlQFagUN11yJqyju4D6SEJkhx6qnPQwItgjcG+JzuIrqKU6gj8VyuiKUrdRfQVSxOvw3TmoC7ookQOuwGhhfy2Q26C4H49NTSSwud0sAluovYK/KhNkzrYCCyy7mK2AjNKXjkQw1cigxjCf0+aZhWKJadjnSoSxM3rtZdhxAlV+guACIeatyhhLG6ixCi5DzDtOp1FxH1UJ+ruwAhuhhACO7vRD3Uf6+7ACG6uVh3AZEdpzZMawwQuS1RROx1AIML+exWXQVEuaeWXlqEURI4TWcBEmohvPdZnY1HMtSGaSUJ2UP0QnQhoe6Dk4GDdBchxD4cZ5jWIF2NRzXUcuotwiwBTNbZeBRJqEXYaTsFj1yoS6c1svyvCDtt93wiF2rgM0SzblFbjjZMa4iOhqMYjmN0FyBEGRTwtzoajmKoj9ZdgBBl0tIBRTHU43QXIESZDB2NRirUhmklgCN11yFEmUbraDRSocb9S+qvuwghymToaDRqof647gKEqMBww7RSQTcatVA36C5AiArUAaOCblRCLYS/Ar+ujlqoDd0FCFEhI+gGoxZq6alF1BhBNxi1UMsGeCJqjKAbjFqoA7+TKESVPhZ0gxJqIfx1QNANSqiF8JeMU/ciqbsAISoU/lArpSYppX7iRzFlkJ5aRE066AbL6vmUUhNwtxOZBqwEHvWzqP2QnlpETeAd0T5DopQaC1xQeq0HHsLd0UPn8qfSU/tgav9HFj7VsOTTuuuIp8QWyAba4v56vmXA88DZjuO0ACilZgZS1b5JT+2xGXULFp884Mn6BerQwbpriadiW9At7u+aeirwAfC0UurnSqnTcZdo0UlC7aFTEk3NNyfv+VRTJr1Ddy0xtifoBvcZasdxHnMcZzpwFPA0cB1wmFLqTqVU4Ev0lnblEB4x1Aer/if1/cOUov+ydOD3cmpJR9AN9nr323Gc7Y7j3O84zjnASOAN4EbfK+umkM92ALuCbjeO6tm2+cn0jXsSyhkC8F4qGfgDEjUkPD11TxzH2eQ4zs8cxzndr4J6sVpTu7GRomP3M5l/LWRUx58XnNhUV3eYzppibl3QDUbt4RMJdZWs9DdeHaS2Hbf3zx3Q0QHDddYUc61BNxi1UAf+FxQnd6V+/OzYxOpTu37t3VSyFaXkfoV/Au+IohZq6an76Nq6+S+cWffaRzZta86kAz89rDHSU/dCQt0HZyZefv265PyTevpvTZmMDGf5S0LdCzn9rtDRamXLnanbxyjV89N4y9Ip3c8exJ2cfvdCeuoKDGPjh4+nZ/dXivp9vWdVMiXDWf6SnroX0lOXaQC7ti/KzNqYVMUR+3vf5rqElp0Za0Q77ryJQEUt1GuATt1FhF2CYufCzKzmA9SuT+7vfXtgTwfsN/SiKu/bOdsJutFIhbr0VNka3XWE3UPp77w4XG08sbf3rUylWlGqLoiaatRbOhqNVKhLluguIMxuTs599oTEitPKee9SGc7y22IdjUYx1C/oLiCsLqxbuHhG3cLPlPv+pkx6p5/1CF7W0WgUQ/287gLC6OREc/P3knM/pVT5P9Pl6bQMZ/nHQUJdtiWA9DBdGOqDVfen5hymVGXb/K5KyuwsHy2zc3bgCyRABENdyGf3oOk3YBh1n0ZZic11iaF+1CQATdfTEMFQl8h1NT1PoyzXbmjvlNlZftLW8UQ11HJdzUenUVbiT+nUapSK6s8/CqSnrtBL1PhDKHembv3INMpKvJVOB/6kUw3ZDjTpajySoS7ks1uBN3XXocvX6h59YUrdqx+ZRlkJW4az/PS0nbO1dTqRDHVJTZ6Cn5l4+fWZyXk9TqOshAxn+eoRnY1HOdQLdRcQtN6mUVaiNZU80IuaxEfsBh7XWUCUQ/0ksFl3EUEpZxplJdoSMpzlkwW6xqf3imyoC/nsbvTt6RWocqdRlqs0nHW4F8cSH/Gw7gIiG+qS+3UX4DdFsbggc0Ov0ygr8U461SrDWb7QfuoN0Q/108R8KuZD6ZufH6E29DqNshLNMpzlF+2n3hDxUBfy2SLwgO46/HJzcu6zJyaWVzV01ZOmTEZ2OvGH1rvee0U61CV36y7AD5VOo6zE8kwqDj/3sAnFqTfEINSFfHYp8L+66/BSX6ZRVmJ1MjnQj+PWuHl2zg7FaEzkQ13yM90FeKWv0ygrsSWRkL2zvHe77gL2ikuoHyYGY9bVTKMs1y6ldspwlucW2zn7Fd1F7BWLUBfy2Z3AvbrrqEaKjt1PZ67v0zTKSrzjLjYoj4h66zbdBXQVi1CX/IAIr4jyu/Q3Xx2stvZpGmUlmjPpDX63UWPeBebrLqKr2IS6kM9+APyX7jr64s7Urc8emWjt8zTKSjRl0u1BtFNDfmjn7A7dRXQVm1CX5IEtuouohBfTKCuxIi3DWR5aA8zVXUR3sfoBF/LZjcAtuusol1fTKCshw1meutXO2aF7kCdWoS75MRD6Req9nEZZiS0yO8sra4E7dRfRk9iFupDPbsM9DQ+toWxc+3h6dj+vplGWa6dSO4owLMg2Y8y0c/ZW3UX0JHahLrmDkO6QOYBd2/+YmbUhqYojg267JZVaLcNZnlgM/LfuIvYllqEu5LO7gJt119GdH9MoK7FUhrO8UASu0bGbZbliGeqSuUCL7iK68mMaZSWaMunQ3dSJoLvtnB3qTRpjG+rStrfX6a5jr+8k7/FlGmUllqfTsm1tdTYC39RdRG9iG2qAQj5rAT/XXccFdYtevrhugS/TKCvxfrLuIN01RNy37Zwd+kuYWIe6ZCbwjq7GT040N89J/mK8X9MoK7E1kZA73333BvBT3UWUQ/sHzW+FfHY7cDEadvToMo1yQNBtd7dDqe1FpWSMum86gKvtnF3UXUg5Yh9qgEI++xIBj10HMY2yEi3pVCiH+CLiW3bOjsxOqzUR6pKbcPe29l1Q0ygr0ZROb9RdQ0Q9AfyH7iIqUTOhLu1rfTHg+7BOUNMoKyGzs/qkFbgkzGPSPamZUAMU8tm3ANPPNu5I3RbYNMpKvJ1OJ3XXEDEdwPQo3O3urqZCXfKf+LQP1zV1v37hrLpXtI5F78v7yTqZnVWZ2XbOflF3EX1Rc6Eu5LMOMAP4k5fHPSPxyhvXJx8JdBplJbYlErIuWfn+gLuSTiTVXKgBCvnsh8AZeDRF82i1suWu1G0fD3oaZbm2KbW1qJSsIFqe1cDFUbuO7qomQw1QyGdbgLOA7dUcR9c0ykq0pFOrddcQEZuAKXbOjvS2RDUbaoBCPvsa8CXcmyIV60/7jkWZWet1TKOsRFMms0l3DRGwHcjaOdvWXUi1ajrUAIV89g/Alyv9PkWxuDAzq+lAtWucD2V5qimT3q27hpDbDUy1c/ZLugvxQs2HGqCQz94HfKOS73kw/V2t0ygr0ZJKyeysfSsCF9k5+yndhXhFQl1SyGfzuMNdvbopec9zJyWWhXLoqifvJ5MyO2vf/snO2fN0F+ElCfVfm0kv25FeULfo5UvqFkwKqB5PbEsoGc7q2Q12zo7drqkS6i5K+13PYB87LoRpGmW5tiq1xVEqFJNKQmaOnbN/pLsIP0TmwxmUQj67GziPbsu/Nqg1rWGZRlmJFen0+7prCBkHt4f+lu5C/CKh7kEhny0W8tmvAv8GcBDb2p5K39gelmmUlViakdlZXezBfbAklj30XhLq/SjkszcDX/ljZlZLRu0Zo7uevpDhrD/bBpxt5+xf6S7EbxLqXhTy2Z8fqrZ8m4jt0bXX2+mUzM5yd6Y8JU7DVvsjoS5HY9sfgFOAlbpLqdQHdcnQPr4akBeBE+PwpFi5JNTlamxrBiYCj+supRLbE2q47ho0uhc43c7Za/f3JqXUKKXU00qppUqpZqXUtQHV5wvlOJGdjKJPY/11wA8hnLOy9tqSUG2nNoyqxZ56M+4uGmVdPyulDgcOdxzndaXUQNxlr77oOM5SP4v0i/TUfdHYdhtwKiE/HV+RTtfi7KxFwPhKbog5jvOB4zivl/59K/AWMMKn+nwnoe6rxrZXgU8DD+kuZV+a0unNumsI0C7cJwI/b+fsPq+cqpQygAlAZFYP7U7ujFajsW0zMJ3G+vtxd9oM1W/35toZznoDmGHn7KpOl5VSB+I+TXid4ziRHO0A6am90dj2G2AccBfuE0uh0JJOhfqa3wOdwBzgJA8CncIN9K8cx3nUi+J0kRtlXmus/wzu/l1H6i7lbxpGNm1LJI7RXYdP/oj7uOfr1R5IuXt23wtsdBwnNJsq9pWE2g+N9SngKmA2oO3R0mONURsdpQbrat8nNnCjnbN/79UBlVKTgOdLx967tc43Hcd5wqs2giSh9lNj/UDgRtwbOIFOBGlLJDZPahh5cJBt+qwV95fkfVHZ00oXCXUQGuuHA98BLgUCWYXklX6Z5i8fPvToINryWRvwfeB2O2f7vrtKHEiog9RYPxq4AbgM6OdnU3PrB7546+BBodsppAKbgbuBfBR3ydBJQq1DY/1Q4J+Bq4FD/Wji+sMOffapAwZEZsmlLt7AHR68387ZO3QXE0USap0a6/sBFwFXACd7eegvjjj8xXfSqaj01O3Aw8Adds5erLuYqJNQh0Vj/Vjca+6LgarXET+5YWTz9kQi7NfUK3HH9udGfQH9MJFQh01jfQI4HXettCxwSF8Oc6wxarOjVBjvfr+LO9PtMeBZuZPtPQm1D5RSc4GzgbWO4/T94Q834CfhhjsLlLXn9aZEYuNpDSPDMj5dBF7F3XTucTtnv6G5ntiTUPtAKXUa7vI591UV6u4a60fgbux3Cm7Yx9HDo76L+2War9Q3nNUJtOA+zPEUsNDO2bLtT4BkQocPHMd5rjTbx1uNbauBuaXX3odbTsQN+Im4If94cyYT1OysDcCb3V7Nds7eGVD7ogcS6ihrbNuKO3940V++Vp9eW1dnAJ8ADGB06Z/DgP77eKW7HNXBXY9tA7Cxy2tDl3+uAN60c3YtztcOPTn99kmpp/6dp6ffPhl/7/gEfwn3Fjtnd2ouSVRBQu2TKIVaxIvMpxYiZiTUPlBKPQC8BByplGpVSlW8/7UQfSWn30LEjPTUQsSMhFqImJFQCxEzEmohYkZCLUTMSKiFiBkJtRAxI6EWImYk1ELEjIRaiJiRUAsRMxJqIWJGQi1EzEiohYgZCbUQMSOhFiJmJNRCxIyEWoiYkVALETMSaiFiRkItRMxIqIWIGQm1EDEjoRYiZv4fDvLUQfTZMhEAAAAASUVORK5CYII=\n",
-            "text/plain": [
-              "<Figure size 432x288 with 1 Axes>"
-            ]
-          },
-          "metadata": {}
-        }
       ]
     },
     {
@@ -5947,34 +5924,34 @@
     },
     {
       "cell_type": "code",
+      "execution_count": 102,
       "metadata": {
         "colab": {
           "base_uri": "https://localhost:8080/",
           "height": 279
         },
         "id": "jRyjxZE_-7AQ",
-        "outputId": "77c1b755-1876-4b97-cb38-cba92d521f58"
+        "outputId": "5898d1e9-612a-4933-b941-38b3e6229534"
       },
-      "source": [
-        "df = pd.DataFrame(np.random.randint(10, size=(10,4)), columns=list(\"ABCD\"))\n",
-        "\n",
-        "df.plot.scatter(x=\"A\", y=\"B\")\n",
-        "plt.show()"
-      ],
-      "execution_count": 448,
       "outputs": [
         {
-          "output_type": "display_data",
           "data": {
-            "image/png": "iVBORw0KGgoAAAANSUhEUgAAAXgAAAEGCAYAAABvtY4XAAAABHNCSVQICAgIfAhkiAAAAAlwSFlzAAALEgAACxIB0t1+/AAAADh0RVh0U29mdHdhcmUAbWF0cGxvdGxpYiB2ZXJzaW9uMy4yLjIsIGh0dHA6Ly9tYXRwbG90bGliLm9yZy+WH4yJAAAPV0lEQVR4nO3dYWzcd33H8c/n6sN266x4jp9gV02lTq2qyaTsNBWioa1lEozKTDIP2gke8KRPNiiIKWY84bmFEEibkKJ2TBpV0RZ3CkOo6yToAx5Q4bSJ1ybthFpoLrTDWA6NkX296P/dA5s2F5zEtPe7393v3i+pqn13ye/b/+Xe/ed/5//fESEAQHlquQcAAKRB4AGgUAQeAApF4AGgUAQeAAo1knuAyx08eDAOHTqUewwAGBgnT578VURM73VfXwX+0KFDWllZyT0GAAwM2z+/2n0cogGAQhF4ACgUgQeAQhF4ACgUgQeAQhUR+PXNlk6fu6D1zVbuUbCL5wTIr68+JvlOnDh1XovLq6rXampXlZYW5jR/eCb3WEON5wToDwO9B7++2dLi8qq225Uuti5pu13p6PIqe40Z8ZwA/WOgA9/c2FK91vmfUK/V1NzYyjQReE6A/jHQgZ+dHFe7qjpua1eVZifHM00EnhOgfwx04KcmRrW0MKexek0HRkc0Vq9paWFOUxOjuUcbWjwnQP9wP12yr9FoxDs5F836ZkvNjS3NTo4Tkj7BcwL0hu2TEdHY676B/xSNtLPXSET6C88JkN9AH6IBAFwdgQeAQhF4ACgUgQeAQhF4ACgUgQeAQhF4ACgUgQeAQhF4ACgUgQeAQhF4ACgUgQeAQhF4ACgUgQeAQiUNvO0v2H7B9vO2H7c9lnI99I/1zZZOn7vAtViBjJKdD972jKTPSborIrZs/5ukByT9S6o10R9OnDqvxeVV1Ws1tatKSwtzmj88k3ssYOikPkQzImnc9oikGyX9IvF6yGx9s6XF5VVttytdbF3SdrvS0eVV9uSBDJIFPiLOS/qqpFclvSbp1xHx1JWPs/2Q7RXbK2tra6nGQY80N7ZUr3X+sarXampubGWaCBheyQJve1LSJyTdJul9km6y/akrHxcRxyKiERGN6enpVOOgR2Ynx9Wuqo7b2lWl2cnxTBMBwyvlIZqPSHolItYioi3pCUkfSrge+sDUxKiWFuY0Vq/pwOiIxuo1LS3McX1WIIOUF91+VdI9tm+UtCXpPkkrCddDn5g/PKMjtx9Uc2NLs5PjxB3IJFngI+IZ28clPSvpkqTnJB1LtR76y9TEKGEHMku5B6+I+Iqkr6RcAwCwN36SFQAKReABoFAEHgAKReABoFAEHgAKReABoFAEHgAKReABoFAEHgAKReABoFAEHgAKReABoFAEHgAKReCBHljfbOn0uQvZr03bL3OgN5KeLhiAdOLUeS0ur6peq6ldVVpamNP84ZmhnQO9wx48kND6ZkuLy6vable62Lqk7Xalo8urPd+D7pc50FsEHkioubGleq3zZVav1dTc2BrKOdBbBB5IaHZyXO2q6ritXVWanRwfyjnQWwQeSGhqYlRLC3Maq9d0YHREY/Walhbmen692n6ZA73liMg9w1sajUasrKzkHgPouvXNlpobW5qdHM8a1X6ZA91j+2RENPa6j0/RAD0wNTHaF0HtlznQGxyiAYBCEXgAKBSBB4BCEXgAKBSBB4BCEXgAKBSBB4BCEXgAKBSBB4BCEXgAKBSBB4BCEXgAKBSBB4BCEXgAKFTSwNt+r+3jtl+0fdb2B1OulxtXrAf2h9dKb6Q+H/w3JD0ZEZ+0/R5JNyZeLxuuWA/sD6+V3km2B2/7ZkkflvSoJEXEmxFxIdV6OXHFemB/eK30VspDNLdJWpP0LdvP2X7E9k1XPsj2Q7ZXbK+sra0lHCcdrlgP7A+vld5KGfgRSR+Q9M2IuFvSbyR96coHRcSxiGhERGN6ejrhOOlwxXpgf3it9FbKwDclNSPimd3vj2sn+MXhivXA/vBa6a1kb7JGxOu2z9m+IyJeknSfpDOp1stt/vCMjtx+kCvWA9fBa6V3Un+K5rOSHtv9BM3Lkj6TeL2suGI9sD+8VnojaeAj4pSkRso1AAB74ydZAaBQBB4ACkXgAaBQBB4ACkXgAaBQBB4ACkXgAaBQBB4ACkXgAaBQBB4ACkXgAaBQBB4ACkXgAaBQBB4ACkXgAaBQBB4ACkXgAaBQBB4ACkXgAaBQBB4ACkXgAaBQBB4ACkXgAaBQBB4ACkXgAaBQBB4ACvV7B972QdtOMQwAoHuuGXjb99h+2vYTtu+2/byk5yX9n+2P9mZEAMA7MXKd+/9R0pcl3SzpB5I+FhE/tn2npMclPZl4PgDAO3S9QzQjEfFURPy7pNcj4seSFBEvph8NAPBuXC/w1WVfb11xX3R5FgBAF13vEM37bb8hyZLGd7/W7vdjSScDALwr1wx8RNzQq0EAAN3F5+ABoFAEHgAKlTzwtm+w/Zzt76VeC9L6Zkunz13Q+mYr9ygAMrvem6zd8LCks5L+oAdrDbUTp85rcXlV9VpN7arS0sKc5g/P5B4LQCZJ9+Btz0r6uKRHUq6DnT33xeVVbbcrXWxd0na70tHlVfbkgSGW+hDN1yUdVefn6TvYfsj2iu2VtbW1xOOUq7mxpXqt8+ms12pqblz54wsAhkWywNu+X9IvI+LktR4XEcciohERjenp6VTjFG92clztqvP/o+2q0uzkeKaJAOSWcg/+iKR52z+T9B1J99r+dsL1htrUxKiWFuY0Vq/pwOiIxuo1LS3MaWpiNPdoADJxRPozDtj+c0l/HxH3X+txjUYjVlZWks9TsvXNlpobW5qdHCfuwBCwfTIiGnvd14tP0aCHpiZGCTsAST0KfEQ8LenpXqwFANjBT7ICQKEIPAAUisADQKEIPAAUisADQKEIPAAUisADQKEIPAAUisADQKEIPAAUisADQKEIPAAUisADQKEIPAAUisADQKEIPAAUisADQKEIPAAUisADQKEIPAAUisADQKEIPAAUisADQKEIPAAUisADQKEIPAAUisADQKEIPAAUisADQKEIPAAUisADQKEIPAAUisADQKEIPAAUisADQKGSBd72LbZ/aPuM7RdsP5xqLQDA7xpJ+HtfkvTFiHjW9gFJJ23/d0ScSbgmAGBXsj34iHgtIp7d/fqipLOSZlKtBwDo1JNj8LYPSbpb0jN73PeQ7RXbK2tra70YBwCGQvLA256QtCzp8xHxxpX3R8SxiGhERGN6ejr1OAAwNJIG3nZdO3F/LCKeSLkWAKBTyk/RWNKjks5GxNdSrQMA2FvKPfgjkj4t6V7bp3b/+auE6wEALpPsY5IR8SNJTvX7AwCujZ9kBYBCEXgAKBSBB4BCEXgAKBSBB4BCEXgAKBSBB4BCEXgAKBSBB4BCEXgAKBSBB4BCEXgAKBSBB4BCEXgUbX2zpdPnLmh9s5V7FKDnkp0uGMjtxKnzWlxeVb1WU7uqtLQwp/nDXPcdw4M9eBRpfbOlxeVVbbcrXWxd0na70tHlVfbkMVQIPIrU3NhSvdb5x7teq6m5sZVpIqD3CDyKNDs5rnZVddzWrirNTo5nmgjoPQKPIk1NjGppYU5j9ZoOjI5orF7T0sKcpiZGc48G9AxvsqJY84dndOT2g2pubGl2cpy4Y+gQeBRtamKUsGNocYgGAApF4AGgUAQeAApF4AGgUAQeAApF4AGgUAQeAApF4AGgUAQeAApF4AGgUAQeAApF4AGgUAQeAApF4AGgUEkDb/ujtl+y/VPbX0q5FgAMovXNlk6fu5DkesHJzgdv+wZJ/yTpLyU1Jf3E9ncj4kyqNQFgkJw4dV6Ly6uq12pqV5WWFuY0f3ima79/yj34P5X004h4OSLelPQdSZ9IuB4ADIz1zZYWl1e13a50sXVJ2+1KR5dXu7onnzLwM5LOXfZ9c/e2DrYfsr1ie2VtbS3hOADQP5obW6rXOhNcr9XU3Njq2hrZ32SNiGMR0YiIxvT0dO5xAKAnZifH1a6qjtvaVaXZyfGurZEy8Ocl3XLZ97O7twHA0JuaGNXSwpzG6jUdGB3RWL2mpYW5rl5DOOVFt38i6Y9s36adsD8g6W8SrgcAA2X+8IyO3H5QzY0tzU6Od/0C8ckCHxGXbP+dpP+SdIOkf46IF1KtBwCDaGpitOth/62Ue/CKiO9L+n7KNQAAe8v+JisAIA0CDwCFIvAAUCgCDwCFckTknuEtttck/fwd/vKDkn7VxXEGGduiE9ujE9vjbSVsi1sjYs+fEu2rwL8btlciopF7jn7AtujE9ujE9nhb6duCQzQAUCgCDwCFKinwx3IP0EfYFp3YHp3YHm8relsUcwweANCppD14AMBlCDwAFGrgA8+Fvd9m+xbbP7R9xvYLth/OPVNutm+w/Zzt7+WeJTfb77V93PaLts/a/mDumXKy/YXd18nzth+3PZZ7pm4b6MBfdmHvj0m6S9KDtu/KO1VWlyR9MSLuknSPpL8d8u0hSQ9LOpt7iD7xDUlPRsSdkt6vId4utmckfU5SIyL+WDunNH8g71TdN9CBFxf27hARr0XEs7tfX9TOC7h7l2gfMLZnJX1c0iO5Z8nN9s2SPizpUUmKiDcj4kLeqbIbkTRue0TSjZJ+kXmerhv0wO/rwt7DyPYhSXdLeibvJFl9XdJRSdX1HjgEbpO0Julbu4esHrF9U+6hcomI85K+KulVSa9J+nVEPJV3qu4b9MBjD7YnJC1L+nxEvJF7nhxs3y/plxFxMvcsfWJE0gckfTMi7pb0G0lD+56V7Unt/G3/Nknvk3ST7U/lnar7Bj3wXNj7Crbr2on7YxHxRO55Mjoiad72z7Rz6O5e29/OO1JWTUnNiPjt3+iOayf4w+ojkl6JiLWIaEt6QtKHMs/UdYMe+Lcu7G37Pdp5k+S7mWfKxra1c4z1bER8Lfc8OUXEP0TEbEQc0s6fix9ERHF7aPsVEa9LOmf7jt2b7pN0JuNIub0q6R7bN+6+bu5TgW86J70ma2pc2Pt3HJH0aUn/Y/vU7m1f3r02LvBZSY/t7gy9LOkzmefJJiKesX1c0rPa+fTZcyrwtAWcqgAACjXoh2gAAFdB4AGgUAQeAApF4AGgUAQeAApF4IHrsP3XtsP2nblnAX4fBB64vgcl/Wj338DA4HPwwDXsntfnJUl/Iek/I+KO6/wSoG+wBw9c2ye0cw71/5W0bvtPcg8E7BeBB67tQe2crEy7/+YwDQYGh2iAq7D9h9o5C+OapNDO+Y5C0q3BCwcDgD144Oo+KelfI+LWiDgUEbdIekXSn2WeC9gXAg9c3YOS/uOK25bFYRoMCA7RAECh2IMHgEIReAAoFIEHgEIReAAoFIEHgEIReAAoFIEHgEL9P9srrYQHMhH1AAAAAElFTkSuQmCC\n",
+            "image/png": "iVBORw0KGgoAAAANSUhEUgAAAXgAAAEGCAYAAABvtY4XAAAABHNCSVQICAgIfAhkiAAAAAlwSFlzAAALEgAACxIB0t1+/AAAADh0RVh0U29mdHdhcmUAbWF0cGxvdGxpYiB2ZXJzaW9uMy4yLjIsIGh0dHA6Ly9tYXRwbG90bGliLm9yZy+WH4yJAAAPV0lEQVR4nO3dYWzcd33H8c/n6sN266x4jp9gV02lTq2qyaTsNBWioa1lEozKTDIP2gke8KRPNiiIKWY84bmFEEibkKJ2TBpV0RZ3CkOo6yToAx5Q4bSJ1ybthFpoLrTDWA6NkX296P/dA5s2F5zEtPe7393v3i+pqn13ye/b/+Xe/ed/5//fESEAQHlquQcAAKRB4AGgUAQeAApF4AGgUAQeAAo1knuAyx08eDAOHTqUewwAGBgnT578VURM73VfXwX+0KFDWllZyT0GAAwM2z+/2n0cogGAQhF4ACgUgQeAQhF4ACgUgQeAQhUR+PXNlk6fu6D1zVbuUbCL5wTIr68+JvlOnDh1XovLq6rXampXlZYW5jR/eCb3WEON5wToDwO9B7++2dLi8qq225Uuti5pu13p6PIqe40Z8ZwA/WOgA9/c2FK91vmfUK/V1NzYyjQReE6A/jHQgZ+dHFe7qjpua1eVZifHM00EnhOgfwx04KcmRrW0MKexek0HRkc0Vq9paWFOUxOjuUcbWjwnQP9wP12yr9FoxDs5F836ZkvNjS3NTo4Tkj7BcwL0hu2TEdHY676B/xSNtLPXSET6C88JkN9AH6IBAFwdgQeAQhF4ACgUgQeAQhF4ACgUgQeAQhF4ACgUgQeAQhF4ACgUgQeAQhF4ACgUgQeAQhF4ACgUgQeAQiUNvO0v2H7B9vO2H7c9lnI99I/1zZZOn7vAtViBjJKdD972jKTPSborIrZs/5ukByT9S6o10R9OnDqvxeVV1Ws1tatKSwtzmj88k3ssYOikPkQzImnc9oikGyX9IvF6yGx9s6XF5VVttytdbF3SdrvS0eVV9uSBDJIFPiLOS/qqpFclvSbp1xHx1JWPs/2Q7RXbK2tra6nGQY80N7ZUr3X+sarXampubGWaCBheyQJve1LSJyTdJul9km6y/akrHxcRxyKiERGN6enpVOOgR2Ynx9Wuqo7b2lWl2cnxTBMBwyvlIZqPSHolItYioi3pCUkfSrge+sDUxKiWFuY0Vq/pwOiIxuo1LS3McX1WIIOUF91+VdI9tm+UtCXpPkkrCddDn5g/PKMjtx9Uc2NLs5PjxB3IJFngI+IZ28clPSvpkqTnJB1LtR76y9TEKGEHMku5B6+I+Iqkr6RcAwCwN36SFQAKReABoFAEHgAKReABoFAEHgAKReABoFAEHgAKReABoFAEHgAKReABoFAEHgAKReABoFAEHgAKReCBHljfbOn0uQvZr03bL3OgN5KeLhiAdOLUeS0ur6peq6ldVVpamNP84ZmhnQO9wx48kND6ZkuLy6vable62Lqk7Xalo8urPd+D7pc50FsEHkioubGleq3zZVav1dTc2BrKOdBbBB5IaHZyXO2q6ritXVWanRwfyjnQWwQeSGhqYlRLC3Maq9d0YHREY/Walhbmen692n6ZA73liMg9w1sajUasrKzkHgPouvXNlpobW5qdHM8a1X6ZA91j+2RENPa6j0/RAD0wNTHaF0HtlznQGxyiAYBCEXgAKBSBB4BCEXgAKBSBB4BCEXgAKBSBB4BCEXgAKBSBB4BCEXgAKBSBB4BCEXgAKBSBB4BCEXgAKFTSwNt+r+3jtl+0fdb2B1OulxtXrAf2h9dKb6Q+H/w3JD0ZEZ+0/R5JNyZeLxuuWA/sD6+V3km2B2/7ZkkflvSoJEXEmxFxIdV6OXHFemB/eK30VspDNLdJWpP0LdvP2X7E9k1XPsj2Q7ZXbK+sra0lHCcdrlgP7A+vld5KGfgRSR+Q9M2IuFvSbyR96coHRcSxiGhERGN6ejrhOOlwxXpgf3it9FbKwDclNSPimd3vj2sn+MXhivXA/vBa6a1kb7JGxOu2z9m+IyJeknSfpDOp1stt/vCMjtx+kCvWA9fBa6V3Un+K5rOSHtv9BM3Lkj6TeL2suGI9sD+8VnojaeAj4pSkRso1AAB74ydZAaBQBB4ACkXgAaBQBB4ACkXgAaBQBB4ACkXgAaBQBB4ACkXgAaBQBB4ACkXgAaBQBB4ACkXgAaBQBB4ACkXgAaBQBB4ACkXgAaBQBB4ACkXgAaBQBB4ACkXgAaBQBB4ACkXgAaBQBB4ACkXgAaBQBB4ACvV7B972QdtOMQwAoHuuGXjb99h+2vYTtu+2/byk5yX9n+2P9mZEAMA7MXKd+/9R0pcl3SzpB5I+FhE/tn2npMclPZl4PgDAO3S9QzQjEfFURPy7pNcj4seSFBEvph8NAPBuXC/w1WVfb11xX3R5FgBAF13vEM37bb8hyZLGd7/W7vdjSScDALwr1wx8RNzQq0EAAN3F5+ABoFAEHgAKlTzwtm+w/Zzt76VeC9L6Zkunz13Q+mYr9ygAMrvem6zd8LCks5L+oAdrDbUTp85rcXlV9VpN7arS0sKc5g/P5B4LQCZJ9+Btz0r6uKRHUq6DnT33xeVVbbcrXWxd0na70tHlVfbkgSGW+hDN1yUdVefn6TvYfsj2iu2VtbW1xOOUq7mxpXqt8+ms12pqblz54wsAhkWywNu+X9IvI+LktR4XEcciohERjenp6VTjFG92clztqvP/o+2q0uzkeKaJAOSWcg/+iKR52z+T9B1J99r+dsL1htrUxKiWFuY0Vq/pwOiIxuo1LS3MaWpiNPdoADJxRPozDtj+c0l/HxH3X+txjUYjVlZWks9TsvXNlpobW5qdHCfuwBCwfTIiGnvd14tP0aCHpiZGCTsAST0KfEQ8LenpXqwFANjBT7ICQKEIPAAUisADQKEIPAAUisADQKEIPAAUisADQKEIPAAUisADQKEIPAAUisADQKEIPAAUisADQKEIPAAUisADQKEIPAAUisADQKEIPAAUisADQKEIPAAUisADQKEIPAAUisADQKEIPAAUisADQKEIPAAUisADQKEIPAAUisADQKEIPAAUisADQKEIPAAUisADQKEIPAAUisADQKGSBd72LbZ/aPuM7RdsP5xqLQDA7xpJ+HtfkvTFiHjW9gFJJ23/d0ScSbgmAGBXsj34iHgtIp7d/fqipLOSZlKtBwDo1JNj8LYPSbpb0jN73PeQ7RXbK2tra70YBwCGQvLA256QtCzp8xHxxpX3R8SxiGhERGN6ejr1OAAwNJIG3nZdO3F/LCKeSLkWAKBTyk/RWNKjks5GxNdSrQMA2FvKPfgjkj4t6V7bp3b/+auE6wEALpPsY5IR8SNJTvX7AwCujZ9kBYBCEXgAKBSBB4BCEXgAKBSBB4BCEXgAKBSBB4BCEXgAKBSBB4BCEXgAKBSBB4BCEXgAKBSBB4BCEXgUbX2zpdPnLmh9s5V7FKDnkp0uGMjtxKnzWlxeVb1WU7uqtLQwp/nDXPcdw4M9eBRpfbOlxeVVbbcrXWxd0na70tHlVfbkMVQIPIrU3NhSvdb5x7teq6m5sZVpIqD3CDyKNDs5rnZVddzWrirNTo5nmgjoPQKPIk1NjGppYU5j9ZoOjI5orF7T0sKcpiZGc48G9AxvsqJY84dndOT2g2pubGl2cpy4Y+gQeBRtamKUsGNocYgGAApF4AGgUAQeAApF4AGgUAQeAApF4AGgUAQeAApF4AGgUAQeAApF4AGgUAQeAApF4AGgUAQeAApF4AGgUEkDb/ujtl+y/VPbX0q5FgAMovXNlk6fu5DkesHJzgdv+wZJ/yTpLyU1Jf3E9ncj4kyqNQFgkJw4dV6Ly6uq12pqV5WWFuY0f3ima79/yj34P5X004h4OSLelPQdSZ9IuB4ADIz1zZYWl1e13a50sXVJ2+1KR5dXu7onnzLwM5LOXfZ9c/e2DrYfsr1ie2VtbS3hOADQP5obW6rXOhNcr9XU3Njq2hrZ32SNiGMR0YiIxvT0dO5xAKAnZifH1a6qjtvaVaXZyfGurZEy8Ocl3XLZ97O7twHA0JuaGNXSwpzG6jUdGB3RWL2mpYW5rl5DOOVFt38i6Y9s36adsD8g6W8SrgcAA2X+8IyO3H5QzY0tzU6Od/0C8ckCHxGXbP+dpP+SdIOkf46IF1KtBwCDaGpitOth/62Ue/CKiO9L+n7KNQAAe8v+JisAIA0CDwCFIvAAUCgCDwCFckTknuEtttck/fwd/vKDkn7VxXEGGduiE9ujE9vjbSVsi1sjYs+fEu2rwL8btlciopF7jn7AtujE9ujE9nhb6duCQzQAUCgCDwCFKinwx3IP0EfYFp3YHp3YHm8relsUcwweANCppD14AMBlCDwAFGrgA8+Fvd9m+xbbP7R9xvYLth/OPVNutm+w/Zzt7+WeJTfb77V93PaLts/a/mDumXKy/YXd18nzth+3PZZ7pm4b6MBfdmHvj0m6S9KDtu/KO1VWlyR9MSLuknSPpL8d8u0hSQ9LOpt7iD7xDUlPRsSdkt6vId4utmckfU5SIyL+WDunNH8g71TdN9CBFxf27hARr0XEs7tfX9TOC7h7l2gfMLZnJX1c0iO5Z8nN9s2SPizpUUmKiDcj4kLeqbIbkTRue0TSjZJ+kXmerhv0wO/rwt7DyPYhSXdLeibvJFl9XdJRSdX1HjgEbpO0Julbu4esHrF9U+6hcomI85K+KulVSa9J+nVEPJV3qu4b9MBjD7YnJC1L+nxEvJF7nhxs3y/plxFxMvcsfWJE0gckfTMi7pb0G0lD+56V7Unt/G3/Nknvk3ST7U/lnar7Bj3wXNj7Crbr2on7YxHxRO55Mjoiad72z7Rz6O5e29/OO1JWTUnNiPjt3+iOayf4w+ojkl6JiLWIaEt6QtKHMs/UdYMe+Lcu7G37Pdp5k+S7mWfKxra1c4z1bER8Lfc8OUXEP0TEbEQc0s6fix9ERHF7aPsVEa9LOmf7jt2b7pN0JuNIub0q6R7bN+6+bu5TgW86J70ma2pc2Pt3HJH0aUn/Y/vU7m1f3r02LvBZSY/t7gy9LOkzmefJJiKesX1c0rPa+fTZcyrwtAWcqgAACjXoh2gAAFdB4AGgUAQeAApF4AGgUAQeAApF4IHrsP3XtsP2nblnAX4fBB64vgcl/Wj338DA4HPwwDXsntfnJUl/Iek/I+KO6/wSoG+wBw9c2ye0cw71/5W0bvtPcg8E7BeBB67tQe2crEy7/+YwDQYGh2iAq7D9h9o5C+OapNDO+Y5C0q3BCwcDgD144Oo+KelfI+LWiDgUEbdIekXSn2WeC9gXAg9c3YOS/uOK25bFYRoMCA7RAECh2IMHgEIReAAoFIEHgEIReAAoFIEHgEIReAAoFIEHgEL9P9srrYQHMhH1AAAAAElFTkSuQmCC",
             "text/plain": [
               "<Figure size 432x288 with 1 Axes>"
             ]
           },
           "metadata": {
             "needs_background": "light"
-          }
+          },
+          "output_type": "display_data"
         }
+      ],
+      "source": [
+        "df = pd.DataFrame(np.random.randint(10, size=(10,4)), columns=list(\"ABCD\"))\n",
+        "\n",
+        "df.plot.scatter(x=\"A\", y=\"B\")\n",
+        "plt.show()"
       ]
     },
     {
@@ -5994,14 +5971,29 @@
     },
     {
       "cell_type": "code",
+      "execution_count": 103,
       "metadata": {
         "colab": {
           "base_uri": "https://localhost:8080/",
           "height": 265
         },
         "id": "rkPJpTYcBuN4",
-        "outputId": "13b8ce1d-f19a-46ae-9bd5-ea4b645f977c"
+        "outputId": "e500580b-50dd-4e8c-e9c6-69f4d80931f1"
       },
+      "outputs": [
+        {
+          "data": {
+            "image/png": "iVBORw0KGgoAAAANSUhEUgAAAWoAAAD4CAYAAADFAawfAAAABHNCSVQICAgIfAhkiAAAAAlwSFlzAAALEgAACxIB0t1+/AAAADh0RVh0U29mdHdhcmUAbWF0cGxvdGxpYiB2ZXJzaW9uMy4yLjIsIGh0dHA6Ly9tYXRwbG90bGliLm9yZy+WH4yJAAAgAElEQVR4nO3deXDc53kf8O+zFxbXLhYnsQtgwVskloeAtUSJIj2RbEeyRDvTJK08tdMkTVR3HFtJPZOJm3baZjJtM0kzUZ3UCes49UwUpY1jtyFlWY4jRVhKMmUsSIAADyxBYkFgcewCu7gW2PPtH8CC14JYAPvb3/V8ZjyRSBB4shQe/PZ53+d5SAgBxhhjymWQOwDGGGOPxomaMcYUjhM1Y4wpHCdqxhhTOE7UjDGmcCYpPml9fb1ob2+X4lMzxpgm+f3+iBCiId/vSZKo29vb0dPTI8WnZowxTSKi4Ea/x6UPxhhTOE7UjDGmcJyoGWNM4ThRM8aYwnGiZowxhSsoURPRbxDRIBENENEbRGSVOjDGGGOrNk3UROQC8BUAXiGEB4ARwMtSB8YYY2xVoaUPE4ByIjIBqAAQki4kpiSh2DLeujIhdxiM6dqmiVoIMQ7gDwCMApgAMCeE+OGDH0dErxBRDxH1hMPh4kfKZPH1dwL416/3YmYxIXcojOlWIaUPB4DPAtgNwAmgkog+/+DHCSHOCiG8QghvQ0PeLkimMkIIdA9FAAC9ozGZo2FMvwopfXwCwG0hRFgIkQLwXQBPSxsWU4LbkSWMx5YBAP5gVOZoGNOvQhL1KIATRFRBRATgOQDXpA2LKUH30GoJq9luhT84K3M0jOlXITXqiwC+A6AXwJW1P3NW4riYAvgCEbTXVeDTR5rRNzaHZDord0iM6VJBtz6EEP9BCPGYEMIjhPiCEIJPljQumc7iw1szOLW/AV1uB5LpLAZDc3KHxZgucWciy6t3NIp4MoNT++vR5XYA4Do1Y3LhRM3y8gXCMBoIT+2tQ5PNihZHOSdqxmTCiZrl5QtE0NlWg2qrGQDgdTvQE4xCCCFzZIzpDydq9pDZpSSujM/h1P679+G73A6EFxIYiy7LGBlj+sSJmj3k/ZsRCAGc2l+//mudXKdmTDacqNlDfIEwbFYTjrbUrP/aY7tsqLQY0cP3qRkrOU7U7D5CCPgCETyzvx5GA63/utFAeLzNAX+QW8kZKzVO1Ow+w+FFTMyt3FefzulyO3Bjch4LKykZImNMvzhRs/vkhjDdW5/O6XI7kBXA5Tv8VM1YKXGiZvfxBcLY01CJFkfFQ793vK0GRHygyFipcaJm6xLpDH58axan85Q9AMBmNeNgUzUnasZKjBM1W+cfiWI5lclb9sjpcjtwaTSGTJYbXxgrFU7UbF13IAKzkXBiT92GH+Ntd2AxkcbQ1EIJI2NM3zhRs3W+QBidbQ5Ulpk2/JiutloAQA+XPxgrGU7UDAAQWUxgMDSP0wcevUattbYc9VVl6OVEzVjJcKJmAFbbxoH81/LuRURrA5q4Q5GxUilkue1BIrp8z//miejXSxEcK53uoQgcFWZ0OO2bfmyX24E7s8uYnl8pQWSMsUJWcd0QQhwXQhwH0AUgDuB7kkfGSma1bTyMk/vubxvfSFf76oCm3lEufzBWClstfTwHYFgIEZQiGCaPoalFTC8kNrw//aAOpw0WkwE9I/pL1L//9nX8v8vjcofBdGarifplAG/k+w0ieoWIeoioJxwO7zwyVjK+wOrf1zOb1KdzykxGHHXZ4dfZE/Xccgrf+MdhvH5xVO5QmM4UnKiJyALgMwD+Jt/vCyHOCiG8QghvQ0NhT2ZMGboDEexrrIKzprzgP9PV7sDA+BxWUhkJI1OWD4cjyArgamgeWW74YSW0lSfqFwD0CiGmpAqGld5KKoOLt2Y2ve3xoK42B1IZgSvj+tlM3h1YvRmzmEgjOBuXORqmJ1tJ1J/DBmUPpl49I1Ek0tlN708/SG+byYUQ6B4Ko612dVjVgI5+QDH5FZSoiagSwCcBfFfacFip+QJhWIwGPLm7dkt/rq6qDLvrK3VzoBiciWMsuox/8XQ7LEYDBkKcqFnpFJSohRBLQog6IQT/16kx7w2F4W13oMKycdv4RjrbHOgd1cdm8tyB63OPNeLgrmoMjs/LHBHTE+5M1LHp+RVcn1zIu82lEN52B2aXkrgdWSpyZMrTHYigtbYc7roKeFw2DITmdPEDiikDJ2odu1Bg2/hG9FKnTmWy+HB4Bqf2N4CI0OG0IxZPYTy2LHdoTCc4UeuYLxBBXaUFh5tt2/rz+xqqYLOaNN+hePlODIuJNE6v/UDzuFbb7PlAkZUKJ2qdymbvbhs3FNA2no/BQOh0OzR/oOgbCsNAwFN7VxP1Y7uqYTQQBrhOzUqEE7VOXZ9cQGQxse36dE5XmwOB6UXMxbW7mfy9QATHW2tgLzcDAKxmI/Y3VvHND1YynKh1KneLYbv16RytD2iKxZPoH4s99AOtw2nHwDgfKLLS4EStU75ABAebqtFks+7o8xxvrYHRQJo9UHz/5gyEAE4fuP8HmsdlQ2QxiemFhEyRMT3hRK1Dy8kMPhqZ3fHTNABUWEw43GzTbKL2BcKotppwrKXmvl/nA0VWSpyodeijkVkk01mc2mLb+Ea63A5cvhNDKpMtyudTitU53RGc3FsPk/H+b5VDzTYQgQ8UWUlwotYh31AYFpMBT7RvrW18I51uB5ZTGVyf0NZm8luRJYzHlnHqwMPvPKrKTNhdX8kHiqwkOFHrkC8QwRPttSi3GIvy+bxrjS9a26PoG1o9cN1ooYLHaccglz5YCXCi1pmp+RXcmFp46HBsJ5w15Wi2WzVXp/YFImivq0Dr2sS8B3lcNoTmVjCzyAeKTFqcqHWmeyh3La+4yx263A70aihRJ9NZfHhr5pGvk2dtEfBgiOvUTFqcqHXGF4igvqoMj+2qLurn7XI7EJpbQUgj8y96R6OIJzOPvBmT29jOdWomNU7UOpLNCly4GcHp/fUg2l7b+Ea0NqDJFwjDaCA8tbduw4+xV5jRWlvOI0+Z5DhR68jViXnMLiXz3mLYqUPNNpSbjRpK1BF0ttWg2mp+5Mcdcdn5iZpJrtANLzVE9B0iuk5E14joKakDY8XXvdY2fnJf8RO12WjAsVa7JhL17FISV8bnCqrjdzjtCM7EMbes3VknTH6FrvV4DcAPhBA/t7aNPP8xOFM031AEh5ptaKzeWdv4RrzuWnzjvWHEk+ltbYxRivdvRiBEYXNQch2KV0PzjyyTMGlFl5JIK2AzvIFW19QV26bfTURkB3AawC8CgBAiCSBZ9EiYpOLJNHqCs/jlk7sl+xpdbgcyWYHLd2J4em/xn9pLpXsoDJvVhKMPtI3n0+FcneU9GJrjRC2Tv+sL4StvXJI7DABAfVUZev7dJ4r+eQt57NkNIAzgL4joGAA/gFeFEPftXyKiVwC8AgBtbW3FjpPt0MVbs0hlRNGv5d3r8bbVxNYbjKo2Uefaxp/ZXw9jAXO666vK0Gy38swPGb13I4yaCjO++qmDcocCq0maY79CErUJQCeALwshLhLRawB+C8C/v/eDhBBnAZwFAK/XK/97EHaf7kAYZSYDvGtjSaVQU2HB/sYq9Ki4Tn1zehGT8ysbdiPm0+G0Y4DvUsvGH5zFx9pr8YUTbrlDkUwh6X8MwJgQ4uLav38Hq4mbqYgvEMGTe+pgNRenbXwjucaXrALqhdvRHVjdI/nMFiYLelw2DIcXsZRISxUW20BkMYGRmfj69VCt2jRRCyEmAdwhotz7iucAXJU0KlZUodgybk4vru/8k1KX24H5lTSGw4uSfy0p+AJh7GmoRIuj8PNyj9MOIYBrE/xUXWq5bliv3hP1mi8DeJ2I+gEcB/CfpQuJFduFQG7buHT16Zyu9QFN6it/JNIZ/PjWzJbKHgDPppaTPxiFxWhY/zvQqoIStRDishDCK4Q4KoT4GSGE+r4Ldaw7EEaTrQwHmqok/1q76ytRW2lR5X1q/0gUK6nslhcqNNnKUF9l4Tq1DPzBKDwum+QlPblxZ6LGZdbaxk/tbyh623g+RITONnUOaOoORGA2Ek7s2do1OyJa36HISieRzqB/fE7z9WmAE7XmDYzPIRZPFWXtVqG63A7ciiypbvynLxBGZ5sDlWVbb9bxuGwITC9iJZWRIDKWz8D4PJLpLCdqpn65bePPSNA2vhHv+mbyWMm+5k5FFhMYDM3j9DbXk3mcdmSyAjcmtbXlRsly79o6OVEztesOROBx2SRpa93IEZcdZiOpauPL+zdzB67b+4G2fqDIA5pKpic4i7baCslGIigJJ2oNW0yk0RuMluS2x72sZiM6nHZV1am7hyJwVJjXZ0xvVYujHDariZfdlogQAv5gTPPX8nI4UWvYj4dnkM6Kktanc7xuB/rG5pBMK38z+WrbeBgn9xXWNp4PEcHjsmOQn6hLYnQ2jshiQhdlD4ATtab5AmGUm42yHLZ0uR1IprOqKAXcmFrA9EJiy/enH+Rx2XF9YgGpjPJ/OKld7vqnHg4SAU7UmuYLRHBiTy3KTKW/Y5r7BlJD+cM3tPW28Xw6nDYkM1kEptTZlakm/mAU1WUmHGgq7ko5peJErVF3ZuO4FVkqeX06p9FmRWttOXpGlJ+ouwNh7GusgrOmfEefhw8US8cfjOJ4W822S1Vqw4laoy6s3WI4LcHarUJ1tTngH41CCOUOaFpJZfDR7dkdlz0AYHddJSotRgxy44uk5ldSuDG1AK+7Vu5QSoYTtUb5AmE0263Y2yB92/hGutprEV5IYCyq3M3kPxmZRSKdLcoeSYOBeORpCVwajUEI/dSnAU7UmpTJClwIRHBKgm3jW9HVlhvQpNz71L5ABBajAU/uLs7TWYfLhquheWRUOuZVDfzBKAwEHG/bfAOPVnCi1qD+sRjmV9Ky1adzDu6qRlWZSdEDmrqHwvC2O4q249HjtGM5lcHtCB8oSqU3GMVju2yo2karv1pxotag7qEIiErbNp6P0UB4vK1GsQeK0/MruD65UNQfaHdHnnL5QwrpTBaXRqO6KnsAnKg1yRcI46jLDkelRe5Q0NnmwI2pBSyspOQO5SEXdtg2ns/ehkqUmQw8SU8iN6YWsJTMSLpSTokKStRENEJEV4joMhH1SB0U2775lRQu3YnJXvbI8bY7IARw+Y7yBjT5AhHUVVpwuNlWtM9pMhpwqNmGK5yoJZEro3W2caLeyE8JIY4LIbySRcN27MPhGWRkahvP53hrDQwExZU/stm728YNRb6L61k7UFTr3kgl8wejaKwuQ4tjZ3fe1YZLHxrjC4RRaTHicYU8cVRbzTi4y4beUWUl6uuTC4gsJiR55+Fx2rGQSGN0Nl70z613/mAU3naHrLeZ5FBoohYAfkhEfiJ6Jd8HENErRNRDRD3hcLh4EbIt8QUieGpvHSwm5fwM7nLX4NJoTFFX1nJzuqV458EditKYml/BWHRZd2UPoPBE/YwQohPACwC+RESnH/wAIcTZtb2K3oYGZdRH9SY4s4TgTFwx9emcLrcDi4m0oobq+wIRHGyqRpOt+LOM9zdVwWwkvvlRZLn6tLddPx2JOYUutx1f+7/TAL4H4Akpg2Lb4wsU/xZDMeRaff0KKX8sJzP4aGRWstepzGTEgaZqHnlaZD0jUZSZDEU9/FWLTRM1EVUSUXXunwF8CsCA1IGxrfMFwnDVlGN3faXcodynxVGOhuoy+EeU0aF48fYMkuksTm1z7VYhPGvLbpU850Rt/KNRHGupUVRZr1QK+f+4CcAFIuoD8BGAN4UQP5A2LLZV6UwWH9ycwekD8raN50NE8Lodinmi9gUisJiK1zaej8dlQzSeQmhuRbKvoScrqQwGx+fQpbP70zmb9mAKIW4BOFaCWNgO9I3FsJCQv218I11uB94amMT0/AoaJagLb4UvEMaTu2thNUs3p7tjvUNxDq4djk9lQN+dGNJZsT4/Rm/09x5Co7qHIjAQ8PTeOrlDySu3MknuuR+TcysYmlqUvI5/aJcNBgKPPC2S3LsxvazeehAnao3wBcI42lKDmgr528bz8TjtsJgMsifqu9fypH3nUW4xYl9jFY88LZLeYBR7GipRq4CxCHLgRK0Bc8spXL4Tw2mF3fa4l8VkwLEWO3pkT9QR1FeV4bFd0q9wyh0osp1Z3Tge1W3ZA+BErQkf3IwgKyDpLYZi6HLXYjA0h5VURpavn80KXLgZwekSzenucNkxvZDA9DwfKO7ErcgSovGU7gYx3YsTtQZ0ByKoKjPheKuyB6l3uR1IZQT6x+R5yrw6MY/ZpWRRtrkU4sjageIglz92xD+ir43j+XCiVjkhBLqHwnh6bx3MRmX/dXaubeSQq07dvVafPlmiOd2HnauNGVz+2Bl/MIqaCjP21Mu3Vk5uyv7OZpsamYljPLas+LIHANRVlWFPfaVsido3FMGhZhsaq0tzPbCqzIQ99ZU882OH/KNRdLY5ij7lUE04Uatc7haDkg8S79XpdqBXhs3k8WQaPcHZkr9OHS47z/zYgVg8iZvTi7ouewCcqFWveyiCttoKuOuU1Ta+Ea/bgdmlJG5Hlkr6dS/emkUqI0reEORx2jAeW0Z0KVnSr6sVufG4nKiZaqUyWXw4HFHcEKZHyX3DlfqaXncgjDKToeQ3Bzx8oLgjPSNRmAyEYy3KPiiXGidqFbs0GsNSMqPYtvF89jZUwWY1obfUiXoojCf31EnaNp5Px9qBIq/m2h5/MIoOpw3lltL+vSkNJ2oV8wXCMBoITym0bTwfg4HQ5XaU9EBxPLaM4fCSLHX8mgoLWhzlfKC4DalMFn1jMd22jd+LE7WKdQciON5aA3u5We5QtqTL7UBgehGxeGnqthdyB64y3YzxOO0882MbrobmsZLK6r4+DXCiVq1YPIn+sZiq6tM5XWuLBC6NlmYzeXcggiZbGfY3ynMP1+OyYWQmjvmVlCxfX61y77o4UXOiVq33b85ACOmHC0nhWKsdRgOhJyj9IoFMVuD9mxGc2t8g25zu3MjTq3yguCX+YBSumnI023lMLCdqlfIFwqi2mnCsxS53KFtWYTHhcLOtJHXqgfE5xOIpWd95eJx3Z1Ozwggh0BOc5afpNQUnaiIyEtElIjovZUBsc7m28ZN762FSeNv4RrrcDvTdmUMqk5X06+Qagp4pUdt4Pg3VZWiylfEVvS0Iza1gaj7BiXrNVr7LXwVwTapAWOGGw0sIza2UbLiQFLrcDiynMrg2IW3y6g5E4HHZUFdVJunX2QyPPN2anrX9mpyoVxWUqImoBcCLAL4pbTjyS6Qz+C9vXVvviFKiu23j6qtP5+QaT6Qsfywm0ugNRhVRx+9w2TEcXkQ8mZY7FFXoDUZRYTGWZG64GhT6RP1HAH4TwIbvU4noFSLqIaKecDhclODk8A/XpvFn793Cz//ph/iTd28im1XeFmlfIILd9ZVora2QO5Rta7aXw2m3Stqh+OPhGaSzQhE3YzxOG7ICuDaxIHcoqtATjOJ4a41qS3vFtumrQEQvAZgWQvgf9XFCiLNCCK8QwtvQIP8TzHad7w+hvsqCFzy78Ptv38AXvnVRUYPfE+kMPhyeUUTy2alOt0PSDkVfIIxys1ERb5/vtpJz+WMzS4k0rk3Mw6uAvzelKOTH1UkAnyGiEQB/DeBZIvpLSaOSyWIijX+4No0XjzTj6597HL/3s0fgD0bxwms+vHtjWu7wAAC9wRiWU+pqG9+I1+3AxNwKQrFlST6/LxDBiT21KDPJ337cbLeittLCdeoC9N2JISv0u8g2n00TtRDia0KIFiFEO4CXAbwjhPi85JHJ4EdXp5BIZ/HSMSeICP/sY204/+Vn0FBdhl/6i5/gd89fRTIt7S2FzfgCYZgMhBN7amWNoxhyjS9SlD/uzMZxK7KkmB9oRIQOp41HnhagJxgFEfC4jnckPogLQPc43x9Cs9163xLNfY3V+L9fOolfeMqNb164jZ/9xgcYKfGIznv5AhF0tjlQbVVX23g+h5qrUW42SlL+uHAzAgA4raCbMUdcdgxNLSCRlmdnpFr4g1EcaKxW3WgEKW0pUQsh/lEI8ZJUwchpLp7Ce0NhvHik+aFNElazEb/zWQ/+9PNdGJ2N48X/7sP3Lo2VPMaZxQQGQnOaqE8DgMlowPHWGklufnQPhdFst2Jvg3LWN3lcdqSzAkOTi3KHoljZrEDvaJTLHg/gJ+o1b1+dRCojcOaYc8OPed6zC99/9RQOO234jf/dh6/+nz4sJUp33er94bW2cRWs3SpUl9uBqxPzRX0d05ks3r8ZwWkZ28bzWe9Q5APFDQWmF7GwkuaDxAdwol5zri+EttoKHN2kJdtVU443fvUEvvLcfnzv0hjOfP1CyQ6IfENh2MvN69uttaCr3YFMVqBvrHgDmvrH5zC/klZcQ1BrbTmqrSY+UHwEHsSUHydqrJYUPhiewUtHmwt6AjMZDfg3nzyAv/rVE4gnM/gn/+MDfOvCbUn3AAoh4AtE8My+ehg1tOSzs3Wt8WWkeOUP31AERMDJvcpK1ES02qHIreQb6gnOoq7SAnedensEpMCJGsBbA5PIZB9d9sjnxJ46fP/VUzh9oB6/c/4qfuXbPZiVaDfezelFTM6vaKY+nWOvMONAUxX8RewE9QXCOOqyw1FpKdrnLBaPy4ZrE/OSzzhRq95gFF1uh6JKVkrAiRqrZY+9DZXbaletrbTgf/6CF//xzGH4AhG88Fo3PhiOFD3G94bWhgtpLFEDq29ze4PRonSBzq+kcOlOTDHX8h7kcdmRTGdxc5oPFB8UXkhgZCbOZY88dJ+op+ZX8NHILM6s3Z3eDiLCL57cje996WlUlpnwz795Ef/thzeQLuJTky8QwZ6GSrQ4tPeWsLPNgfmVNG6Gd568PhyeQUYhbeP5dPDI0w3l5uuUegGxGug+Ub/ZPwEhgJeObq3skU+H047zX34GP9fZgq+/cxMvn/0xxovQdbeSyuDi7RlVD2F6FG/7auNLMa7p+QJhVFqMim2W2F1fiQqLkUee5tEbjMJiNKz/MGN36T5Rn+sP4VCzDfuKtKapwmLC7//8Mbz28nFcn1zAC3/UjR8MTOzoc/qDUayksop9Styp9roK1FVa0FOEA0VfIIKn9tbBYlLmf9pGA+Fws42fqPPoCUbhcdlKvileDZT5X3OJ3JmN49JoDGeONRf9c3/2uAtvfuUZ7K6vxBf/she//b0rWEltryOtOxCG2Ug4sUc928a3gohWBzTt8EAxOLOE4ExcsfXpHI/LjqsT88gocDKjXBLpDK6Mza2/u2L303WifvPK6pPuS0d2XvbIx11Xib/54tP4V6f34PWLo/jsH7+Poamtj7n0DUXQ5XagsswkQZTK0OV24HZkCTOLiW1/Dl9g9RBX6e88Opw2xJMZ3JZxFIHSDIzPI5nJolOhJSu56TpRn+8P4VhrDdokvLNpMRnwtU8fwrd/+QnMLCXwmT++gDc+Gi34znV4IYGrE/OKf0rcqdxJ/07q1L5AGK6acuyuryxWWJLgkacP8wd5o8uj6DZR3wovYmB8HmeOFr/skc/HDzTg+6+ewsfaa/G1717Br/3VJcwtpzb9c+/nhgtpPFEfcdlhNtK271OnM1l8cHMGpw/UK/4O7r7GKlhMBq5T38MfjMJdV4GGanlXpimVbhP1+f7VsseLJUrUANBYbcW3f+kJ/NYLj+HtwUl8+jXfpk+Q3YEwHBVmdDhtJYpSHlazER6XfdsdipfvxLCQSKvinYfZaMChXdU88nSNEAL+YPS+qZXsfjpO1CE80V6LZnt5Sb+uwUD44sf34m+++BSIgH/6Zxuv/FpvG9/f8NBEPy3yuh3oH5/b1hjQ7kAEBgW2jW+kw2XHQGhO0rEDajE6G0dkMYkuvj+9IV0m6huTCxiaWsRLEtz2KNTjbQ58/9VTj1z5dWNqAeGFhOIPx4qly+1AMp3d1h1jXyCMY601sFeoY4axx2nHwkoad2al2W6jJjyIaXO6TNTn+0MwEPCCR75EDQA2q/mRK798Q+q4xVAsuRnEWy1/zMVT6FNw23g+HtdqKYtHnq7en64uM+FAI28c30ghy22tRPQREfUR0SAR/adSBCYVIQTO9YXw9N56RRxcPGrlV3cgjP2NVSUvz8ilsdqKttqKLd/8+GA4gqwATqvoB9qBpmqYDMQHiljtSHzc7dBFeW+7CnmiTgB4VghxDMBxAM8T0Qlpw5LOwPg8RmbieKmEh4iFyLfy66Pbs6p6SiyGLrcDPcHolmq33YEIqstMONZaI2FkxWU1G3GgqVr3I0/nllO4MbXAB4mbKGS5rRBC5KblmNf+p9oTkPP9IZgMhOc9u+QO5SG5lV9/9oXVlV+JtHbbxjfS5XYgspgouHYrhED3UBhP7a2D2aiuSp7HZcPguL4PFC/fiUEIHsS0mYL+yyYiIxFdBjAN4O+FEBfzfMwrRNRDRD3hcLjYcRaFEALn+ydwan89aiqUN6s456c7duGtV0/hd3/Gg9MaWrtViPXGl9HZgj5+ZCaO8diyKteTeVx2zCwlMfnAIbKe+INRGAiqejckh4IStRAiI4Q4DqAFwBNE5MnzMWeFEF4hhLehQZnfNL2jMYzHlre8IEAOzppyfP6EW1PbXApxoKka1WWmggc0+QKrDwVqqk/n3B15qt/yhz84i0PNNlRpeDxCMWx1C3kMwLsAnpcmHGmd6wvBYjLgk4eb5A6FbcBoIBxvK3wzefdQBG21FXDXKbttPJ9DzdUwkH5nU6czWVwejfG1vAIUcuujgYhq1v65HMAnAVyXOrBiy2QF3rwygZ862IBqqzru2upVl9uBG1MLmF95dIt9KpPFh8MR1dbxKywm7G2o0u3Mj+uTC1hKZjhRF6CQJ+pmAO8SUT+An2C1Rn1e2rCK76PbswgvJFRR9tA7r7sWQgCXRx+9mfzSaAxLyYyqb8Z4XHZc0ekTdW6sLSfqzRVy66NfCPG4EOKoEMIjhPidUgRWbOf6Qyg3G/HsY41yh8I2cazVDgNtPknPFwjDaCA8tVe9c7o7nDZMzScwvaC/A0V/MIomWxlcNfroE9gJdd1n2hCepPIAAA+SSURBVKZUJosfDEziE4ebUGHhQwulq7aacXCXrYCBVREcb62BvVy9pay7I0/1d6DYMxKF112r+GmHSqCLRP3B8Axml5KKa3JhG/O6Hbg0Gt1wC0p0KYn+sZjqx78eXpuKOKiz8sfk3ArGY8vrYwPYo+kiUZ/rC6G6zISPq/CurV51uR1YSmZwfTL/k+b7wxEIAZw6oM6DxByb1Yz2ugrdXdHjQUxbo/lEnUhn8PbgJD7VsYuXZqpI7hu4d4Pyh28oApvVhKMu9W+szo081RN/MAqr2aD5OevFovlE3T0UwcJKWtaRpmzrWhzlaKwuy1unXp3THcbJffUwqaxtPB+P046x6DJi8aTcoZSMfzSKoy01qmv7l4vmX6Xz/SHUVJjxzD51v0XWGyKCt311QNODhsNLCM2tqPpa3r1yI0/1cqC4nMxgcHwOXi57FEzTiXo5mcHfX53CC55d/JNbhTrbHBiLLmPqgVkYubZxtTa6POhuK7k+yh/9YzGks4Lr01ug6ez1zvVpxJMZnDnKTS5qtNFmcl8ggt31lWitlW57fCnVVlrgqinXzcjT3LukTh5tWjBNJ+rz/SHUV5XhyT3qbYjQsw6nHWUmw32JOpHO4MPhGc08Ted0OG26uaLXG4xib0MlHJXKnWCpNJpN1IuJNN65Po0Xj+zS3QQ6rbCYDDjWcv+Apt5gDMspdbeN5+Nx2XErsoSFTeabqJ0QAv7RKJc9tkizifpHV6eQSGd5tofKdbU7MBiaw0pqdTO5LxCGyUA4sadW5siKK3egeG1iQeZIpDUcXkIsnoLXra2/P6lpNlGf6wuh2W7lOpjKdbU5kMoI9I+tlgV8gQg62xyam4CYayXX+oFi7l48dyRujSYT9Vw8he5AGC8dbeaFmSqX+4buCc5iZjGBgdCc5urTwOpi38bqMs03vviDUdRUmLGnXn3zw+WkyQlFbw9OIpURXPbQgNpKC/Y0VKI3GEWLo2KtbVxb9ekcj8uOQY23kvcEZ9HVxhvHt0qTT9Tn+kNoq63AEQ20F7PV8oc/GEX3UBg1FWbN/r16nDYEphewnMzIHYokoktJDIeXuOyxDYVseGkloneJ6CoRDRLRq6UIbLsiiwl8MDyDM8eaeXyiRnjbHYjGU3izfwIn99Vr9hZPh8uOrMCGg6jULrcogDsSt66QJ+o0gK8KIQ4DOAHgS0R0WNqwtu+tgUlksgIvcZOLZuSuci2nMqpcYluo9QNFjTa++INRmAyEoy28cXyrCtnwMiGE6F375wUA1wC4pA5su871hbCvsQqP7aqWOxRWJHvqq9aXAzyjsfvT93LarXBUmDEwps0DRX8wig6nDeUWnmK5VVuqURNRO4DHAVzM83uvEFEPEfWEw+HiRLdFk3Mr+MnILM4cdXLZQ0MMBsLTe+vw2K5qTa9tIiJ4NDryNJXJom8shi6+P70tBd/6IKIqAH8L4NeFEA+9NxNCnAVwFgC8Xm/+tRwSe/PKBIQAjzTVoN/7uaNIpbNyhyG5Dqcdf37hFhLpDMpM2nnyvBqax0oqyx2J21TQEzURmbGapF8XQnxX2pC273x/CIebbdjbUCV3KKzIbFYz6qrK5A5Dch6XDamMQGBqUe5Qiio3iMnbzol6Owq59UEA/hzANSHEH0of0vbcmY3j0miMn6aZqnk0OvK0NxiFq6YcTTar3KGoUiFP1CcBfAHAs0R0ee1/n5Y4ri073z8BADzSlKlaW20FqstMmqpTCyFWG1247LFtm9aohRAXACj+ZO58fwjHWms0M6OY6ZPBQDjstGlq2e14bBlT8wkue+yAJjoTb4UXMRiax5mjXPZg6udx2XFtYh7pjDYOT/28KGDHNJGoz/dPgAjc5MI0weOyIZHOYji8JHcoReEPRlFpMXJvww5oIlGf6wvhY+5a7LLzQQVTP60dKPqDURxvq9HExni5qP6VuzG5gMD0Is7wbQ+mEXsaqmA1GzRxoLiUSOPaxDy6uOyxI6pP1Of6QjAQ8LyHEzXTBqOBcLjZpomRp5fvxJAVQFc7dyTuhKoTtRAC5/pDeHpvPRqqtd8MwfTjiMuOwdAcsllZmnyLxh+Mggh4vI0HMe2EqhP1wPg8gjNxLnswzelw2bGUzGBkRt0Hij3BKA42VcOmsdVppabqRH2uPwSTgfDTHbvkDoWxolo/UFTxyNNsVuBSMMqLAopAtYk6mxV4s38Cpw80oKbCInc4jBXV/qYqWIwGDKr45kdgehELiTQfJBaBahP1pTtRjMeW8RI3uTANMhsNeKy5WtU3P3qCswB4EFMxqDZRn+ubgMVkwCcPN8kdCmOS6HDaMTA+DyHUeaDoD0ZRX2VBG4912DFVJupMVuDNKxN49mAjqvmQgmmUx2XD3HIKY9FluUPZFn8wii63g5d4FIEqE/XF2zMILyR4pCnTNDV3KIYXEgjOxHliXpGoMlGf759AhcWIZx9rlDsUxiRzcFc1jAZSZZ06t3GcE3VxqC5RpzJZvHVlAs8dakKFpeBNYoypjtVsxP7GKlWOPPUHo7AYDeub1dnOqC5Rv38zgmg8xSNNmS54XHYMjM+p7kDRH4ziSItdU3sf5VTIKq5vEdE0EQ2UIqDNnO+fQLXVhI8fbJA7FMYk53HaMLOUxNR8Qu5QCpZIZ3BlbA5eLnsUTSFP1P8LwPMSx1GQRDqDtwcn8anDu/gnNdOFXOlATQeKA+NzSGay3JFYRJsmaiFEN4DZEsSyqe6hCBZW0jzbg+nGoWYbiKCqA0Xe6FJ8RatRE9ErRNRDRD3hcLhYn/Y+5/pCcFSYcXJfvSSfnzGlqSwzYU99paoOFHtGomivq+CJlkVUtEQthDgrhPAKIbwNDcWvHy8nM/jRtSk872mGmTdFMB3xrI08VQMhBHpHeRBTsakm471zfRrxZIbLHkx3PE47JuZWEFlU/oHi6GwckcUkvG5eFFBMqknU5/pCaKguw5O76+QOhbGS6nDZAACDKhh52jPCjS5SKOR63hsAPgRwkIjGiOhfSh/W/RZWUnj3xjRePNIMo4HnBjB96VBRK7l/NIpqqwn7G6vkDkVTNm3tE0J8rhSBPMqPrk0hkc7ySFOmS/ZyM9x1FaqoU/tHouhsc8DAD1RFpYrSx7m+CTjtVr7uw3TLszbyVMnmllMYml7gsocEFJ+oY/EkfIEwXjzazD+lmW51uGwYnY1jLp6SO5QNXb4TgxDgjkQJKD5Rvz04iVRG4Mwxp9yhMCab3MjTwQnllj/8I7MwEHCslTeOF5viE/X5/gm46ypwhKdwMR3rcK7d/FBw+cM/GsWhZhsqy3iqZbEpOlFHFhN4/2YELx1t5i0RTNfqqsrgtFsV20qezmRxaTTGZQ+JKDpRv3VlAlkBLnswBqBjbeSpEl2fXEA8meGORIkoOlGf65/AvsYqHGyqljsUxmTncdpxK7KExURa7lAektvo4m3njkQpKDZRT86t4Ccjszhz1MllD8awuuxWCODahPLq1D0jUeyyWeG0W+UORZMUm6jfvDIBIcALbBlbo+TZ1LxxXFqKTdTn+kI43GzD3gZuRWUMABqry1BfVaa4xpfJuRWMx5a50UVCikzUd2bjuHwnxoeIjN2DiOBx2RTXSp5bFMCJWjqKTNTn+ycAgGd7MPYAj9OOwPQiVlIZuUNZ5w9GYTUbcHjtrjcrPkUm6nN9IRxvrUFrbYXcoTCmKB6XDZmswPXJBblDWecPzuJYSw0v9JCQ4l7Z4fAirk7Mc9mDsTyUNvJ0OZnBYGieyx4SU1yiPt83ASLgxSNc9mDsQS2OctjLzYqpU/eNxZDOCnjbOVFLSVGJWgiBc/0hfKy9Frv4PiZjD8kdKCrl5gdvHC+NghI1ET1PRDeI6CYR/ZZUwdyYWsDN6UWc4UNExjbkcdpxY3IByXRW7lDQG4xiX2MVaioscoeiaYWs4jIC+BMALwA4DOBzRHRYimDO9YVgIOAFLnswtqEOlx3JTBaBaXkPFLNZAf9oFF38NC25QuYRPgHgphDiFgAQ0V8D+CyAq8UMRAiB8/0TOLmvHvVVZcX81IxpSm7k7698uwdVMo4UzQiBWDzFB4klUMjfsgvAnXv+fQzAkw9+EBG9AuAVAGhra9tyIMupDJ7aU4en99Vv+c8ypiftdRX41VO7MR5bljsUHG+twScPN8kdhuYV7cexEOIsgLMA4PV6xVb/fIXFhP/6s0eLFQ5jmkVE+O0XJak+MoUq5DBxHEDrPf/esvZrjDHGSqCQRP0TAPuJaDcRWQC8DODvpA2LMcZYzqalDyFEmoh+DcDbAIwAviWEGJQ8MsYYYwAKrFELIb4P4PsSx8IYYywPRXUmMsYYexgnasYYUzhO1IwxpnCcqBljTOFIiC33pmz+SYnCAILb/OP1ACJFDEfN+LW4H78e9+PX4y4tvBZuIURDvt+QJFHvBBH1CCG8csehBPxa3I9fj/vx63GX1l8LLn0wxpjCcaJmjDGFU2KiPit3AArCr8X9+PW4H78ed2n6tVBcjZoxxtj9lPhEzRhj7B6cqBljTOEUk6hLtUBXDYiolYjeJaKrRDRIRK/KHZPciMhIRJeI6LzcsciNiGqI6DtEdJ2IrhHRU3LHJCci+o2175MBInqDiKxyx1RsikjUpVygqxJpAF8VQhwGcALAl3T+egDAqwCuyR2EQrwG4AdCiMcAHIOOXxcicgH4CgCvEMKD1VHML8sbVfEpIlHjngW6QogkgNwCXV0SQkwIIXrX/nkBq9+ILnmjkg8RtQB4EcA35Y5FbkRkB3AawJ8DgBAiKYSIyRuV7EwAyonIBKACQEjmeIpOKYk63wJd3SamexFRO4DHAVyUNxJZ/RGA3wSQlTsQBdgNIAzgL9ZKQd8kokq5g5KLEGIcwB8AGAUwAWBOCPFDeaMqPqUkapYHEVUB+FsAvy6EmJc7HjkQ0UsApoUQfrljUQgTgE4A3xBCPA5gCYBuz3SIyIHVd9+7ATgBVBLR5+WNqviUkqh5ge4DiMiM1ST9uhDiu3LHI6OTAD5DRCNYLYk9S0R/KW9IshoDMCaEyL3D+g5WE7defQLAbSFEWAiRAvBdAE/LHFPRKSVR8wLdexARYbUGeU0I8YdyxyMnIcTXhBAtQoh2rP538Y4QQnNPTIUSQkwCuENEB9d+6TkAV2UMSW6jAE4QUcXa981z0ODhakE7E6XGC3QfchLAFwBcIaLLa7/2b9d2VzL2ZQCvrz3U3ALwSzLHIxshxEUi+g6AXqzelroEDbaTcws5Y4wpnFJKH4wxxjbAiZoxxhSOEzVjjCkcJ2rGGFM4TtSMMaZwnKgZY0zhOFEzxpjC/X+fSXP+x2JULwAAAABJRU5ErkJggg==",
+            "text/plain": [
+              "<Figure size 432x288 with 1 Axes>"
+            ]
+          },
+          "metadata": {
+            "needs_background": "light"
+          },
+          "output_type": "display_data"
+        }
+      ],
       "source": [
         "df = pd.DataFrame(np.random.randint(10, size=(10,4)), columns=list(\"ABCD\"))\n",
         "\n",
@@ -6009,21 +6001,6 @@
         "plt.show()\n",
         "\n",
         "# df.A.plot.line()과 같다."
-      ],
-      "execution_count": 449,
-      "outputs": [
-        {
-          "output_type": "display_data",
-          "data": {
-            "image/png": "iVBORw0KGgoAAAANSUhEUgAAAWoAAAD4CAYAAADFAawfAAAABHNCSVQICAgIfAhkiAAAAAlwSFlzAAALEgAACxIB0t1+/AAAADh0RVh0U29mdHdhcmUAbWF0cGxvdGxpYiB2ZXJzaW9uMy4yLjIsIGh0dHA6Ly9tYXRwbG90bGliLm9yZy+WH4yJAAAgAElEQVR4nO3deXDc53kf8O+zFxbXLhYnsQtgwVskloeAtUSJIj2RbEeyRDvTJK08tdMkTVR3HFtJPZOJm3baZjJtM0kzUZ3UCes49UwUpY1jtyFlWY4jRVhKMmUsSIAADyxBYkFgcewCu7gW2PPtH8CC14JYAPvb3/V8ZjyRSBB4shQe/PZ53+d5SAgBxhhjymWQOwDGGGOPxomaMcYUjhM1Y4wpHCdqxhhTOE7UjDGmcCYpPml9fb1ob2+X4lMzxpgm+f3+iBCiId/vSZKo29vb0dPTI8WnZowxTSKi4Ea/x6UPxhhTOE7UjDGmcJyoGWNM4ThRM8aYwnGiZowxhSsoURPRbxDRIBENENEbRGSVOjDGGGOrNk3UROQC8BUAXiGEB4ARwMtSB8YYY2xVoaUPE4ByIjIBqAAQki4kpiSh2DLeujIhdxiM6dqmiVoIMQ7gDwCMApgAMCeE+OGDH0dErxBRDxH1hMPh4kfKZPH1dwL416/3YmYxIXcojOlWIaUPB4DPAtgNwAmgkog+/+DHCSHOCiG8QghvQ0PeLkimMkIIdA9FAAC9ozGZo2FMvwopfXwCwG0hRFgIkQLwXQBPSxsWU4LbkSWMx5YBAP5gVOZoGNOvQhL1KIATRFRBRATgOQDXpA2LKUH30GoJq9luhT84K3M0jOlXITXqiwC+A6AXwJW1P3NW4riYAvgCEbTXVeDTR5rRNzaHZDord0iM6VJBtz6EEP9BCPGYEMIjhPiCEIJPljQumc7iw1szOLW/AV1uB5LpLAZDc3KHxZgucWciy6t3NIp4MoNT++vR5XYA4Do1Y3LhRM3y8gXCMBoIT+2tQ5PNihZHOSdqxmTCiZrl5QtE0NlWg2qrGQDgdTvQE4xCCCFzZIzpDydq9pDZpSSujM/h1P679+G73A6EFxIYiy7LGBlj+sSJmj3k/ZsRCAGc2l+//mudXKdmTDacqNlDfIEwbFYTjrbUrP/aY7tsqLQY0cP3qRkrOU7U7D5CCPgCETyzvx5GA63/utFAeLzNAX+QW8kZKzVO1Ow+w+FFTMyt3FefzulyO3Bjch4LKykZImNMvzhRs/vkhjDdW5/O6XI7kBXA5Tv8VM1YKXGiZvfxBcLY01CJFkfFQ793vK0GRHygyFipcaJm6xLpDH58axan85Q9AMBmNeNgUzUnasZKjBM1W+cfiWI5lclb9sjpcjtwaTSGTJYbXxgrFU7UbF13IAKzkXBiT92GH+Ntd2AxkcbQ1EIJI2NM3zhRs3W+QBidbQ5Ulpk2/JiutloAQA+XPxgrGU7UDAAQWUxgMDSP0wcevUattbYc9VVl6OVEzVjJcKJmAFbbxoH81/LuRURrA5q4Q5GxUilkue1BIrp8z//miejXSxEcK53uoQgcFWZ0OO2bfmyX24E7s8uYnl8pQWSMsUJWcd0QQhwXQhwH0AUgDuB7kkfGSma1bTyMk/vubxvfSFf76oCm3lEufzBWClstfTwHYFgIEZQiGCaPoalFTC8kNrw//aAOpw0WkwE9I/pL1L//9nX8v8vjcofBdGarifplAG/k+w0ieoWIeoioJxwO7zwyVjK+wOrf1zOb1KdzykxGHHXZ4dfZE/Xccgrf+MdhvH5xVO5QmM4UnKiJyALgMwD+Jt/vCyHOCiG8QghvQ0NhT2ZMGboDEexrrIKzprzgP9PV7sDA+BxWUhkJI1OWD4cjyArgamgeWW74YSW0lSfqFwD0CiGmpAqGld5KKoOLt2Y2ve3xoK42B1IZgSvj+tlM3h1YvRmzmEgjOBuXORqmJ1tJ1J/DBmUPpl49I1Ek0tlN708/SG+byYUQ6B4Ko612dVjVgI5+QDH5FZSoiagSwCcBfFfacFip+QJhWIwGPLm7dkt/rq6qDLvrK3VzoBiciWMsuox/8XQ7LEYDBkKcqFnpFJSohRBLQog6IQT/16kx7w2F4W13oMKycdv4RjrbHOgd1cdm8tyB63OPNeLgrmoMjs/LHBHTE+5M1LHp+RVcn1zIu82lEN52B2aXkrgdWSpyZMrTHYigtbYc7roKeFw2DITmdPEDiikDJ2odu1Bg2/hG9FKnTmWy+HB4Bqf2N4CI0OG0IxZPYTy2LHdoTCc4UeuYLxBBXaUFh5tt2/rz+xqqYLOaNN+hePlODIuJNE6v/UDzuFbb7PlAkZUKJ2qdymbvbhs3FNA2no/BQOh0OzR/oOgbCsNAwFN7VxP1Y7uqYTQQBrhOzUqEE7VOXZ9cQGQxse36dE5XmwOB6UXMxbW7mfy9QATHW2tgLzcDAKxmI/Y3VvHND1YynKh1KneLYbv16RytD2iKxZPoH4s99AOtw2nHwDgfKLLS4EStU75ABAebqtFks+7o8xxvrYHRQJo9UHz/5gyEAE4fuP8HmsdlQ2QxiemFhEyRMT3hRK1Dy8kMPhqZ3fHTNABUWEw43GzTbKL2BcKotppwrKXmvl/nA0VWSpyodeijkVkk01mc2mLb+Ea63A5cvhNDKpMtyudTitU53RGc3FsPk/H+b5VDzTYQgQ8UWUlwotYh31AYFpMBT7RvrW18I51uB5ZTGVyf0NZm8luRJYzHlnHqwMPvPKrKTNhdX8kHiqwkOFHrkC8QwRPttSi3GIvy+bxrjS9a26PoG1o9cN1ooYLHaccglz5YCXCi1pmp+RXcmFp46HBsJ5w15Wi2WzVXp/YFImivq0Dr2sS8B3lcNoTmVjCzyAeKTFqcqHWmeyh3La+4yx263A70aihRJ9NZfHhr5pGvk2dtEfBgiOvUTFqcqHXGF4igvqoMj+2qLurn7XI7EJpbQUgj8y96R6OIJzOPvBmT29jOdWomNU7UOpLNCly4GcHp/fUg2l7b+Ea0NqDJFwjDaCA8tbduw4+xV5jRWlvOI0+Z5DhR68jViXnMLiXz3mLYqUPNNpSbjRpK1BF0ttWg2mp+5Mcdcdn5iZpJrtANLzVE9B0iuk5E14joKakDY8XXvdY2fnJf8RO12WjAsVa7JhL17FISV8bnCqrjdzjtCM7EMbes3VknTH6FrvV4DcAPhBA/t7aNPP8xOFM031AEh5ptaKzeWdv4RrzuWnzjvWHEk+ltbYxRivdvRiBEYXNQch2KV0PzjyyTMGlFl5JIK2AzvIFW19QV26bfTURkB3AawC8CgBAiCSBZ9EiYpOLJNHqCs/jlk7sl+xpdbgcyWYHLd2J4em/xn9pLpXsoDJvVhKMPtI3n0+FcneU9GJrjRC2Tv+sL4StvXJI7DABAfVUZev7dJ4r+eQt57NkNIAzgL4joGAA/gFeFEPftXyKiVwC8AgBtbW3FjpPt0MVbs0hlRNGv5d3r8bbVxNYbjKo2Uefaxp/ZXw9jAXO666vK0Gy38swPGb13I4yaCjO++qmDcocCq0maY79CErUJQCeALwshLhLRawB+C8C/v/eDhBBnAZwFAK/XK/97EHaf7kAYZSYDvGtjSaVQU2HB/sYq9Ki4Tn1zehGT8ysbdiPm0+G0Y4DvUsvGH5zFx9pr8YUTbrlDkUwh6X8MwJgQ4uLav38Hq4mbqYgvEMGTe+pgNRenbXwjucaXrALqhdvRHVjdI/nMFiYLelw2DIcXsZRISxUW20BkMYGRmfj69VCt2jRRCyEmAdwhotz7iucAXJU0KlZUodgybk4vru/8k1KX24H5lTSGw4uSfy0p+AJh7GmoRIuj8PNyj9MOIYBrE/xUXWq5bliv3hP1mi8DeJ2I+gEcB/CfpQuJFduFQG7buHT16Zyu9QFN6it/JNIZ/PjWzJbKHgDPppaTPxiFxWhY/zvQqoIStRDishDCK4Q4KoT4GSGE+r4Ldaw7EEaTrQwHmqok/1q76ytRW2lR5X1q/0gUK6nslhcqNNnKUF9l4Tq1DPzBKDwum+QlPblxZ6LGZdbaxk/tbyh623g+RITONnUOaOoORGA2Ek7s2do1OyJa36HISieRzqB/fE7z9WmAE7XmDYzPIRZPFWXtVqG63A7ciiypbvynLxBGZ5sDlWVbb9bxuGwITC9iJZWRIDKWz8D4PJLpLCdqpn65bePPSNA2vhHv+mbyWMm+5k5FFhMYDM3j9DbXk3mcdmSyAjcmtbXlRsly79o6OVEztesOROBx2SRpa93IEZcdZiOpauPL+zdzB67b+4G2fqDIA5pKpic4i7baCslGIigJJ2oNW0yk0RuMluS2x72sZiM6nHZV1am7hyJwVJjXZ0xvVYujHDariZfdlogQAv5gTPPX8nI4UWvYj4dnkM6Kktanc7xuB/rG5pBMK38z+WrbeBgn9xXWNp4PEcHjsmOQn6hLYnQ2jshiQhdlD4ATtab5AmGUm42yHLZ0uR1IprOqKAXcmFrA9EJiy/enH+Rx2XF9YgGpjPJ/OKld7vqnHg4SAU7UmuYLRHBiTy3KTKW/Y5r7BlJD+cM3tPW28Xw6nDYkM1kEptTZlakm/mAU1WUmHGgq7ko5peJErVF3ZuO4FVkqeX06p9FmRWttOXpGlJ+ouwNh7GusgrOmfEefhw8US8cfjOJ4W822S1Vqw4laoy6s3WI4LcHarUJ1tTngH41CCOUOaFpJZfDR7dkdlz0AYHddJSotRgxy44uk5ldSuDG1AK+7Vu5QSoYTtUb5AmE0263Y2yB92/hGutprEV5IYCyq3M3kPxmZRSKdLcoeSYOBeORpCVwajUEI/dSnAU7UmpTJClwIRHBKgm3jW9HVlhvQpNz71L5ABBajAU/uLs7TWYfLhquheWRUOuZVDfzBKAwEHG/bfAOPVnCi1qD+sRjmV9Ky1adzDu6qRlWZSdEDmrqHwvC2O4q249HjtGM5lcHtCB8oSqU3GMVju2yo2karv1pxotag7qEIiErbNp6P0UB4vK1GsQeK0/MruD65UNQfaHdHnnL5QwrpTBaXRqO6KnsAnKg1yRcI46jLDkelRe5Q0NnmwI2pBSyspOQO5SEXdtg2ns/ehkqUmQw8SU8iN6YWsJTMSLpSTokKStRENEJEV4joMhH1SB0U2775lRQu3YnJXvbI8bY7IARw+Y7yBjT5AhHUVVpwuNlWtM9pMhpwqNmGK5yoJZEro3W2caLeyE8JIY4LIbySRcN27MPhGWRkahvP53hrDQwExZU/stm728YNRb6L61k7UFTr3kgl8wejaKwuQ4tjZ3fe1YZLHxrjC4RRaTHicYU8cVRbzTi4y4beUWUl6uuTC4gsJiR55+Fx2rGQSGN0Nl70z613/mAU3naHrLeZ5FBoohYAfkhEfiJ6Jd8HENErRNRDRD3hcLh4EbIt8QUieGpvHSwm5fwM7nLX4NJoTFFX1nJzuqV458EditKYml/BWHRZd2UPoPBE/YwQohPACwC+RESnH/wAIcTZtb2K3oYGZdRH9SY4s4TgTFwx9emcLrcDi4m0oobq+wIRHGyqRpOt+LOM9zdVwWwkvvlRZLn6tLddPx2JOYUutx1f+7/TAL4H4Akpg2Lb4wsU/xZDMeRaff0KKX8sJzP4aGRWstepzGTEgaZqHnlaZD0jUZSZDEU9/FWLTRM1EVUSUXXunwF8CsCA1IGxrfMFwnDVlGN3faXcodynxVGOhuoy+EeU0aF48fYMkuksTm1z7VYhPGvLbpU850Rt/KNRHGupUVRZr1QK+f+4CcAFIuoD8BGAN4UQP5A2LLZV6UwWH9ycwekD8raN50NE8Lodinmi9gUisJiK1zaej8dlQzSeQmhuRbKvoScrqQwGx+fQpbP70zmb9mAKIW4BOFaCWNgO9I3FsJCQv218I11uB94amMT0/AoaJagLb4UvEMaTu2thNUs3p7tjvUNxDq4djk9lQN+dGNJZsT4/Rm/09x5Co7qHIjAQ8PTeOrlDySu3MknuuR+TcysYmlqUvI5/aJcNBgKPPC2S3LsxvazeehAnao3wBcI42lKDmgr528bz8TjtsJgMsifqu9fypH3nUW4xYl9jFY88LZLeYBR7GipRq4CxCHLgRK0Bc8spXL4Tw2mF3fa4l8VkwLEWO3pkT9QR1FeV4bFd0q9wyh0osp1Z3Tge1W3ZA+BErQkf3IwgKyDpLYZi6HLXYjA0h5VURpavn80KXLgZwekSzenucNkxvZDA9DwfKO7ErcgSovGU7gYx3YsTtQZ0ByKoKjPheKuyB6l3uR1IZQT6x+R5yrw6MY/ZpWRRtrkU4sjageIglz92xD+ir43j+XCiVjkhBLqHwnh6bx3MRmX/dXaubeSQq07dvVafPlmiOd2HnauNGVz+2Bl/MIqaCjP21Mu3Vk5uyv7OZpsamYljPLas+LIHANRVlWFPfaVsido3FMGhZhsaq0tzPbCqzIQ99ZU882OH/KNRdLY5ij7lUE04Uatc7haDkg8S79XpdqBXhs3k8WQaPcHZkr9OHS47z/zYgVg8iZvTi7ouewCcqFWveyiCttoKuOuU1Ta+Ea/bgdmlJG5Hlkr6dS/emkUqI0reEORx2jAeW0Z0KVnSr6sVufG4nKiZaqUyWXw4HFHcEKZHyX3DlfqaXncgjDKToeQ3Bzx8oLgjPSNRmAyEYy3KPiiXGidqFbs0GsNSMqPYtvF89jZUwWY1obfUiXoojCf31EnaNp5Px9qBIq/m2h5/MIoOpw3lltL+vSkNJ2oV8wXCMBoITym0bTwfg4HQ5XaU9EBxPLaM4fCSLHX8mgoLWhzlfKC4DalMFn1jMd22jd+LE7WKdQciON5aA3u5We5QtqTL7UBgehGxeGnqthdyB64y3YzxOO0882MbrobmsZLK6r4+DXCiVq1YPIn+sZiq6tM5XWuLBC6NlmYzeXcggiZbGfY3ynMP1+OyYWQmjvmVlCxfX61y77o4UXOiVq33b85ACOmHC0nhWKsdRgOhJyj9IoFMVuD9mxGc2t8g25zu3MjTq3yguCX+YBSumnI023lMLCdqlfIFwqi2mnCsxS53KFtWYTHhcLOtJHXqgfE5xOIpWd95eJx3Z1Ozwggh0BOc5afpNQUnaiIyEtElIjovZUBsc7m28ZN762FSeNv4RrrcDvTdmUMqk5X06+Qagp4pUdt4Pg3VZWiylfEVvS0Iza1gaj7BiXrNVr7LXwVwTapAWOGGw0sIza2UbLiQFLrcDiynMrg2IW3y6g5E4HHZUFdVJunX2QyPPN2anrX9mpyoVxWUqImoBcCLAL4pbTjyS6Qz+C9vXVvviFKiu23j6qtP5+QaT6Qsfywm0ugNRhVRx+9w2TEcXkQ8mZY7FFXoDUZRYTGWZG64GhT6RP1HAH4TwIbvU4noFSLqIaKecDhclODk8A/XpvFn793Cz//ph/iTd28im1XeFmlfIILd9ZVora2QO5Rta7aXw2m3Stqh+OPhGaSzQhE3YzxOG7ICuDaxIHcoqtATjOJ4a41qS3vFtumrQEQvAZgWQvgf9XFCiLNCCK8QwtvQIP8TzHad7w+hvsqCFzy78Ptv38AXvnVRUYPfE+kMPhyeUUTy2alOt0PSDkVfIIxys1ERb5/vtpJz+WMzS4k0rk3Mw6uAvzelKOTH1UkAnyGiEQB/DeBZIvpLSaOSyWIijX+4No0XjzTj6597HL/3s0fgD0bxwms+vHtjWu7wAAC9wRiWU+pqG9+I1+3AxNwKQrFlST6/LxDBiT21KDPJ337cbLeittLCdeoC9N2JISv0u8g2n00TtRDia0KIFiFEO4CXAbwjhPi85JHJ4EdXp5BIZ/HSMSeICP/sY204/+Vn0FBdhl/6i5/gd89fRTIt7S2FzfgCYZgMhBN7amWNoxhyjS9SlD/uzMZxK7KkmB9oRIQOp41HnhagJxgFEfC4jnckPogLQPc43x9Cs9163xLNfY3V+L9fOolfeMqNb164jZ/9xgcYKfGIznv5AhF0tjlQbVVX23g+h5qrUW42SlL+uHAzAgA4raCbMUdcdgxNLSCRlmdnpFr4g1EcaKxW3WgEKW0pUQsh/lEI8ZJUwchpLp7Ce0NhvHik+aFNElazEb/zWQ/+9PNdGJ2N48X/7sP3Lo2VPMaZxQQGQnOaqE8DgMlowPHWGklufnQPhdFst2Jvg3LWN3lcdqSzAkOTi3KHoljZrEDvaJTLHg/gJ+o1b1+dRCojcOaYc8OPed6zC99/9RQOO234jf/dh6/+nz4sJUp33er94bW2cRWs3SpUl9uBqxPzRX0d05ks3r8ZwWkZ28bzWe9Q5APFDQWmF7GwkuaDxAdwol5zri+EttoKHN2kJdtVU443fvUEvvLcfnzv0hjOfP1CyQ6IfENh2MvN69uttaCr3YFMVqBvrHgDmvrH5zC/klZcQ1BrbTmqrSY+UHwEHsSUHydqrJYUPhiewUtHmwt6AjMZDfg3nzyAv/rVE4gnM/gn/+MDfOvCbUn3AAoh4AtE8My+ehg1tOSzs3Wt8WWkeOUP31AERMDJvcpK1ES02qHIreQb6gnOoq7SAnedensEpMCJGsBbA5PIZB9d9sjnxJ46fP/VUzh9oB6/c/4qfuXbPZiVaDfezelFTM6vaKY+nWOvMONAUxX8RewE9QXCOOqyw1FpKdrnLBaPy4ZrE/OSzzhRq95gFF1uh6JKVkrAiRqrZY+9DZXbaletrbTgf/6CF//xzGH4AhG88Fo3PhiOFD3G94bWhgtpLFEDq29ze4PRonSBzq+kcOlOTDHX8h7kcdmRTGdxc5oPFB8UXkhgZCbOZY88dJ+op+ZX8NHILM6s3Z3eDiLCL57cje996WlUlpnwz795Ef/thzeQLuJTky8QwZ6GSrQ4tPeWsLPNgfmVNG6Gd568PhyeQUYhbeP5dPDI0w3l5uuUegGxGug+Ub/ZPwEhgJeObq3skU+H047zX34GP9fZgq+/cxMvn/0xxovQdbeSyuDi7RlVD2F6FG/7auNLMa7p+QJhVFqMim2W2F1fiQqLkUee5tEbjMJiNKz/MGN36T5Rn+sP4VCzDfuKtKapwmLC7//8Mbz28nFcn1zAC3/UjR8MTOzoc/qDUayksop9Styp9roK1FVa0FOEA0VfIIKn9tbBYlLmf9pGA+Fws42fqPPoCUbhcdlKvileDZT5X3OJ3JmN49JoDGeONRf9c3/2uAtvfuUZ7K6vxBf/she//b0rWEltryOtOxCG2Ug4sUc928a3gohWBzTt8EAxOLOE4ExcsfXpHI/LjqsT88gocDKjXBLpDK6Mza2/u2L303WifvPK6pPuS0d2XvbIx11Xib/54tP4V6f34PWLo/jsH7+Poamtj7n0DUXQ5XagsswkQZTK0OV24HZkCTOLiW1/Dl9g9RBX6e88Opw2xJMZ3JZxFIHSDIzPI5nJolOhJSu56TpRn+8P4VhrDdokvLNpMRnwtU8fwrd/+QnMLCXwmT++gDc+Gi34znV4IYGrE/OKf0rcqdxJ/07q1L5AGK6acuyuryxWWJLgkacP8wd5o8uj6DZR3wovYmB8HmeOFr/skc/HDzTg+6+ewsfaa/G1717Br/3VJcwtpzb9c+/nhgtpPFEfcdlhNtK271OnM1l8cHMGpw/UK/4O7r7GKlhMBq5T38MfjMJdV4GGanlXpimVbhP1+f7VsseLJUrUANBYbcW3f+kJ/NYLj+HtwUl8+jXfpk+Q3YEwHBVmdDhtJYpSHlazER6XfdsdipfvxLCQSKvinYfZaMChXdU88nSNEAL+YPS+qZXsfjpO1CE80V6LZnt5Sb+uwUD44sf34m+++BSIgH/6Zxuv/FpvG9/f8NBEPy3yuh3oH5/b1hjQ7kAEBgW2jW+kw2XHQGhO0rEDajE6G0dkMYkuvj+9IV0m6huTCxiaWsRLEtz2KNTjbQ58/9VTj1z5dWNqAeGFhOIPx4qly+1AMp3d1h1jXyCMY601sFeoY4axx2nHwkoad2al2W6jJjyIaXO6TNTn+0MwEPCCR75EDQA2q/mRK798Q+q4xVAsuRnEWy1/zMVT6FNw23g+HtdqKYtHnq7en64uM+FAI28c30ghy22tRPQREfUR0SAR/adSBCYVIQTO9YXw9N56RRxcPGrlV3cgjP2NVSUvz8ilsdqKttqKLd/8+GA4gqwATqvoB9qBpmqYDMQHiljtSHzc7dBFeW+7CnmiTgB4VghxDMBxAM8T0Qlpw5LOwPg8RmbieKmEh4iFyLfy66Pbs6p6SiyGLrcDPcHolmq33YEIqstMONZaI2FkxWU1G3GgqVr3I0/nllO4MbXAB4mbKGS5rRBC5KblmNf+p9oTkPP9IZgMhOc9u+QO5SG5lV9/9oXVlV+JtHbbxjfS5XYgspgouHYrhED3UBhP7a2D2aiuSp7HZcPguL4PFC/fiUEIHsS0mYL+yyYiIxFdBjAN4O+FEBfzfMwrRNRDRD3hcLjYcRaFEALn+ydwan89aiqUN6s456c7duGtV0/hd3/Gg9MaWrtViPXGl9HZgj5+ZCaO8diyKteTeVx2zCwlMfnAIbKe+INRGAiqejckh4IStRAiI4Q4DqAFwBNE5MnzMWeFEF4hhLehQZnfNL2jMYzHlre8IEAOzppyfP6EW1PbXApxoKka1WWmggc0+QKrDwVqqk/n3B15qt/yhz84i0PNNlRpeDxCMWx1C3kMwLsAnpcmHGmd6wvBYjLgk4eb5A6FbcBoIBxvK3wzefdQBG21FXDXKbttPJ9DzdUwkH5nU6czWVwejfG1vAIUcuujgYhq1v65HMAnAVyXOrBiy2QF3rwygZ862IBqqzru2upVl9uBG1MLmF95dIt9KpPFh8MR1dbxKywm7G2o0u3Mj+uTC1hKZjhRF6CQJ+pmAO8SUT+An2C1Rn1e2rCK76PbswgvJFRR9tA7r7sWQgCXRx+9mfzSaAxLyYyqb8Z4XHZc0ekTdW6sLSfqzRVy66NfCPG4EOKoEMIjhPidUgRWbOf6Qyg3G/HsY41yh8I2cazVDgNtPknPFwjDaCA8tVe9c7o7nDZMzScwvaC/A0V/MIomWxlcNfroE9gJdd1n2hCepPIAAA+SSURBVKZUJosfDEziE4ebUGHhQwulq7aacXCXrYCBVREcb62BvVy9pay7I0/1d6DYMxKF112r+GmHSqCLRP3B8Axml5KKa3JhG/O6Hbg0Gt1wC0p0KYn+sZjqx78eXpuKOKiz8sfk3ArGY8vrYwPYo+kiUZ/rC6G6zISPq/CurV51uR1YSmZwfTL/k+b7wxEIAZw6oM6DxByb1Yz2ugrdXdHjQUxbo/lEnUhn8PbgJD7VsYuXZqpI7hu4d4Pyh28oApvVhKMu9W+szo081RN/MAqr2aD5OevFovlE3T0UwcJKWtaRpmzrWhzlaKwuy1unXp3THcbJffUwqaxtPB+P046x6DJi8aTcoZSMfzSKoy01qmv7l4vmX6Xz/SHUVJjxzD51v0XWGyKCt311QNODhsNLCM2tqPpa3r1yI0/1cqC4nMxgcHwOXi57FEzTiXo5mcHfX53CC55d/JNbhTrbHBiLLmPqgVkYubZxtTa6POhuK7k+yh/9YzGks4Lr01ug6ez1zvVpxJMZnDnKTS5qtNFmcl8ggt31lWitlW57fCnVVlrgqinXzcjT3LukTh5tWjBNJ+rz/SHUV5XhyT3qbYjQsw6nHWUmw32JOpHO4MPhGc08Ted0OG26uaLXG4xib0MlHJXKnWCpNJpN1IuJNN65Po0Xj+zS3QQ6rbCYDDjWcv+Apt5gDMspdbeN5+Nx2XErsoSFTeabqJ0QAv7RKJc9tkizifpHV6eQSGd5tofKdbU7MBiaw0pqdTO5LxCGyUA4sadW5siKK3egeG1iQeZIpDUcXkIsnoLXra2/P6lpNlGf6wuh2W7lOpjKdbU5kMoI9I+tlgV8gQg62xyam4CYayXX+oFi7l48dyRujSYT9Vw8he5AGC8dbeaFmSqX+4buCc5iZjGBgdCc5urTwOpi38bqMs03vviDUdRUmLGnXn3zw+WkyQlFbw9OIpURXPbQgNpKC/Y0VKI3GEWLo2KtbVxb9ekcj8uOQY23kvcEZ9HVxhvHt0qTT9Tn+kNoq63AEQ20F7PV8oc/GEX3UBg1FWbN/r16nDYEphewnMzIHYokoktJDIeXuOyxDYVseGkloneJ6CoRDRLRq6UIbLsiiwl8MDyDM8eaeXyiRnjbHYjGU3izfwIn99Vr9hZPh8uOrMCGg6jULrcogDsSt66QJ+o0gK8KIQ4DOAHgS0R0WNqwtu+tgUlksgIvcZOLZuSuci2nMqpcYluo9QNFjTa++INRmAyEoy28cXyrCtnwMiGE6F375wUA1wC4pA5su871hbCvsQqP7aqWOxRWJHvqq9aXAzyjsfvT93LarXBUmDEwps0DRX8wig6nDeUWnmK5VVuqURNRO4DHAVzM83uvEFEPEfWEw+HiRLdFk3Mr+MnILM4cdXLZQ0MMBsLTe+vw2K5qTa9tIiJ4NDryNJXJom8shi6+P70tBd/6IKIqAH8L4NeFEA+9NxNCnAVwFgC8Xm/+tRwSe/PKBIQAjzTVoN/7uaNIpbNyhyG5Dqcdf37hFhLpDMpM2nnyvBqax0oqyx2J21TQEzURmbGapF8XQnxX2pC273x/CIebbdjbUCV3KKzIbFYz6qrK5A5Dch6XDamMQGBqUe5Qiio3iMnbzol6Owq59UEA/hzANSHEH0of0vbcmY3j0miMn6aZqnk0OvK0NxiFq6YcTTar3KGoUiFP1CcBfAHAs0R0ee1/n5Y4ri073z8BADzSlKlaW20FqstMmqpTCyFWG1247LFtm9aohRAXACj+ZO58fwjHWms0M6OY6ZPBQDjstGlq2e14bBlT8wkue+yAJjoTb4UXMRiax5mjXPZg6udx2XFtYh7pjDYOT/28KGDHNJGoz/dPgAjc5MI0weOyIZHOYji8JHcoReEPRlFpMXJvww5oIlGf6wvhY+5a7LLzQQVTP60dKPqDURxvq9HExni5qP6VuzG5gMD0Is7wbQ+mEXsaqmA1GzRxoLiUSOPaxDy6uOyxI6pP1Of6QjAQ8LyHEzXTBqOBcLjZpomRp5fvxJAVQFc7dyTuhKoTtRAC5/pDeHpvPRqqtd8MwfTjiMuOwdAcsllZmnyLxh+Mggh4vI0HMe2EqhP1wPg8gjNxLnswzelw2bGUzGBkRt0Hij3BKA42VcOmsdVppabqRH2uPwSTgfDTHbvkDoWxolo/UFTxyNNsVuBSMMqLAopAtYk6mxV4s38Cpw80oKbCInc4jBXV/qYqWIwGDKr45kdgehELiTQfJBaBahP1pTtRjMeW8RI3uTANMhsNeKy5WtU3P3qCswB4EFMxqDZRn+ubgMVkwCcPN8kdCmOS6HDaMTA+DyHUeaDoD0ZRX2VBG4912DFVJupMVuDNKxN49mAjqvmQgmmUx2XD3HIKY9FluUPZFn8wii63g5d4FIEqE/XF2zMILyR4pCnTNDV3KIYXEgjOxHliXpGoMlGf759AhcWIZx9rlDsUxiRzcFc1jAZSZZ06t3GcE3VxqC5RpzJZvHVlAs8dakKFpeBNYoypjtVsxP7GKlWOPPUHo7AYDeub1dnOqC5Rv38zgmg8xSNNmS54XHYMjM+p7kDRH4ziSItdU3sf5VTIKq5vEdE0EQ2UIqDNnO+fQLXVhI8fbJA7FMYk53HaMLOUxNR8Qu5QCpZIZ3BlbA5eLnsUTSFP1P8LwPMSx1GQRDqDtwcn8anDu/gnNdOFXOlATQeKA+NzSGay3JFYRJsmaiFEN4DZEsSyqe6hCBZW0jzbg+nGoWYbiKCqA0Xe6FJ8RatRE9ErRNRDRD3hcLhYn/Y+5/pCcFSYcXJfvSSfnzGlqSwzYU99paoOFHtGomivq+CJlkVUtEQthDgrhPAKIbwNDcWvHy8nM/jRtSk872mGmTdFMB3xrI08VQMhBHpHeRBTsakm471zfRrxZIbLHkx3PE47JuZWEFlU/oHi6GwckcUkvG5eFFBMqknU5/pCaKguw5O76+QOhbGS6nDZAACDKhh52jPCjS5SKOR63hsAPgRwkIjGiOhfSh/W/RZWUnj3xjRePNIMo4HnBjB96VBRK7l/NIpqqwn7G6vkDkVTNm3tE0J8rhSBPMqPrk0hkc7ySFOmS/ZyM9x1FaqoU/tHouhsc8DAD1RFpYrSx7m+CTjtVr7uw3TLszbyVMnmllMYml7gsocEFJ+oY/EkfIEwXjzazD+lmW51uGwYnY1jLp6SO5QNXb4TgxDgjkQJKD5Rvz04iVRG4Mwxp9yhMCab3MjTwQnllj/8I7MwEHCslTeOF5viE/X5/gm46ypwhKdwMR3rcK7d/FBw+cM/GsWhZhsqy3iqZbEpOlFHFhN4/2YELx1t5i0RTNfqqsrgtFsV20qezmRxaTTGZQ+JKDpRv3VlAlkBLnswBqBjbeSpEl2fXEA8meGORIkoOlGf65/AvsYqHGyqljsUxmTncdpxK7KExURa7lAektvo4m3njkQpKDZRT86t4Ccjszhz1MllD8awuuxWCODahPLq1D0jUeyyWeG0W+UORZMUm6jfvDIBIcALbBlbo+TZ1LxxXFqKTdTn+kI43GzD3gZuRWUMABqry1BfVaa4xpfJuRWMx5a50UVCikzUd2bjuHwnxoeIjN2DiOBx2RTXSp5bFMCJWjqKTNTn+ycAgGd7MPYAj9OOwPQiVlIZuUNZ5w9GYTUbcHjtrjcrPkUm6nN9IRxvrUFrbYXcoTCmKB6XDZmswPXJBblDWecPzuJYSw0v9JCQ4l7Z4fAirk7Mc9mDsTyUNvJ0OZnBYGieyx4SU1yiPt83ASLgxSNc9mDsQS2OctjLzYqpU/eNxZDOCnjbOVFLSVGJWgiBc/0hfKy9Frv4PiZjD8kdKCrl5gdvHC+NghI1ET1PRDeI6CYR/ZZUwdyYWsDN6UWc4UNExjbkcdpxY3IByXRW7lDQG4xiX2MVaioscoeiaYWs4jIC+BMALwA4DOBzRHRYimDO9YVgIOAFLnswtqEOlx3JTBaBaXkPFLNZAf9oFF38NC25QuYRPgHgphDiFgAQ0V8D+CyAq8UMRAiB8/0TOLmvHvVVZcX81IxpSm7k7698uwdVMo4UzQiBWDzFB4klUMjfsgvAnXv+fQzAkw9+EBG9AuAVAGhra9tyIMupDJ7aU4en99Vv+c8ypiftdRX41VO7MR5bljsUHG+twScPN8kdhuYV7cexEOIsgLMA4PV6xVb/fIXFhP/6s0eLFQ5jmkVE+O0XJak+MoUq5DBxHEDrPf/esvZrjDHGSqCQRP0TAPuJaDcRWQC8DODvpA2LMcZYzqalDyFEmoh+DcDbAIwAviWEGJQ8MsYYYwAKrFELIb4P4PsSx8IYYywPRXUmMsYYexgnasYYUzhO1IwxpnCcqBljTOFIiC33pmz+SYnCAILb/OP1ACJFDEfN+LW4H78e9+PX4y4tvBZuIURDvt+QJFHvBBH1CCG8csehBPxa3I9fj/vx63GX1l8LLn0wxpjCcaJmjDGFU2KiPit3AArCr8X9+PW4H78ed2n6tVBcjZoxxtj9lPhEzRhj7B6cqBljTOEUk6hLtUBXDYiolYjeJaKrRDRIRK/KHZPciMhIRJeI6LzcsciNiGqI6DtEdJ2IrhHRU3LHJCci+o2175MBInqDiKxyx1RsikjUpVygqxJpAF8VQhwGcALAl3T+egDAqwCuyR2EQrwG4AdCiMcAHIOOXxcicgH4CgCvEMKD1VHML8sbVfEpIlHjngW6QogkgNwCXV0SQkwIIXrX/nkBq9+ILnmjkg8RtQB4EcA35Y5FbkRkB3AawJ8DgBAiKYSIyRuV7EwAyonIBKACQEjmeIpOKYk63wJd3SamexFRO4DHAVyUNxJZ/RGA3wSQlTsQBdgNIAzgL9ZKQd8kokq5g5KLEGIcwB8AGAUwAWBOCPFDeaMqPqUkapYHEVUB+FsAvy6EmJc7HjkQ0UsApoUQfrljUQgTgE4A3xBCPA5gCYBuz3SIyIHVd9+7ATgBVBLR5+WNqviUkqh5ge4DiMiM1ST9uhDiu3LHI6OTAD5DRCNYLYk9S0R/KW9IshoDMCaEyL3D+g5WE7defQLAbSFEWAiRAvBdAE/LHFPRKSVR8wLdexARYbUGeU0I8YdyxyMnIcTXhBAtQoh2rP538Y4QQnNPTIUSQkwCuENEB9d+6TkAV2UMSW6jAE4QUcXa981z0ODhakE7E6XGC3QfchLAFwBcIaLLa7/2b9d2VzL2ZQCvrz3U3ALwSzLHIxshxEUi+g6AXqzelroEDbaTcws5Y4wpnFJKH4wxxjbAiZoxxhSOEzVjjCkcJ2rGGFM4TtSMMaZwnKgZY0zhOFEzxpjC/X+fSXP+x2JULwAAAABJRU5ErkJggg==\n",
-            "text/plain": [
-              "<Figure size 432x288 with 1 Axes>"
-            ]
-          },
-          "metadata": {
-            "needs_background": "light"
-          }
-        }
       ]
     },
     {
@@ -6037,34 +6014,34 @@
     },
     {
       "cell_type": "code",
+      "execution_count": 104,
       "metadata": {
         "colab": {
           "base_uri": "https://localhost:8080/",
           "height": 262
         },
         "id": "l4_51Vn4A9xh",
-        "outputId": "16e9cb06-0eba-44ee-8529-547bef8b73b7"
+        "outputId": "f554a918-8f2f-49a4-8430-a9d5dd79ecda"
       },
-      "source": [
-        "df = pd.DataFrame(np.random.randint(10, size=(10,4)), columns=list(\"ABCD\"))\n",
-        "\n",
-        "df.A.plot.bar()\n",
-        "plt.show()\n"
-      ],
-      "execution_count": 450,
       "outputs": [
         {
-          "output_type": "display_data",
           "data": {
-            "image/png": "iVBORw0KGgoAAAANSUhEUgAAAWoAAAD1CAYAAAB5n7/BAAAABHNCSVQICAgIfAhkiAAAAAlwSFlzAAALEgAACxIB0t1+/AAAADh0RVh0U29mdHdhcmUAbWF0cGxvdGxpYiB2ZXJzaW9uMy4yLjIsIGh0dHA6Ly9tYXRwbG90bGliLm9yZy+WH4yJAAAMQElEQVR4nO3dbYxlhV3H8e+fXagstLTJTggPpYPRVqumLU6gFrW11Ipd0samL6BprU1wXyhCjVFXa8IrzZo0al8Yk00piSktCZRGdA2l2qKpGsosrDwtfaJbHovTqGChkQI/X9y7dZjMMhfnnjN/4ftJNnPn3Dvn/PfOvd975sy9cysJkqS+jtnqASRJz81QS1JzhlqSmjPUktScoZak5gy1JDW3fYiV7ty5M4uLi0OsWpJekA4cOPDtJAvrnTdIqBcXF1leXh5i1ZL0glRV3zzaeR76kKTmDLUkNWeoJak5Qy1JzRlqSWrOUEtSc4Zakpoz1JLU3CAveJGkF5LFPfs3vY7De3f9n7/WPWpJas5QS1JzhlqSmjPUktScoZak5gy1JDVnqCWpOUMtSc0ZaklqzlBLUnOGWpKaM9SS1JyhlqTmDLUkNWeoJak5Qy1JzRlqSWrOUEtSc4ZakpqbKdRV9ZtVdVdV3VlVn6qqHxh6MEnSxIahrqrTgEuBpSQ/DmwDLhx6MEnSxKyHPrYDx1fVdmAH8NBwI0mSVtsw1EkeBD4C3Ac8DDya5Ma1l6uq3VW1XFXLKysr859Ukl6kZjn08QrgXcCZwKnACVX1vrWXS7IvyVKSpYWFhflPKkkvUrMc+ngb8I0kK0m+B1wHvGnYsSRJR8wS6vuAN1bVjqoq4Dzg0LBjSZKOmOUY9c3AtcCtwB3Tr9k38FySpKnts1woyeXA5QPPIklah69MlKTmDLUkNWeoJak5Qy1JzRlqSWrOUEtSc4Zakpoz1JLUnKGWpOYMtSQ1Z6glqTlDLUnNGWpJas5QS1JzhlqSmjPUktScoZak5mZ6hxdJ41rcs3/T6zi8d9ccJlEH7lFLUnOGWpKaM9SS1JyhlqTmDLUkNWeoJak5Qy1JzRlqSWrOUEtSc4Zakpoz1JLUnKGWpOYMtSQ1Z6glqTlDLUnNGWpJas5QS1JzhlqSmjPUktTcTKGuqpdX1bVVdU9VHaqqnxp6MEnSxKxvbvtR4IYk76mq44AdA84kSVplw1BX1UnAzwK/ApDkSeDJYceSJB0xyx71mcAKcGVVvQ44AFyW5PHVF6qq3cBugDPOOGPec75gLe7Zv+l1HN67aw6TCPx+qKdZjlFvB84C/iLJG4DHgT1rL5RkX5KlJEsLCwtzHlOSXrxmCfUDwANJbp5+fi2TcEuSRrBhqJN8C7i/ql4zXXQecPegU0mSvm/WZ338BnDV9Bkf9wIfHG4kSdJqM4U6yUFgaeBZJEnr8JWJktScoZak5gy1JDVnqCWpOUMtSc0ZaklqzlBLUnOGWpKaM9SS1JyhlqTmDLUkNWeoJak5Qy1JzRlqSWrOUEtSc4Zakpoz1JLU3KxvxfWCs7hn/6bXcXjvrjlMsvW8LqTe3KOWpOYMtSQ1Z6glqTlDLUnNGWpJas5QS1JzhlqSmjPUktScoZak5gy1JDVnqCWpOUMtSc0ZaklqzlBLUnOGWpKaM9SS1JyhlqTmDLUkNWeoJam5mUNdVduq6raq+pshB5IkPdvz2aO+DDg01CCSpPXNFOqqOh3YBXxs2HEkSWvNukf9Z8DvAM8c7QJVtbuqlqtqeWVlZS7DSZJmCHVVXQD8W5IDz3W5JPuSLCVZWlhYmNuAkvRiN8se9bnAO6vqMHA18Naq+sSgU0mSvm/DUCf5vSSnJ1kELgQ+n+R9g08mSQJ8HrUktbf9+Vw4yU3ATYNMIklal3vUktScoZak5gy1JDVnqCWpOUMtSc0ZaklqzlBLUnOGWpKaM9SS1JyhlqTmDLUkNWeoJak5Qy1JzRlqSWrOUEtSc4Zakpoz1JLU3PN6hxdpSIt79m96HYf37prDJOrE24V71JLUnqGWpOYMtSQ1Z6glqTlDLUnNGWpJas5QS1JzhlqSmjPUktScoZak5gy1JDVnqCWpOUMtSc0ZaklqzlBLUnOGWpKaM9SS1JyhlqTmDLUkNbdhqKvqlVX1haq6u6ruqqrLxhhMkjQxy5vbPgX8VpJbq+qlwIGq+lySuweeTZLEDHvUSR5Ocuv09H8Bh4DThh5MkjTxvI5RV9Ui8Abg5nXO211Vy1W1vLKyMp/pJEmzh7qqTgQ+DXwoyWNrz0+yL8lSkqWFhYV5zihJL2ozhbqqjmUS6auSXDfsSJKk1WZ51kcBVwCHkvzJ8CNJklabZY/6XOD9wFur6uD03zsGnkuSNLXh0/OSfBGoEWaRJK3DVyZKUnOGWpKaM9SS1JyhlqTmDLUkNWeoJak5Qy1JzRlqSWrOUEtSc4Zakpoz1JLUnKGWpOYMtSQ1Z6glqTlDLUnNGWpJas5QS1JzG77DyxAW9+zf9DoO7901h0kkHY330z7co5ak5gy1JDVnqCWpOUMtSc0ZaklqzlBLUnOGWpKaM9SS1JyhlqTmDLUkNWeoJak5Qy1JzRlqSWrOUEtSc4Zakpoz1JLUnKGWpOYMtSQ1Z6glqbmZQl1V51fVl6vqa1W1Z+ihJEn/a8NQV9U24M+BXwReC1xUVa8dejBJ0sQse9RnA19Lcm+SJ4GrgXcNO5Yk6YhK8twXqHoPcH6Si6efvx84J8klay63G9g9/fQ1wJc3MddO4Nub+Pp56TBHhxmgxxwdZoAec3SYAXrM0WEG2Pwcr0qysN4Z2zex0mdJsg/YN491VdVykqV5rOv/+xwdZugyR4cZuszRYYYuc3SYYeg5Zjn08SDwylWfnz5dJkkawSyhvgX44ao6s6qOAy4Erh92LEnSERse+kjyVFVdAnwW2AZ8PMldA881l0Moc9Bhjg4zQI85OswAPeboMAP0mKPDDDDgHBv+MlGStLV8ZaIkNWeoJak5Qy1Jzc3tedSbUVU/wuTVjqdNFz0IXJ/k0NZNtTWm18VpwM1JvrNq+flJbhhphrOBJLll+ucCzgfuSfK3Y2z/Oeb6yyS/vMUz/DSTV+vemeTGkbZ5DnAoyWNVdTywBzgLuBv4oySPjjDDpcBnktw/9LY2mOPIM88eSvJ3VfVe4E3AIWBfku+NNMcPAu9m8tTlp4GvAJ9M8tgg29vqXyZW1e8CFzF5afoD08WnM/lmXJ1k71bNdkRVfTDJlSNs51Lg15nc6F4PXJbkr6bn3ZrkrBFmuJzJ33XZDnwOOAf4AvDzwGeT/OHQM0znWPsU0AJ+Dvg8QJJ3jjTHl5KcPT39q0y+P58B3g789Ri3z6q6C3jd9BlY+4AngGuB86bL3z3CDI8CjwNfBz4FXJNkZejtrjPHVUxumzuA/wROBK5jcl1Ukg+MMMOlwAXAPwLvAG6bzvJLwK8luWnuG02ypf+YPBIdu87y44CvbvV801nuG2k7dwAnTk8vAstMYg1w24gzbGNyR3gMeNl0+fHA7SNe57cCnwDeArx5+vHh6ek3jzjHbatO3wIsTE+fANwx0gyHVl8va847ONb1wORQ6duBK4AV4AbgA8BLR/x+3D79uB14BNg2/bzGun0euY9MT+8AbpqePmOo+2mHQx/PAKcC31yz/JTpeaOoqtuPdhZw8khjHJPp4Y4kh6vqLcC1VfWq6RxjeCrJ08ATVfX1TH+US/Ldqhrt+wEsAZcBHwZ+O8nBqvpukn8YcQaAY6rqFUwiVZnuRSZ5vKqeGmmGO1f9VPevVbWUZLmqXg2M8qM+k0NhzwA3AjdW1bFMfvK6CPgIsO7fqBjAMdPDHycwieRJwL8DLwGOHWkGmDxQPD3d7okASe6bXi+DbGyrfQj4+6r6KnDk+NcZwA8Blxz1q+bvZOAXgP9Ys7yAfx5phkeq6vVJDgIk+U5VXQB8HPiJkWZ4sqp2JHkC+MkjC6vqJEZ84JxG4U+r6prpx0fYmtvrScABJreDVNUpSR6uqhMZ78HzYuCjVfUHTP7oz79U1f1M7i8XjzTDs/6vmRwLvh64vqp2jDQDTPbm72HyU9+HgWuq6l7gjUwOn47hY8AtVXUz8DPAHwNU1QKTB4252/Jj1ABVdQyTX9Cs/mXiLdM9u7FmuAK4MskX1znvk0neO8IMpzPZo/3WOuedm+SfRpjhJUn+e53lO4FTktwx9AzrqapdwLlJfn8rtr/WNE4nJ/nGiNt8GXAmkwesB5I8MuK2X53kK2Nt77lU1akASR6qqpcDb2NyePJLI87wY8CPMvml8j2Db69DqCVJR+fzqCWpOUMtSc0ZaklqzlBLUnOGWpKa+x+T7oMSQzrZIgAAAABJRU5ErkJggg==\n",
+            "image/png": "iVBORw0KGgoAAAANSUhEUgAAAWoAAAD1CAYAAAB5n7/BAAAABHNCSVQICAgIfAhkiAAAAAlwSFlzAAALEgAACxIB0t1+/AAAADh0RVh0U29mdHdhcmUAbWF0cGxvdGxpYiB2ZXJzaW9uMy4yLjIsIGh0dHA6Ly9tYXRwbG90bGliLm9yZy+WH4yJAAAMQElEQVR4nO3dbYxlhV3H8e+fXagstLTJTggPpYPRVqumLU6gFrW11Ipd0samL6BprU1wXyhCjVFXa8IrzZo0al8Yk00piSktCZRGdA2l2qKpGsosrDwtfaJbHovTqGChkQI/X9y7dZjMMhfnnjN/4ftJNnPn3Dvn/PfOvd975sy9cysJkqS+jtnqASRJz81QS1JzhlqSmjPUktScoZak5gy1JDW3fYiV7ty5M4uLi0OsWpJekA4cOPDtJAvrnTdIqBcXF1leXh5i1ZL0glRV3zzaeR76kKTmDLUkNWeoJak5Qy1JzRlqSWrOUEtSc4Zakpoz1JLU3CAveJGkF5LFPfs3vY7De3f9n7/WPWpJas5QS1JzhlqSmjPUktScoZak5gy1JDVnqCWpOUMtSc0ZaklqzlBLUnOGWpKaM9SS1JyhlqTmDLUkNWeoJak5Qy1JzRlqSWrOUEtSc4ZakpqbKdRV9ZtVdVdV3VlVn6qqHxh6MEnSxIahrqrTgEuBpSQ/DmwDLhx6MEnSxKyHPrYDx1fVdmAH8NBwI0mSVtsw1EkeBD4C3Ac8DDya5Ma1l6uq3VW1XFXLKysr859Ukl6kZjn08QrgXcCZwKnACVX1vrWXS7IvyVKSpYWFhflPKkkvUrMc+ngb8I0kK0m+B1wHvGnYsSRJR8wS6vuAN1bVjqoq4Dzg0LBjSZKOmOUY9c3AtcCtwB3Tr9k38FySpKnts1woyeXA5QPPIklah69MlKTmDLUkNWeoJak5Qy1JzRlqSWrOUEtSc4Zakpoz1JLUnKGWpOYMtSQ1Z6glqTlDLUnNGWpJas5QS1JzhlqSmjPUktScoZak5mZ6hxdJ41rcs3/T6zi8d9ccJlEH7lFLUnOGWpKaM9SS1JyhlqTmDLUkNWeoJak5Qy1JzRlqSWrOUEtSc4Zakpoz1JLUnKGWpOYMtSQ1Z6glqTlDLUnNGWpJas5QS1JzhlqSmjPUktTcTKGuqpdX1bVVdU9VHaqqnxp6MEnSxKxvbvtR4IYk76mq44AdA84kSVplw1BX1UnAzwK/ApDkSeDJYceSJB0xyx71mcAKcGVVvQ44AFyW5PHVF6qq3cBugDPOOGPec75gLe7Zv+l1HN67aw6TCPx+qKdZjlFvB84C/iLJG4DHgT1rL5RkX5KlJEsLCwtzHlOSXrxmCfUDwANJbp5+fi2TcEuSRrBhqJN8C7i/ql4zXXQecPegU0mSvm/WZ338BnDV9Bkf9wIfHG4kSdJqM4U6yUFgaeBZJEnr8JWJktScoZak5gy1JDVnqCWpOUMtSc0ZaklqzlBLUnOGWpKaM9SS1JyhlqTmDLUkNWeoJak5Qy1JzRlqSWrOUEtSc4Zakpoz1JLU3KxvxfWCs7hn/6bXcXjvrjlMsvW8LqTe3KOWpOYMtSQ1Z6glqTlDLUnNGWpJas5QS1JzhlqSmjPUktScoZak5gy1JDVnqCWpOUMtSc0ZaklqzlBLUnOGWpKaM9SS1JyhlqTmDLUkNWeoJam5mUNdVduq6raq+pshB5IkPdvz2aO+DDg01CCSpPXNFOqqOh3YBXxs2HEkSWvNukf9Z8DvAM8c7QJVtbuqlqtqeWVlZS7DSZJmCHVVXQD8W5IDz3W5JPuSLCVZWlhYmNuAkvRiN8se9bnAO6vqMHA18Naq+sSgU0mSvm/DUCf5vSSnJ1kELgQ+n+R9g08mSQJ8HrUktbf9+Vw4yU3ATYNMIklal3vUktScoZak5gy1JDVnqCWpOUMtSc0ZaklqzlBLUnOGWpKaM9SS1JyhlqTmDLUkNWeoJak5Qy1JzRlqSWrOUEtSc4Zakpoz1JLU3PN6hxdpSIt79m96HYf37prDJOrE24V71JLUnqGWpOYMtSQ1Z6glqTlDLUnNGWpJas5QS1JzhlqSmjPUktScoZak5gy1JDVnqCWpOUMtSc0ZaklqzlBLUnOGWpKaM9SS1JyhlqTmDLUkNbdhqKvqlVX1haq6u6ruqqrLxhhMkjQxy5vbPgX8VpJbq+qlwIGq+lySuweeTZLEDHvUSR5Ocuv09H8Bh4DThh5MkjTxvI5RV9Ui8Abg5nXO211Vy1W1vLKyMp/pJEmzh7qqTgQ+DXwoyWNrz0+yL8lSkqWFhYV5zihJL2ozhbqqjmUS6auSXDfsSJKk1WZ51kcBVwCHkvzJ8CNJklabZY/6XOD9wFur6uD03zsGnkuSNLXh0/OSfBGoEWaRJK3DVyZKUnOGWpKaM9SS1JyhlqTmDLUkNWeoJak5Qy1JzRlqSWrOUEtSc4Zakpoz1JLUnKGWpOYMtSQ1Z6glqTlDLUnNGWpJas5QS1JzG77DyxAW9+zf9DoO7901h0kkHY330z7co5ak5gy1JDVnqCWpOUMtSc0ZaklqzlBLUnOGWpKaM9SS1JyhlqTmDLUkNWeoJak5Qy1JzRlqSWrOUEtSc4Zakpoz1JLUnKGWpOYMtSQ1Z6glqbmZQl1V51fVl6vqa1W1Z+ihJEn/a8NQV9U24M+BXwReC1xUVa8dejBJ0sQse9RnA19Lcm+SJ4GrgXcNO5Yk6YhK8twXqHoPcH6Si6efvx84J8klay63G9g9/fQ1wJc3MddO4Nub+Pp56TBHhxmgxxwdZoAec3SYAXrM0WEG2Pwcr0qysN4Z2zex0mdJsg/YN491VdVykqV5rOv/+xwdZugyR4cZuszRYYYuc3SYYeg5Zjn08SDwylWfnz5dJkkawSyhvgX44ao6s6qOAy4Erh92LEnSERse+kjyVFVdAnwW2AZ8PMldA881l0Moc9Bhjg4zQI85OswAPeboMAP0mKPDDDDgHBv+MlGStLV8ZaIkNWeoJak5Qy1Jzc3tedSbUVU/wuTVjqdNFz0IXJ/k0NZNtTWm18VpwM1JvrNq+flJbhhphrOBJLll+ucCzgfuSfK3Y2z/Oeb6yyS/vMUz/DSTV+vemeTGkbZ5DnAoyWNVdTywBzgLuBv4oySPjjDDpcBnktw/9LY2mOPIM88eSvJ3VfVe4E3AIWBfku+NNMcPAu9m8tTlp4GvAJ9M8tgg29vqXyZW1e8CFzF5afoD08WnM/lmXJ1k71bNdkRVfTDJlSNs51Lg15nc6F4PXJbkr6bn3ZrkrBFmuJzJ33XZDnwOOAf4AvDzwGeT/OHQM0znWPsU0AJ+Dvg8QJJ3jjTHl5KcPT39q0y+P58B3g789Ri3z6q6C3jd9BlY+4AngGuB86bL3z3CDI8CjwNfBz4FXJNkZejtrjPHVUxumzuA/wROBK5jcl1Ukg+MMMOlwAXAPwLvAG6bzvJLwK8luWnuG02ypf+YPBIdu87y44CvbvV801nuG2k7dwAnTk8vAstMYg1w24gzbGNyR3gMeNl0+fHA7SNe57cCnwDeArx5+vHh6ek3jzjHbatO3wIsTE+fANwx0gyHVl8va847ONb1wORQ6duBK4AV4AbgA8BLR/x+3D79uB14BNg2/bzGun0euY9MT+8AbpqePmOo+2mHQx/PAKcC31yz/JTpeaOoqtuPdhZw8khjHJPp4Y4kh6vqLcC1VfWq6RxjeCrJ08ATVfX1TH+US/Ldqhrt+wEsAZcBHwZ+O8nBqvpukn8YcQaAY6rqFUwiVZnuRSZ5vKqeGmmGO1f9VPevVbWUZLmqXg2M8qM+k0NhzwA3AjdW1bFMfvK6CPgIsO7fqBjAMdPDHycwieRJwL8DLwGOHWkGmDxQPD3d7okASe6bXi+DbGyrfQj4+6r6KnDk+NcZwA8Blxz1q+bvZOAXgP9Ys7yAfx5phkeq6vVJDgIk+U5VXQB8HPiJkWZ4sqp2JHkC+MkjC6vqJEZ84JxG4U+r6prpx0fYmtvrScABJreDVNUpSR6uqhMZ78HzYuCjVfUHTP7oz79U1f1M7i8XjzTDs/6vmRwLvh64vqp2jDQDTPbm72HyU9+HgWuq6l7gjUwOn47hY8AtVXUz8DPAHwNU1QKTB4252/Jj1ABVdQyTX9Cs/mXiLdM9u7FmuAK4MskX1znvk0neO8IMpzPZo/3WOuedm+SfRpjhJUn+e53lO4FTktwx9AzrqapdwLlJfn8rtr/WNE4nJ/nGiNt8GXAmkwesB5I8MuK2X53kK2Nt77lU1akASR6qqpcDb2NyePJLI87wY8CPMvml8j2Db69DqCVJR+fzqCWpOUMtSc0ZaklqzlBLUnOGWpKa+x+T7oMSQzrZIgAAAABJRU5ErkJggg==",
             "text/plain": [
               "<Figure size 432x288 with 1 Axes>"
             ]
           },
           "metadata": {
             "needs_background": "light"
-          }
+          },
+          "output_type": "display_data"
         }
+      ],
+      "source": [
+        "df = pd.DataFrame(np.random.randint(10, size=(10,4)), columns=list(\"ABCD\"))\n",
+        "\n",
+        "df.A.plot.bar()\n",
+        "plt.show()\n"
       ]
     },
     {
@@ -6078,34 +6055,34 @@
     },
     {
       "cell_type": "code",
+      "execution_count": 105,
       "metadata": {
         "colab": {
           "base_uri": "https://localhost:8080/",
           "height": 265
         },
         "id": "RZ4XJLJ0A9xi",
-        "outputId": "2ed571ae-cf49-48bc-e558-64092bb3c3fb"
+        "outputId": "f2063ec0-d41a-4ffa-e90c-9830abd7614f"
       },
-      "source": [
-        "df = pd.DataFrame(np.random.randint(10, size=(10,4)), columns=list(\"ABCD\"))\n",
-        "\n",
-        "df.A.plot.barh()\n",
-        "plt.show()\n"
-      ],
-      "execution_count": 451,
       "outputs": [
         {
-          "output_type": "display_data",
           "data": {
-            "image/png": "iVBORw0KGgoAAAANSUhEUgAAAWoAAAD4CAYAAADFAawfAAAABHNCSVQICAgIfAhkiAAAAAlwSFlzAAALEgAACxIB0t1+/AAAADh0RVh0U29mdHdhcmUAbWF0cGxvdGxpYiB2ZXJzaW9uMy4yLjIsIGh0dHA6Ly9tYXRwbG90bGliLm9yZy+WH4yJAAANvUlEQVR4nO3df6xfdX3H8efLFoVWVgxUU1u2SzJCRiACu2EoSjYqBoSgWfYHJJjMLGN/OAduicH9Q/zPJca4PxaTBlAWsQQLJAsqg0QyRqLV21JDoWAUC7SiLXGUX8uA+t4f33PL7eWWnnK/534/tM9HcsO993s495WG++LTzznn+05VIUlq17smHUCS9NYsaklqnEUtSY2zqCWpcRa1JDVu+RAnPeWUU2pqamqIU0vSUWnLli3PVdXqhV4bpKinpqaYmZkZ4tSSdFRK8tShXnPrQ5IaZ1FLUuMsaklqnEUtSY0b5GLiI7v3MXXD94Y4tSQ1aedXLh/s3K6oJalxvYo6yXVJtid5NMn1Q4eSJL3hsEWd5Czgb4HzgQ8BVyT546GDSZJG+qyo/wTYXFWvVNXrwH8BfzlsLEnSrD5FvR34WJKTk6wAPgmcOv+gJNcmmUkys/+VfePOKUnHrMPe9VFVO5L8C3Af8DKwDdi/wHEbgA0A71lzumNjJGlMel1MrKqbq+pPq+oi4H+Anw8bS5I0q9d91EneX1V7kvwho/3pC4aNJUma1feBlzuTnAy8Bnyuqp4fMJMkaY5eRV1VHxs6iCRpYYM8Qn722lXMDPg4pSQdS3yEXJIaZ1FLUuMsaklqnEUtSY2zqCWpcRa1JDXOopakxlnUktQ4i1qSGmdRS1LjLGpJapxFLUmN6zuF/AvdBPLtSTYmOX7oYJKkkT5TyNcC/wBMV9VZwDLgqqGDSZJG+m59LAdOSLIcWAH8erhIkqS5DlvUVbUb+CrwNPAssK+q7pt/3Nwp5Hv37h1/Ukk6RvXZ+ngf8CngNOCDwMok18w/rqo2VNV0VU2vXr16/Ekl6RjVZ+vj48CvqmpvVb0G3AV8ZNhYkqRZfYr6aeCCJCuSBFgP7Bg2liRpVp896s3AJmAr8Ej372wYOJckqdN3CvmNwI0DZ5EkLcAnEyWpcRa1JDXOopakxlnUktQ4i1qSGmdRS1LjLGpJapxFLUmNs6glqXEWtSQ1rtcj5Efqkd37mLrhe0Oc+qi38yuXTzqCpMa4opakxlnUktS4PhNezkiybc7HC0muX4pwkqQee9RV9QRwDkCSZcBu4O6Bc0mSOke69bEe+GVVPTVEGEnSmx1pUV8FbFzohblTyPe/sm/xySRJwBEUdZJ3A1cC313o9blTyJetWDWufJJ0zDuSFfVlwNaq+u1QYSRJb3YkRX01h9j2kCQNp1dRJ1kJXALcNWwcSdJ8faeQvwyc3PekZ69dxYyPQkvSWPhkoiQ1zqKWpMZZ1JLUOItakhpnUUtS4yxqSWqcRS1JjbOoJalxFrUkNc6ilqTGHXNTyJ3yLemdxhW1JDWu77vnnZRkU5LHk+xI8uGhg0mSRvpuffwrcG9V/VU36WXFgJkkSXMctqiTrAIuAv4aoKpeBV4dNpYkaVafrY/TgL3AN5M8nOSmbpDAQRxuK0nD6FPUy4HzgG9U1bnAy8AN8w9yuK0kDaNPUe8CdlXV5u7rTYyKW5K0BA5b1FX1G+CZJGd031oPPDZoKknSAX3v+vg8cFt3x8eTwGeHiyRJmqvvcNttwPTAWSRJCxjkEXKnkEvS+PgIuSQ1zqKWpMZZ1JLUOItakhpnUUtS4yxqSWqcRS1JjbOoJalxFrUkNc6ilqTGHXNTyCVpCDsHfNsMV9SS1LheK+okO4EXgf3A61XlO+lJ0hI5kq2Pv6iq5wZLIklakFsfktS4vkVdwH1JtiS5dqEDnEIuScPou/Xx0araneT9wP1JHq+qB+ceUFUbgA0A71lzeo05pyQds3qtqKtqd/fPPcDdwPlDhpIkveGwRZ1kZZITZz8HPgFsHzqYJGmkz9bHB4C7k8we/52qunfQVJKkAw5b1FX1JPChJcgiSVqAU8glqXHeRy1JjbOoJalxFrUkNc6ilqTGWdSS1DiLWpIaZ1FLUuMsaklqnEUtSY2zqCWpcU4hl6QxcAq5JB3Dehd1kmVJHk5yz5CBJEkHO5IV9XXAjqGCSJIW1quok6wDLgduGjaOJGm+vivqrwNfBH5/qAOcQi5Jw+gzM/EKYE9VbXmr46pqQ1VNV9X0shWrxhZQko51fVbUFwJXJtkJ3A5cnOTbg6aSJB1w2KKuqi9V1bqqmgKuAn5YVdcMnkySBHgftSQ1L1U19pNOT0/XzMzM2M8rSUerJFuqanqh11xRS1LjLGpJapxFLUmNs6glqXEWtSQ1zqKWpMZZ1JLUOItakhpnUUtS4yxqSWqcw20laQwcbitJxzCLWpIa12fCy/FJfpLkZ0keTfLlpQgmSRrps0f9f8DFVfVSkuOAh5L8oKp+PHA2SRI9irpGb1j9Uvflcd3H+N/EWpK0oF571EmWJdkG7AHur6rNCxzjFHJJGkCvoq6q/VV1DrAOOD/JWQsc4xRySRrAEd31UVXPAw8Alw4TR5I0X5+7PlYnOan7/ATgEuDxoYNJkkb63PWxBrg1yTJGxX5HVd0zbCxJ0iynkEtSA5xCLknvYBa1JDXOopakxlnUktQ4i1qSGmdRS1LjLGpJapxFLUmNs6glqXEWtSQ1zinkkg4YcpK23j5X1JLUuD5vc3pqkgeSPNYNt71uKYJJkkb6bH28DvxTVW1NciKwJcn9VfXYwNkkSfRYUVfVs1W1tfv8RWAHsHboYJKkkSPao04yBZwLONxWkpZI76JO8l7gTuD6qnph/usOt5WkYfQq6iTHMSrp26rqrmEjSZLm6nPXR4CbgR1V9bXhI0mS5uqzor4Q+AxwcZJt3ccnB84lSeoc9va8qnoIyBJkkSQtYJBHyM9eu4oZH0WVpLHwEXJJapxFLUmNs6glqXEWtSQ1zqKWpMZZ1JLUOItakhpnUUtS4yxqSWqcRS1JjXMKuaQDnELeJlfUktS4Pu9HfUuSPUm2L0UgSdLB+qyovwVcOnAOSdIh9JlC/iDwuyXIIklawNj2qJ1CLknDGFtRO4VckobhXR+S1DiLWpIa1+f2vI3Aj4AzkuxK8jfDx5IkzeozhfzqpQgiSVqYU8glqXHuUUtS4yxqSWqcRS1JjbOoJalxFrUkNc6ilqTGWdSS1DiLWpIaZ1FLUuMcbqujisNZdTRyRS1JjbOoJalxvYo6yaVJnkjyiyQ3DB1KkvSGPu9HvQz4N+Ay4Ezg6iRnDh1MkjTSZ0V9PvCLqnqyql4Fbgc+NWwsSdKsPkW9Fnhmzte7uu8dxCnkkjQMp5BLUuP6FPVu4NQ5X6/rvidJWgJ9ivqnwOlJTkvybuAq4D+GjSVJmtVnuO3rSf4e+E9gGXBLVT06eDJJEgCpqrGfdHp6umZmZsZ+Xkk6WiXZUlXTC73mk4mS1DiLWpIaZ1FLUuMsaklqnEUtSY0b5K6PJC8CT4z9xONxCvDcpEO8BfMtjvkWx3xv32Kz/VFVrV7ohUEmvABPHOo2k0lLMtNqNjDfYplvccz39g2Zza0PSWqcRS1JjRuqqDcMdN5xaDkbmG+xzLc45nv7Bss2yMVESdL4uPUhSY2zqCWpcWMt6panlSe5JcmeJNsnnWUhSU5N8kCSx5I8muS6SWeaK8nxSX6S5Gddvi9POtN8SZYleTjJPZPOMl+SnUkeSbItSXNvLZnkpCSbkjyeZEeSD08606wkZ3R/brMfLyS5ftK55kryhe73YnuSjUmOH+v5x7VH3U0r/zlwCaO5ij8Frq6qx8byAxYpyUXAS8C/V9VZk84zX5I1wJqq2prkRGAL8OmG/vwCrKyql5IcBzwEXFdVP55wtAOS/CMwDfxBVV0x6TxzJdkJTFdVkw9rJLkV+O+quqkbELKiqp6fdK75up7ZDfxZVT016TwASdYy+n04s6r+N8kdwPer6lvj+hnjXFE3Pa28qh4EfjfpHIdSVc9W1dbu8xeBHSwwRHhSauSl7svjuo9mrkQnWQdcDtw06SzvNElWARcBNwNU1astlnRnPfDLVkp6juXACUmWAyuAX4/z5OMs6l7TynV4SaaAc4HNk01ysG5rYRuwB7i/qlrK93Xgi8DvJx3kEAq4L8mWJNdOOsw8pwF7gW92W0c3JVk56VCHcBWwcdIh5qqq3cBXgaeBZ4F9VXXfOH+GFxMbk+S9wJ3A9VX1wqTzzFVV+6vqHEYDjs9P0sQWUpIrgD1VtWXSWd7CR6vqPOAy4HPdVlwrlgPnAd+oqnOBl4GmrjEBdFsyVwLfnXSWuZK8j9HuwWnAB4GVSa4Z588YZ1E7rXyRur3fO4HbququSec5lO6vxQ8Al046S+dC4MpuH/h24OIk355spIN1qy6qag9wN6OtwlbsAnbN+RvSJkbF3ZrLgK1V9dtJB5nn48CvqmpvVb0G3AV8ZJw/YJxF7bTyRegu1t0M7Kiqr006z3xJVic5qfv8BEYXjR+fbKqRqvpSVa2rqilG/939sKrGuqJZjCQruwvEdFsKnwCaufuoqn4DPJPkjO5b64EmLmLPczWNbXt0ngYuSLKi+z1ez+ga09iM7d3zWp9WnmQj8OfAKUl2ATdW1c2TTXWQC4HPAI90+8AA/1xV359gprnWALd2V93fBdxRVc3dBteoDwB3j36HWQ58p6runWykN/k8cFu3yHoS+OyE8xyk+x/cJcDfTTrLfFW1OckmYCvwOvAwY36c3EfIJalxXkyUpMZZ1JLUOItakhpnUUtS4yxqSWqcRS1JjbOoJalx/w/HJfD6NE8e+AAAAABJRU5ErkJggg==\n",
+            "image/png": "iVBORw0KGgoAAAANSUhEUgAAAWoAAAD4CAYAAADFAawfAAAABHNCSVQICAgIfAhkiAAAAAlwSFlzAAALEgAACxIB0t1+/AAAADh0RVh0U29mdHdhcmUAbWF0cGxvdGxpYiB2ZXJzaW9uMy4yLjIsIGh0dHA6Ly9tYXRwbG90bGliLm9yZy+WH4yJAAANvUlEQVR4nO3df6xfdX3H8efLFoVWVgxUU1u2SzJCRiACu2EoSjYqBoSgWfYHJJjMLGN/OAduicH9Q/zPJca4PxaTBlAWsQQLJAsqg0QyRqLV21JDoWAUC7SiLXGUX8uA+t4f33PL7eWWnnK/534/tM9HcsO993s495WG++LTzznn+05VIUlq17smHUCS9NYsaklqnEUtSY2zqCWpcRa1JDVu+RAnPeWUU2pqamqIU0vSUWnLli3PVdXqhV4bpKinpqaYmZkZ4tSSdFRK8tShXnPrQ5IaZ1FLUuMsaklqnEUtSY0b5GLiI7v3MXXD94Y4tSQ1aedXLh/s3K6oJalxvYo6yXVJtid5NMn1Q4eSJL3hsEWd5Czgb4HzgQ8BVyT546GDSZJG+qyo/wTYXFWvVNXrwH8BfzlsLEnSrD5FvR34WJKTk6wAPgmcOv+gJNcmmUkys/+VfePOKUnHrMPe9VFVO5L8C3Af8DKwDdi/wHEbgA0A71lzumNjJGlMel1MrKqbq+pPq+oi4H+Anw8bS5I0q9d91EneX1V7kvwho/3pC4aNJUma1feBlzuTnAy8Bnyuqp4fMJMkaY5eRV1VHxs6iCRpYYM8Qn722lXMDPg4pSQdS3yEXJIaZ1FLUuMsaklqnEUtSY2zqCWpcRa1JDXOopakxlnUktQ4i1qSGmdRS1LjLGpJapxFLUmN6zuF/AvdBPLtSTYmOX7oYJKkkT5TyNcC/wBMV9VZwDLgqqGDSZJG+m59LAdOSLIcWAH8erhIkqS5DlvUVbUb+CrwNPAssK+q7pt/3Nwp5Hv37h1/Ukk6RvXZ+ngf8CngNOCDwMok18w/rqo2VNV0VU2vXr16/Ekl6RjVZ+vj48CvqmpvVb0G3AV8ZNhYkqRZfYr6aeCCJCuSBFgP7Bg2liRpVp896s3AJmAr8Ej372wYOJckqdN3CvmNwI0DZ5EkLcAnEyWpcRa1JDXOopakxlnUktQ4i1qSGmdRS1LjLGpJapxFLUmNs6glqXEWtSQ1rtcj5Efqkd37mLrhe0Oc+qi38yuXTzqCpMa4opakxlnUktS4PhNezkiybc7HC0muX4pwkqQee9RV9QRwDkCSZcBu4O6Bc0mSOke69bEe+GVVPTVEGEnSmx1pUV8FbFzohblTyPe/sm/xySRJwBEUdZJ3A1cC313o9blTyJetWDWufJJ0zDuSFfVlwNaq+u1QYSRJb3YkRX01h9j2kCQNp1dRJ1kJXALcNWwcSdJ8faeQvwyc3PekZ69dxYyPQkvSWPhkoiQ1zqKWpMZZ1JLUOItakhpnUUtS4yxqSWqcRS1JjbOoJalxFrUkNc6ilqTGHXNTyJ3yLemdxhW1JDWu77vnnZRkU5LHk+xI8uGhg0mSRvpuffwrcG9V/VU36WXFgJkkSXMctqiTrAIuAv4aoKpeBV4dNpYkaVafrY/TgL3AN5M8nOSmbpDAQRxuK0nD6FPUy4HzgG9U1bnAy8AN8w9yuK0kDaNPUe8CdlXV5u7rTYyKW5K0BA5b1FX1G+CZJGd031oPPDZoKknSAX3v+vg8cFt3x8eTwGeHiyRJmqvvcNttwPTAWSRJCxjkEXKnkEvS+PgIuSQ1zqKWpMZZ1JLUOItakhpnUUtS4yxqSWqcRS1JjbOoJalxFrUkNc6ilqTGHXNTyCVpCDsHfNsMV9SS1LheK+okO4EXgf3A61XlO+lJ0hI5kq2Pv6iq5wZLIklakFsfktS4vkVdwH1JtiS5dqEDnEIuScPou/Xx0araneT9wP1JHq+qB+ceUFUbgA0A71lzeo05pyQds3qtqKtqd/fPPcDdwPlDhpIkveGwRZ1kZZITZz8HPgFsHzqYJGmkz9bHB4C7k8we/52qunfQVJKkAw5b1FX1JPChJcgiSVqAU8glqXHeRy1JjbOoJalxFrUkNc6ilqTGWdSS1DiLWpIaZ1FLUuMsaklqnEUtSY2zqCWpcU4hl6QxcAq5JB3Dehd1kmVJHk5yz5CBJEkHO5IV9XXAjqGCSJIW1quok6wDLgduGjaOJGm+vivqrwNfBH5/qAOcQi5Jw+gzM/EKYE9VbXmr46pqQ1VNV9X0shWrxhZQko51fVbUFwJXJtkJ3A5cnOTbg6aSJB1w2KKuqi9V1bqqmgKuAn5YVdcMnkySBHgftSQ1L1U19pNOT0/XzMzM2M8rSUerJFuqanqh11xRS1LjLGpJapxFLUmNs6glqXEWtSQ1zqKWpMZZ1JLUOItakhpnUUtS4yxqSWqcw20laQwcbitJxzCLWpIa12fCy/FJfpLkZ0keTfLlpQgmSRrps0f9f8DFVfVSkuOAh5L8oKp+PHA2SRI9irpGb1j9Uvflcd3H+N/EWpK0oF571EmWJdkG7AHur6rNCxzjFHJJGkCvoq6q/VV1DrAOOD/JWQsc4xRySRrAEd31UVXPAw8Alw4TR5I0X5+7PlYnOan7/ATgEuDxoYNJkkb63PWxBrg1yTJGxX5HVd0zbCxJ0iynkEtSA5xCLknvYBa1JDXOopakxlnUktQ4i1qSGmdRS1LjLGpJapxFLUmNs6glqXEWtSQ1zinkkg4YcpK23j5X1JLUuD5vc3pqkgeSPNYNt71uKYJJkkb6bH28DvxTVW1NciKwJcn9VfXYwNkkSfRYUVfVs1W1tfv8RWAHsHboYJKkkSPao04yBZwLONxWkpZI76JO8l7gTuD6qnph/usOt5WkYfQq6iTHMSrp26rqrmEjSZLm6nPXR4CbgR1V9bXhI0mS5uqzor4Q+AxwcZJt3ccnB84lSeoc9va8qnoIyBJkkSQtYJBHyM9eu4oZH0WVpLHwEXJJapxFLUmNs6glqXEWtSQ1zqKWpMZZ1JLUOItakhpnUUtS4yxqSWqcRS1JjXMKuaQDnELeJlfUktS4Pu9HfUuSPUm2L0UgSdLB+qyovwVcOnAOSdIh9JlC/iDwuyXIIklawNj2qJ1CLknDGFtRO4VckobhXR+S1DiLWpIa1+f2vI3Aj4AzkuxK8jfDx5IkzeozhfzqpQgiSVqYU8glqXHuUUtS4yxqSWqcRS1JjbOoJalxFrUkNc6ilqTGWdSS1DiLWpIaZ1FLUuMcbqujisNZdTRyRS1JjbOoJalxvYo6yaVJnkjyiyQ3DB1KkvSGPu9HvQz4N+Ay4Ezg6iRnDh1MkjTSZ0V9PvCLqnqyql4Fbgc+NWwsSdKsPkW9Fnhmzte7uu8dxCnkkjQMp5BLUuP6FPVu4NQ5X6/rvidJWgJ9ivqnwOlJTkvybuAq4D+GjSVJmtVnuO3rSf4e+E9gGXBLVT06eDJJEgCpqrGfdHp6umZmZsZ+Xkk6WiXZUlXTC73mk4mS1DiLWpIaZ1FLUuMsaklqnEUtSY0b5K6PJC8CT4z9xONxCvDcpEO8BfMtjvkWx3xv32Kz/VFVrV7ohUEmvABPHOo2k0lLMtNqNjDfYplvccz39g2Zza0PSWqcRS1JjRuqqDcMdN5xaDkbmG+xzLc45nv7Bss2yMVESdL4uPUhSY2zqCWpcWMt6panlSe5JcmeJNsnnWUhSU5N8kCSx5I8muS6SWeaK8nxSX6S5Gddvi9POtN8SZYleTjJPZPOMl+SnUkeSbItSXNvLZnkpCSbkjyeZEeSD08606wkZ3R/brMfLyS5ftK55kryhe73YnuSjUmOH+v5x7VH3U0r/zlwCaO5ij8Frq6qx8byAxYpyUXAS8C/V9VZk84zX5I1wJqq2prkRGAL8OmG/vwCrKyql5IcBzwEXFdVP55wtAOS/CMwDfxBVV0x6TxzJdkJTFdVkw9rJLkV+O+quqkbELKiqp6fdK75up7ZDfxZVT016TwASdYy+n04s6r+N8kdwPer6lvj+hnjXFE3Pa28qh4EfjfpHIdSVc9W1dbu8xeBHSwwRHhSauSl7svjuo9mrkQnWQdcDtw06SzvNElWARcBNwNU1astlnRnPfDLVkp6juXACUmWAyuAX4/z5OMs6l7TynV4SaaAc4HNk01ysG5rYRuwB7i/qlrK93Xgi8DvJx3kEAq4L8mWJNdOOsw8pwF7gW92W0c3JVk56VCHcBWwcdIh5qqq3cBXgaeBZ4F9VXXfOH+GFxMbk+S9wJ3A9VX1wqTzzFVV+6vqHEYDjs9P0sQWUpIrgD1VtWXSWd7CR6vqPOAy4HPdVlwrlgPnAd+oqnOBl4GmrjEBdFsyVwLfnXSWuZK8j9HuwWnAB4GVSa4Z588YZ1E7rXyRur3fO4HbququSec5lO6vxQ8Al046S+dC4MpuH/h24OIk355spIN1qy6qag9wN6OtwlbsAnbN+RvSJkbF3ZrLgK1V9dtJB5nn48CvqmpvVb0G3AV8ZJw/YJxF7bTyRegu1t0M7Kiqr006z3xJVic5qfv8BEYXjR+fbKqRqvpSVa2rqilG/939sKrGuqJZjCQruwvEdFsKnwCaufuoqn4DPJPkjO5b64EmLmLPczWNbXt0ngYuSLKi+z1ez+ga09iM7d3zWp9WnmQj8OfAKUl2ATdW1c2TTXWQC4HPAI90+8AA/1xV359gprnWALd2V93fBdxRVc3dBteoDwB3j36HWQ58p6runWykN/k8cFu3yHoS+OyE8xyk+x/cJcDfTTrLfFW1OckmYCvwOvAwY36c3EfIJalxXkyUpMZZ1JLUOItakhpnUUtS4yxqSWqcRS1JjbOoJalx/w/HJfD6NE8e+AAAAABJRU5ErkJggg==",
             "text/plain": [
               "<Figure size 432x288 with 1 Axes>"
             ]
           },
           "metadata": {
             "needs_background": "light"
-          }
+          },
+          "output_type": "display_data"
         }
+      ],
+      "source": [
+        "df = pd.DataFrame(np.random.randint(10, size=(10,4)), columns=list(\"ABCD\"))\n",
+        "\n",
+        "df.A.plot.barh()\n",
+        "plt.show()\n"
       ]
     },
     {
@@ -6119,34 +6096,34 @@
     },
     {
       "cell_type": "code",
+      "execution_count": 106,
       "metadata": {
         "colab": {
           "base_uri": "https://localhost:8080/",
           "height": 265
         },
         "id": "d51iAVlmA9xj",
-        "outputId": "f93bbf07-a7d2-482b-99e9-7bb0ed35b231"
+        "outputId": "8678fe31-a371-44a7-af6c-1a1fe63b8297"
       },
-      "source": [
-        "df = pd.DataFrame(np.random.randint(10, size=(10,4)), columns=list(\"ABCD\"))\n",
-        "\n",
-        "df.A.plot.box()\n",
-        "plt.show()"
-      ],
-      "execution_count": 452,
       "outputs": [
         {
-          "output_type": "display_data",
           "data": {
-            "image/png": "iVBORw0KGgoAAAANSUhEUgAAAWoAAAD4CAYAAADFAawfAAAABHNCSVQICAgIfAhkiAAAAAlwSFlzAAALEgAACxIB0t1+/AAAADh0RVh0U29mdHdhcmUAbWF0cGxvdGxpYiB2ZXJzaW9uMy4yLjIsIGh0dHA6Ly9tYXRwbG90bGliLm9yZy+WH4yJAAAKRklEQVR4nO3dX4yld13H8c/X3SW0ZVPUnhilbIerSoKB4oSoKJFWCFgDXnDRTTDBmMyNUTAmul413NXEGL0ymeAfothGS3thG5uSCDFNtGS2FG27QCJssfVPpxqhkEYK+Xoxs2WZnnWe6c4z8+vO65VMZnbPM+d8bvru2WeeM6e6OwCM6/sOewAA/z+hBhicUAMMTqgBBifUAIM7PsedXnfddb2ysjLHXQNckc6ePftsdy+W3TZLqFdWVrKxsTHHXQNckarqyUvd5tQHwOCEGmBwQg0wOKEGGJxQAwxuUqir6jeq6vGqeqyq7qyqV889DIAtu4a6ql6X5NeTrHb3m5IcS3Lb3MMA2DL11MfxJFdV1fEkVyf5t/kmAXCxXV/w0t1PV9XvJflqkueTPNjdD+48rqrWkqwlyalTp/Z7J7xEVR3YY/m97RymKac+vj/J+5O8IcmPJLmmqj6487juXu/u1e5eXSyWvgoS9lV37/njht++72V9HxymKac+fi7JV7p7s7tfSHJPkp+adxYAF0wJ9VeT/ERVXV1b/9a8Jcm5eWcBcMGuoe7uh5PcneSRJP+8/T3rM+8CYNuk357X3bcnuX3mLQAs4ZWJAIMTaoDBCTXA4IQaYHBCDTA4oQYYnFADDE6oAQYn1ACDE2qAwQk1wOCEGmBwQg0wOKEGGJxQAwxOqAEGJ9QAgxNqgMEJNcDgdg11Vd1YVY9e9PH1qvrIQYwDYMKb23b3F5O8JUmq6liSp5PcO/MuALbt9dTHLUn+pbufnGMMAC+111DfluTOZTdU1VpVbVTVxubm5uUvAyDJHkJdVa9K8r4kf73s9u5e7+7V7l5dLBb7tQ/gyNvLM+r3Jnmku/9zrjEAvNReQn06lzjtAcB8JoW6qq5J8q4k98w7B4Cddr08L0m6+5tJfnDmLQAs4ZWJAIMTaoDBTTr1AQfhzR99MF97/oXZH2flzP2z3v+1V53I529/96yPwdEi1Azja8+/kPN33HrYMy7b3P8j4Ohx6gNgcEINMDihBhicUAMMTqgBBifUAIMTaoDBCTXA4IQaYHBCDTA4oQYYnFADDE6oAQYn1ACDE2qAwQk1wOCmvgv5a6vq7qr6QlWdq6qfnHsYAFumvsPLHyZ5oLs/UFWvSnL1jJsAuMiuoa6qa5O8I8mHkqS7v5XkW/POAuCCKac+3pBkM8mfVtXnqupjVXXNzoOqaq2qNqpqY3Nzc9+HAhxVU0J9PMlbk/xRd9+U5JtJzuw8qLvXu3u1u1cXi8U+zwQ4uqaE+qkkT3X3w9t/vjtb4QbgAOwa6u7+jyT/WlU3bv/VLUmemHUVAC+aetXHryX5xPYVH19O8svzTQLgYpNC3d2PJlmdeQsAS3hlIsDghBpgcEINMDihBhicUAMMTqgBBifUAIMTaoDBCTXA4IQaYHBCDTA4oQYYnFADDE6oAQYn1ACDE2qAwQk1wOCEGmBwQg0wuEnvmVhV55M8l+Q7Sb7d3d4/EeCATH0X8iR5Z3c/O9sSAJZy6gNgcFND3UkerKqzVbW27ICqWquqjara2Nzc3L+FAEfc1FD/dHe/Ncl7k/xqVb1j5wHdvd7dq929ulgs9nUkwFE2KdTd/fT252eS3JvkbXOOAuC7dg11VV1TVScvfJ3k3Ukem3sYAFumXPXxQ0nuraoLx/9ldz8w6yoAXrRrqLv7y0nefABbAFjC5XkAgxNqgMEJNcDghBpgcEINMDihBhicUAMMTqgBBifUAIMTaoDBCTXA4IQaYHBCDTA4oQYYnFADDE6oAQYn1ACDE2qAwQk1wOAmh7qqjlXV56rqvjkHAfC99vKM+sNJzs01BIDlJoW6qq5PcmuSj807B4Cdjk887g+S/FaSk5c6oKrWkqwlyalTpy5/GUfOyTeeyY99/Mxhz7hsJ9+YbD2vgf2xa6ir6heSPNPdZ6vqZy91XHevJ1lPktXV1d63hRwZz527I+fveOUHbuXM/Yc9gSvMlFMfb0/yvqo6n+SuJDdX1V/MugqAF+0a6u7+ne6+vrtXktyW5O+6+4OzLwMgieuoAYY39YeJSZLu/kySz8yyBIClPKMGGJxQAwxOqAEGJ9QAgxNqgMEJNcDghBpgcEINMDihBhicUAMMTqgBBifUAIMTaoDBCTXA4IQaYHBCDTA4oQYYnFADDE6oAQa3a6ir6tVV9dmq+nxVPV5VHz2IYQBsmfLmtv+b5Obu/kZVnUjyUFX9bXf/48zbAMiEUHd3J/nG9h9PbH/0nKMA+K5J56ir6lhVPZrkmSSf6u6HlxyzVlUbVbWxubm53zsBjqxJoe7u73T3W5Jcn+RtVfWmJcesd/dqd68uFov93glwZO3pqo/u/p8kn07ynnnmALDTlKs+FlX12u2vr0ryriRfmHsYAFumXPXxw0k+XlXHshX2v+ru++adBcAFU676+KckNx3AFgCW8MpEgMEJNcDghBpgcEINMDihBhicUAMMTqgBBifUAIMTaoDBCTXA4IQaYHBCDTA4oQYYnFADDE6oAQYn1ACDE2qAwQk1wOCEGmBwQg0wuF1DXVWvr6pPV9UTVfV4VX34IIYBsGXXdyFP8u0kv9ndj1TVySRnq+pT3f3EzNsAyIRn1N397939yPbXzyU5l+R1cw8DYMuezlFX1UqSm5I8vOS2taraqKqNzc3N/VkHwPRQV9VrknwyyUe6++s7b+/u9e5e7e7VxWKxnxsBjrRJoa6qE9mK9Ce6+555JwFwsSlXfVSSP05yrrt/f/5JAFxsyjPqtyf5pSQ3V9Wj2x8/P/MuALbtenledz+UpA5gCwBLeGUiwOCEGmBwQg0wOKEGGJxQAwxOqAEGJ9QAgxNqgMFN+X3UcGBWztx/2BMu27VXnTjsCVxhhJphnL/j1tkfY+XM/QfyOLCfnPoAGJxQAwxOqAEGJ9QAgxNqgMEJNcDghBpgcEINMDihBhjclHch/5OqeqaqHjuIQQB8rynPqP8syXtm3gHAJewa6u7++yT/fQBbAFhi334pU1WtJVlLklOnTu3X3cIlVdXL+77f3fv3dPfLeizYD/v2w8TuXu/u1e5eXSwW+3W3cEndfWAfcJhc9QEwOKEGGNyUy/PuTPIPSW6sqqeq6lfmnwXABbv+MLG7Tx/EEACWc+oDYHBCDTA4oQYYnFADDK7muJi/qjaTPLnvdwyX77okzx72CFjihu5e+mrBWUINo6qqje5ePewdsBdOfQAMTqgBBifUHDXrhz0A9so5aoDBeUYNMDihBhicUHNkVNUvVlVX1Y8e9hbYC6HmKDmd5KHtz/CK4YeJHAlV9ZokX0zyziR/0903HvIkmMwzao6K9yd5oLu/lOS/qurHD3sQTCXUHBWnk9y1/fVdcfqDVxCnPrjiVdUPJHkqyWaSTnJs+/MN7T8AXgE8o+Yo+ECSP+/uG7p7pbtfn+QrSX7mkHfBJELNUXA6yb07/u6TcfqDVwinPgAG5xk1wOCEGmBwQg0wOKEGGJxQAwxOqAEGJ9QAg/s/2WuhIXKUsFIAAAAASUVORK5CYII=\n",
+            "image/png": "iVBORw0KGgoAAAANSUhEUgAAAWoAAAD4CAYAAADFAawfAAAABHNCSVQICAgIfAhkiAAAAAlwSFlzAAALEgAACxIB0t1+/AAAADh0RVh0U29mdHdhcmUAbWF0cGxvdGxpYiB2ZXJzaW9uMy4yLjIsIGh0dHA6Ly9tYXRwbG90bGliLm9yZy+WH4yJAAAKTklEQVR4nO3dX4hm913H8c/X3S1N0pCqGUSabsarWEhpUx+KWi02saU1Ur0oNAsWFGFuRFsRZL0KvdsLEb0Slvqn2Jpg8+fCLIYUbJGARmbTVJNsK9huauKfTJS2aQk2LV8vZjbdbp51znTnzPyS5/WCYf6cM+f53ux7D7855znV3QFgXD9w2AMA8P8TaoDBCTXA4IQaYHBCDTC4o3Mc9Prrr+/19fU5Dg3wqnT27Nnnuntt2bZZQr2+vp7Nzc05Dg3wqlRVT11um6UPgMEJNcDghBpgcEINMDihBhjcpFBX1W9X1RNV9XhV3VVVr517MAC27RrqqnpDkt9Ksujum5McSXLH3IMBsG3q0sfRJFdV1dEkVyf59/lGAuBiu97w0t3PVNXvJ/lKkheSPNTdD126X1VtJNlIkuPHj+/3nPAy6yfPHNhrnT91+4G9FlyqdntwQFX9YJJ7k3wwyVeTfCrJPd39icv9zmKxaHcmMqL1k2dElyFV1dnuXizbNmXp4+eTfLm7t7r7xST3Jfnp/RwQgMubEuqvJPnJqrq6qirJbUnOzTsWABfsGurufiTJPUkeTfLPO79zeua5ANgx6d3zuvvOJHfOPAsAS7gzEWBwQg0wOKEGGJxQAwxOqAEGJ9QAgxNqgMEJNcDghBpgcEINMDihBhicUAMMTqgBBifUAIMTaoDBCTXA4IQaYHBCDTA4oQYY3K6hrqqbquqxiz6+XlUfOYjhAJjwcNvu/mKStyZJVR1J8kyS+2eeC4Ade136uC3Jv3b3U3MMA8DL7TXUdyS5a9mGqtqoqs2q2tza2rryyQBIsodQV9Vrkrw/yaeWbe/u09296O7F2trafs0HsPL2ckb9viSPdvd/zTUMAC+3l1CfyGWWPQCYz6RQV9U1Sd6d5L55xwHgUrtenpck3f3NJD888ywALOHORIDBCTXA4CYtfcBBeMtHH8rXXnhx9tdZP3lm1uNfd9WxfP7O98z6GqwWoWYYX3vhxZw/dfthj3HF5v6PgNVj6QNgcEINMDihBhicUAMMTqgBBifUAIMTaoDBCTXA4IQaYHBCDTA4oQYYnFADDE6oAQYn1ACDE2qAwQk1wOCmPoX89VV1T1V9oarOVdVPzT0YANumPuHlj5I82N0fqKrXJLl6xpkAuMiuoa6q65K8M8mvJkl3fyvJt+YdC4ALpix9/FiSrSR/VlWfq6qPVdU1l+5UVRtVtVlVm1tbW/s+KMCqmhLqo0neluSPu/uWJN9McvLSnbr7dHcvunuxtra2z2MCrK4poX46ydPd/cjO9/dkO9wAHIBdQ93d/5nk36rqpp0f3ZbkyVmnAuAlU6/6+M0kn9y54uNLSX5tvpEAuNikUHf3Y0kWM88CwBLuTAQYnFADDE6oAQYn1ACDE2qAwQk1wOCEGmBwQg0wOKEGGJxQAwxOqAEGJ9QAgxNqgMEJNcDghBpgcEINMDihBhicUAMMTqgBBjfpmYlVdT7J80m+k+Tb3e35iQAHZOpTyJPkXd393GyTALCUpQ+AwU0NdSd5qKrOVtXGsh2qaqOqNqtqc2tra/8mBFhxU0P9M939tiTvS/IbVfXOS3fo7tPdvejuxdra2r4OCbDKJoW6u5/Z+fxskvuTvH3OoQD4rl1DXVXXVNW1F75O8p4kj889GADbplz18SNJ7q+qC/v/ZXc/OOtUALxk11B395eSvOUAZgFgCZfnAQxOqAEGJ9QAgxNqgMEJNcDghBpgcEINMDihBhicUAMMTqgBBifUAIMTaoDBCTXA4IQaYHBCDTA4oQYYnFADDE6oAQYn1ACDmxzqqjpSVZ+rqgfmHAiA77WXM+oPJzk31yAALDcp1FV1Q5Lbk3xs3nEAuNTRifv9YZLfTXLt5Xaoqo0kG0ly/PjxK5+MlXPtm07mzR8/edhjXLFr35Rsn9fA/tg11FX1i0me7e6zVfVzl9uvu08nOZ0ki8Wi921CVsbz507l/KlXfuDWT5457BF4lZmy9PGOJO+vqvNJ7k5ya1V9YtapAHjJrqHu7t/r7hu6ez3JHUn+trt/ZfbJAEjiOmqA4U39Y2KSpLs/m+Szs0wCwFLOqAEGJ9QAgxNqgMEJNcDghBpgcEINMDihBhicUAMMTqgBBifUAIMTaoDBCTXA4IQaYHBCDTA4oQYYnFADDE6oAQYn1ACDE2qAwe0a6qp6bVX9Y1V9vqqeqKqPHsRgAGyb8nDb/01ya3d/o6qOJXm4qv6mu/9h5tkAyIRQd3cn+cbOt8d2PnrOoQD4rklr1FV1pKoeS/Jskk939yNL9tmoqs2q2tza2trvOQFW1qRQd/d3uvutSW5I8vaqunnJPqe7e9Hdi7W1tf2eE2Bl7emqj+7+apLPJHnvPOMAcKkpV32sVdXrd76+Ksm7k3xh7sEA2Dblqo8fTfLxqjqS7bD/VXc/MO9YAFww5aqPf0pyywHMAsAS7kwEGJxQAwxOqAEGJ9QAgxNqgMEJNcDghBpgcEINMDihBhicUAMMTqgBBifUAIMTaoDBCTXA4IQaYHBCDTA4oQYYnFADDE6oAQYn1ACD2zXUVfXGqvpMVT1ZVU9U1YcPYjAAtu36FPIk307yO939aFVdm+RsVX26u5+ceTYAMuGMurv/o7sf3fn6+STnkrxh7sEA2LanNeqqWk9yS5JHlmzbqKrNqtrc2tran+kAmB7qqnpdknuTfKS7v37p9u4+3d2L7l6sra3t54wAK21SqKvqWLYj/cnuvm/ekQC42JSrPirJnyQ5191/MP9IAFxsyhn1O5J8KMmtVfXYzscvzDwXADt2vTyvux9OUgcwCwBLuDMRYHBCDTA4oQYYnFADDE6oAQYn1ACDE2qAwQk1wOCmvB81HJj1k2cOe4Qrdt1Vxw57BF5lhJphnD91++yvsX7yzIG8DuwnSx8AgxNqgMEJNcDghBpgcEINMDihBhicUAMMTqgBBifUAIOb8hTyP62qZ6vq8YMYCIDvNeWM+s+TvHfmOQC4jF1D3d1/l+R/DmAWAJbYtzdlqqqNJBtJcvz48f06LFzW9/tOe9/P73kjJw5TdffuO1WtJ3mgu2+ectDFYtGbm5tXNhnACqmqs929WLbNVR8AgxNqgMFNuTzvriR/n+Smqnq6qn59/rEAuGDXPyZ294mDGASA5Sx9AAxOqAEGJ9QAgxNqgMFNuuFlzwet2kry1L4fGK7c9UmeO+whYIkbu3tt2YZZQg2jqqrNy939BaOy9AEwOKEGGJxQs2pOH/YAsFfWqAEG54waYHBCDTA4oWZlVNUvV1VX1Y8f9iywF0LNKjmR5OGdz/CK4Y+JrISqel2SLyZ5V5K/7u6bDnkkmMwZNavil5I82N3/kuS/q+onDnsgmEqoWRUnkty98/XdsfzBK4ilD171quqHkjydZCtJJzmy8/nG9g+AVwBn1KyCDyT5i+6+sbvXu/uNSb6c5GcPeS6YRKhZBSeS3H/Jz+6N5Q9eISx9AAzOGTXA4IQaYHBCDTA4oQYYnFADDE6oAQYn1ACD+z856RC5vsnJCAAAAABJRU5ErkJggg==",
             "text/plain": [
               "<Figure size 432x288 with 1 Axes>"
             ]
           },
           "metadata": {
             "needs_background": "light"
-          }
+          },
+          "output_type": "display_data"
         }
+      ],
+      "source": [
+        "df = pd.DataFrame(np.random.randint(10, size=(10,4)), columns=list(\"ABCD\"))\n",
+        "\n",
+        "df.A.plot.box()\n",
+        "plt.show()"
       ]
     },
     {
@@ -6160,34 +6137,34 @@
     },
     {
       "cell_type": "code",
+      "execution_count": 107,
       "metadata": {
         "colab": {
           "base_uri": "https://localhost:8080/",
           "height": 265
         },
         "id": "xcFxvyvNA9xj",
-        "outputId": "0cac55fd-ca6e-417e-e389-0979cc919e4c"
+        "outputId": "dc46f6e4-e1e9-404f-c2e7-ed28b2ff4ec6"
       },
-      "source": [
-        "df = pd.DataFrame(np.random.randint(10, size=(10,4)), columns=list(\"ABCD\"))\n",
-        "\n",
-        "df.A.plot.density()\n",
-        "plt.show()"
-      ],
-      "execution_count": 453,
       "outputs": [
         {
-          "output_type": "display_data",
           "data": {
-            "image/png": "iVBORw0KGgoAAAANSUhEUgAAAYgAAAD4CAYAAAD2FnFTAAAABHNCSVQICAgIfAhkiAAAAAlwSFlzAAALEgAACxIB0t1+/AAAADh0RVh0U29mdHdhcmUAbWF0cGxvdGxpYiB2ZXJzaW9uMy4yLjIsIGh0dHA6Ly9tYXRwbG90bGliLm9yZy+WH4yJAAAgAElEQVR4nO3deXxU1f3/8dcnOyQhQBaWhCVAWMIuAVQQF1BRFHChgm1damu1pS6ttWqtWlpbl1at1bp83RdEBEGsKIIL1g1J2MMaIEBCgEAgLNmTz++PGfpLY4AQ5ubOTD7PxyMPZu4y8x4N8+Gcc8+5oqoYY4wxdYW4HcAYY4x/sgJhjDGmXlYgjDHG1MsKhDHGmHpZgTDGGFOvMLcD+EpCQoJ27drV7RjGGBNQsrKy9qpqYn37gqZAdO3alczMTLdjGGNMQBGRbcfaZ11Mxhhj6mUFwhhjTL2sQBhjjKmXFQhjjDH1sgJhjDGmXlYgjDHG1MvRAiEiY0Vkg4jkiMhd9ewfJSLLRKRKRK6ss6+ziHwsIutEZK2IdHUyqzHGmP/l2DwIEQkFngbOB/KApSIyT1XX1jpsO3AdcEc9L/Ea8KCqLhSRGKDGqazGNDc1NcragoOsLThI4aFyamqUxNhI0trFMjAljrBQ61wwzk6UGwbkqOoWABGZAUwA/lsgVDXXu+9/vvxFJB0IU9WF3uMOO5jTmGYjb38JL3+Vy7yVOyk8VF7vMbFRYYwf2JHrR3SlR1JsEyc0/sTJApEM7Kj1PA8Y3sBzewIHRORdIBVYBNylqtW1DxKRG4EbATp37nzKgY0JVofLq3h84UZe/ToXgDF92jG2X3sGpMTRsXULQkTYfbCM1fnFLFq7m3ey8njru+1MHtaZOy/sReuWEe5+AOMKf11qIww4CxiMpxvqbTxdUS/WPkhVnweeB8jIyLBb4xlTj6W5Rdzy1nIKisuYMqwTvzovjY6tW3zvuE5tW9KpbUsu7t+Bey9J58lPNvHGt9v4bP0eHr9qEKd3i3chvXGTkx2N+UCnWs9TvNsaIg9YoapbVLUKmAuc5uN8xgS9l7/aypTnvyUiLITZN5/JXy8fUG9xqKttdAQPjO/LnF+MICo8lB++sIS3l25vgsTGnzhZIJYCaSKSKiIRwGRg3kmc21pEjq4weB61xi6MMcenqvz1w3X88f21nNMriXlTRzKkS5uTfp3+KXHMmzqCM7vH87vZq/nnJ5scSGv8lWMFwvsv/6nAAmAdMFNVs0VkmoiMBxCRoSKSB0wCnhORbO+51XiubPpERFYDAvyfU1mNCSaqyr1z1/Dc4i38+PQuPP/jIcS1CG/068VGhfPSdUO5/LRk/r5wI88u3uzDtMafOToGoarzgfl1tt1X6/FSPF1P9Z27EBjgZD5jgtEjCzbw5pLt3HR2d343thcicsqvGR4awqNXDqSiqoaHPlxPXItwpgyzC0OCnb8OUhtjGuGF/2zhmc8388PhnX1WHI4KDREev2oQh8qq+MPcNaQmRNvAdZCz2TDGBIlP1+/mwfnruLh/e6ZN6OfT4nBUeGgI/7x6MJ3jW3LzG1nk7S/x+XsY/2EFwpggsHXvEW6dsYL0Dq147AeDCA3xfXE4qlVUOC9ck0FVtXLrjBVUVdsiB8HKCoQxAe5IeRU/fz2TsBDh2R8NISo81PH37JYYw58v60fWtv089VmO4+9n3GEFwpgA98f3s9m05zBPThlMp7Ytm+x9JwxK5rLByTz5ySaythU12fuapmMFwpgA9tGaXczMzOPms7tzVlriiU/wsWkT+tIhrgV3zlpFeVX1iU8wAcUKhDEBas/BMu5+dxX9kltx25iermSIjQrnz5f1Y3PhEZ753OZHBBsrEMYEIFXlrndXU1JRzRNXDSIizL2/yuf2SmL8wI7867PN5OyxhZeDiRUIYwLQ+6sK+HT9Hu4c29svluS+79J0WkSEct97a1C1dTODhRUIYwJMcUkl097PZkBKHNed2dXtOAAkxETy6/N78vXmfSxat8ftOMZHrEAYE2D++uE69pdU8pfL+js63+FkXT28M90To/nL/HVUVNnciGBgBcKYAPLd1iJmLN3BDSNT6Zcc53ac/xEeGsK949LZuvcIb3y7ze04xgesQBgTIKqqa7jvvTUkt27BbWPS3I5Tr3N6JXJWWgL/+GQTxSWVbscxp8gKhDEBYsbSHazfdYjfj+tDywj/XGdTRLj7oj4Ul1bywpdb3I5jTpEVCGMCQHFJJX//eAPDUttyUb/2bsc5rvSOrRjXvwMvfbmVoiMVbscxp8AKhDEB4B+fbOJAaSX3X5ruyCqtvnbbmDRKKqt5/gtrRQQyRwuEiIwVkQ0ikiMid9Wzf5SILBORKhG5sp79rUQkT0SecjKnMf4sZ89hXvsml8lDO9O3o38NTB9LWrtYJgzsyKtf51J4qNztOKaRHCsQIhIKPA1cBKQDU0Qkvc5h24HrgOnHeJk/AV84ldGYQPDQh+toER7Kby5wZzmNxrpldBoV1TX833+sFRGonGxBDANyVHWLqlYAM4AJtQ9Q1VxVXQV876JpERkCtAM+djCjMX4tM7eIRev2cNM53UmIiXQ7zknplhjDJQM68Oa32+yKpgDlZIFIBnbUep7n3XZCIhIC/B244wTH3SgimSKSWVhY2OigxvgjVeXhj9aTGBvJ9SO6uh2nUW46uztHKqp5/dtct6OYRvDXQepfAPNVNe94B6nq86qaoaoZiYlNv9SxMU76fEMhS3P3c8voNL+9rPVE+nRoxbm9Enn5q1xKK2w58EDjZIHIBzrVep7i3dYQZwBTRSQX+BtwjYg85Nt4xvivmhpP66FLfEsmD+104hP82E1nd2ffkQreydpx4oONX3GyQCwF0kQkVUQigMnAvIacqKo/VNXOqtoVTzfTa6r6vaugjAlW81buZP2uQ/zmgl6Eh/prQ79hhqW25bTOrXlu8RYq7f7VAcWx3zxVrQKmAguAdcBMVc0WkWkiMh5ARIaKSB4wCXhORLKdymNMoKioquHvCzeQ3qEVl/Tv4HacUyYi3HxOD/IPlPLhml1uxzEnwdGOTVWdD8yvs+2+Wo+X4ul6Ot5rvAK84kA8Y/zSjKXb2VFUyivX9yPEj1ZrPRWjeyfRJb4lr3y1lfEDO7odxzRQYLddjQkyZZXVPP1ZDsO6tuXsnsFz4UVIiHDtGV1Ztv0AK3cccDuOaSArEMb4kZmZO9h9sJzbxqQFxJIaJ2NSRgrREaG88nWu21FMA1mBMMZPlFdV88znmxnatQ1ndI93O47PxUaFMymjE/9etZM9B8vcjmMawAqEMX5iZmYeBcVl3Dq6Z9C1Ho669syuVFYrby7Z7nYU0wBWIIzxA+VV1fzrsxyGdGnDiB7B13o4KjUhmnN7JfLmku2UV9nEOX9nBcIYP/COt/UQjGMPdV0/IpW9h8v5cLVd8urvrEAY47KKqhqe+Xwzp3VuzcgeCW7HcdzIHgl0iW/JdOtm8ntWIIxx2aysPPIPlHLrmOAde6gtJESYMqwz3+UWsWn3IbfjmOOwAmGMiyqqanj6sxwGdWrNqLTgbz0cdeWQFMJDhbe+s/WZ/JkVCGNcNHvZ0dZD8I891JYQE8mFfdsze1keZZU2WO2vrEAY45LKak/rYWCn1pwTRLOmG+rq4Z0pLq1k/uoCt6OYY7ACYYxL3l2WR97+Um4b3bxaD0ed0S2ebgnRNljtx6xAGOOCyuoanvoshwEpcZzTq/m1HsCzyuuUYZ3J3LafjTZY7ZesQBjjgjnL8tlRVMqtzbT1cNQVQ1KICA2xVoSfsgJhTBM72nronxzHeb2T3I7jqrbREVzQtx1zV+TbzGo/ZAXCmCY2d3k+24tKmn3r4ahJGZ04UFLJJ+v2uB3F1GEFwpgmVOVtPfTt2IrRfZp36+GokT0S6BAXxTuZNifC3zhaIERkrIhsEJEcEfnePaVFZJSILBORKhG5stb2QSLyjYhki8gqEbnKyZzGNJX3Vuxk2z5rPdQWGiJcfloyizcWstuWAfcrjhUIEQkFngYuAtKBKSKSXuew7cB1wPQ620uAa1S1LzAWeEJEWjuV1ZimcLT1kN6hFeent3M7jl+5ckgnahTmLM93O4qpxckWxDAgR1W3qGoFMAOYUPsAVc1V1VVATZ3tG1V1k/fxTmAP0DyvBTRB4/1VO9m69wi3WOvhe1ITosno0oZ3Mnegqm7HMV5OFohkoHanYp5320kRkWFABLC5nn03ikimiGQWFhY2OqgxTquuUf75aQ6928dygbUe6jUpI4XNhUdYbves9ht+PUgtIh2A14HrVbWm7n5VfV5VM1Q1IzHRGhjGf/171U62FHpaDyEh1nqoz7gBHWkRHso7mXluRzFeThaIfKBTrecp3m0NIiKtgA+A36vqtz7OZkyTqa5RnvxkE73axTK2b3u34/itmMgwLurfnn+v3Elphc2J8AdOFoilQJqIpIpIBDAZmNeQE73HzwFeU9VZDmY0xnEfrC5gc+ERfjW6h7UeTmDSkE4cKq9iQbbdbc4fOFYgVLUKmAosANYBM1U1W0Smich4ABEZKiJ5wCTgORHJ9p7+A2AUcJ2IrPD+DHIqqzFOqalR/vnJJtKSYri4Xwe34/i94alt6dS2BbOXWTeTPwhz8sVVdT4wv862+2o9Xoqn66nueW8AbziZzZimMH9NAZv2HObJKYOt9dAAISHCxEHJPP1ZDnsOlpHUKsrtSM2aXw9SGxPIarxjD90ToxnX31oPDTVxcDI1CvNW7nQ7SrNnBcIYh8xfU8DG3Ye5ZXQaodZ6aLDuiTEMTImzSXN+wAqEMQ6oqq7hsYUbSUuK4ZIBHd2OE3AmDk4me+dBu0+Ey6xAGOOAOcvz2VJ4hN9c0NNaD41w6cCOhIaItSJcZgXCGB8rr6rmiUWb6J8cx4U276FREmIiGZWWwHvL86mpsaU33GIFwhgfe3vpDvIPlHLHhb1szaVTMHFwMjuLy/gut8jtKM2WFQhjfKi0opp/fprDsK5tGZWW4HacgHZBenuiI0KZs8y6mdxiBcIYH3rtm1wKD5Vb68EHWkSEMrZfB+avLqCs0pbecIMVCGN85GBZJc8s3szZPRMZltrW7ThB4bLByRwqr+LT9XY7UjdYgTDGR579fDMHSir57YW93I4SNM7oHk+7VpG8a91MrrACYYwP5B8o5cUvt3LZ4GT6Jce5HSdohIYIEwYl8/mGPRQdqXA7TrNjBcIYH/jbgg0A3GGtB5+bOCiZqhrlg9UFbkdpdqxAGHOKVuUdYM7yfG4YmUpy6xZuxwk66R1b0bt9LHNshdcmZwXCmFOgqjz4wTrioyO4+ZzubscJWhMGJbNs+wG27ytxO0qzYgXCmFOwcO1ulmwt4rbzexIbFe52nKA1fpBnPav3VthgdVOyAmFMI5VVVvOnD9bSIymGyUM7nfgE02jJrVswPLUtc1fko2pLbzQVRwuEiIwVkQ0ikiMid9Wzf5SILBORKhG5ss6+a0Vkk/fnWidzGtMYz3y+mR1FpUwb35fwUPu3ltMmDk5mc+ER1uQfdDtKs+HYb7WIhAJPAxcB6cAUEUmvc9h24Dpgep1z2wL3A8OBYcD9ItLGqazGnKxt+47wzOLNXDqwI2f2sCU1msLF/ToQERrCXOtmajJO/rNnGJCjqltUtQKYAUyofYCq5qrqKqCmzrkXAgtVtUhV9wMLgbEOZjWmwVSV++dlEx4i3Duuj9txmo24luGc0yuR91fupNpWeG0SThaIZGBHred53m0+O1dEbhSRTBHJLCwsbHRQY07Gx2t38/mGQm4/vyft7J7JTeqywcnsOVTON5v3uR2lWQjojlNVfV5VM1Q1IzEx0e04phkoLq3kvvfW0Lt9LNee2dXtOM3Oub2TiI0KsxsJNREnC0Q+UPvSjhTvNqfPNcYxD36wlsJD5Txy5QAbmHZBVHgoF/Vrz4LsXbbCaxNw8jd8KZAmIqkiEgFMBuY18NwFwAUi0sY7OH2Bd5sxrlm8sZCZmXncOKo7A1Jaux2n2Zo4KJnD5VUsWrfb7ShBz7ECoapVwFQ8X+zrgJmqmi0i00RkPICIDBWRPGAS8JyIZHvPLQL+hKfILAWmebcZ44pDZZXcPXsV3ROjuW1MmttxmrXh3eJp3yqKudbN5LgwJ19cVecD8+tsu6/W46V4uo/qO/cl4CUn8xnTUPfPy2bXwTLeuelMosJD3Y7TrIWGCOMHdeSlL7ey/0gFbaIj3I4UtBrUghCRd0VknIhYp6tpduYsz+PdZflMPS+NIV1sOo4/mDCoo63w2gQa+oX/L+BqYJOIPCQitqaxaRa27j3CvXPWMKxrW245r4fbcYxXeodWpCXF2NpMDmtQgVDVRar6Q+A0IBdYJCJfi8j1ImIrlJmgVFpRzdTpywgLDeGJyYMIs6uW/IaIMHFwMktz97OjyFZ4dUqDf+NFJB7Pshg/BZYD/8BTMBY6kswYF6kqd85exdqCgzx+1UA62n0e/M4E7wqv81budDlJ8GroGMQc4D9AS+BSVR2vqm+r6q+AGCcDGuOGZxZv5v2VO7njgl6c17ud23FMPVLatGRo1zbMXW4rvDqloS2I/1PVdFX9q6oWAIhIJICqZjiWzhgXfLi6gEcXbODSgR35hd0EyK9NGJTMpj2HWVtgK7w6oaEF4s/1bPvGl0GM8Qdf5+zl1hkrOK1zGx65YgAi4nYkcxzj+ncgPFRsToRDjlsgRKS9iAwBWojIYBE5zftzDp7uJmOCxrLt+/nZa5mkJkTz0rVDaRFh8x38XZvoCM7umcQ8W+HVESeaKHchnoHpFOCxWtsPAfc4lMmYJvfN5n389NWlJMRG8toNw4hraRfnBYqJgzuyaN1ulmzZZ/fm8LHjFghVfRV4VUSuUNXZTZTJmCa1cO1upk5fRue2LXnzp8NJsiW8A8qYPu2IiQxj7op8KxA+dtwCISI/UtU3gK4i8uu6+1X1sXpOM81EdY2yKu8AWdv2s3H3IXL3llBUUsHB0kpCQ4SwUKF1iwjax0WR3LoF6R1akd6xFWntYogMc7/7RlX51+eb+dvHG+ifHMfL1w0lPibS7VjmJEWFhzK2X3s+XL2LaRP62VIoPnSiLqZo7592KasBPF+qS3P3MzNzB4vW7eZASSUACTERdEuIIS0phlZR4dSoUlldw/6SSrbvK+GrnL2UVHiWZ44KD2FIlzac2T2BM7rHMzClNaEhTTsYvO9wOffMWc2C7N2MH9iRR64cYF8sAWzioGRmZeXx6fo9XNy/g9txgsaJupie8/75x6aJY/xVTY3yUfYunvxkE+t3HSI6IpQL+7Xn7J6JnNE9nqTY43fL1NQo24pKyN5ZTNa2/XyzeR+PLtgAQHx0BOf2TmJMn3aclZZAdKRza0iqKh+t2cUf3lvDwdIqfn9xH356VqpdrRTgPL+Dkcxdnm8Fwoca9DdRRB7Bc6lrKfARMAC43dv9ZIJcZm4Rf3gvm3UFB+meGM0jVwxg3IAOJ/VFHhIipCZEk5oQzSUDPDNg9x0u56vN+/hk3W4+zt7FrKw8IsJCGNE9ntF92nFe7ySfzmBetn0/D81fz3e5RfTp0Io3fjqQ3u1b+ez1jXtCQ4TxAzvy6je5HCipoHVLW+HVF6QhMxBFZIWqDhKRy4BLgF8DX6jqQKcDNlRGRoZmZma6HSOoHC6v4sEP1vLWdzvoGBfF7y7qzSUDOjrSHVRZXcPS3CIWrd3DonW72e5dX6d7YjSjeiYyKi2RYaltT7p1UVxayaK1u3n9222s2HGAhJgIbj+/J1dldLK1lYLMmvxiLvnnl/zlsv5cPbyz23EChohkHWvCc0MLxBpV7SciLwCzVPUjEVlpBSJ4Ze8sZur05Wzbd4QbRqZy25iejnb91Kaq5Ow5zOKNhXyxaS9LtuyjvKqGEIEeSTH0T25N7/axdGzdgg6to2gVFUaICDWqFB2ppKC4lLUFB1m54wCZufupqlG6JURzzRlduDKjEzFN9DlM01JVxjy2mPiYSGb+/Ay34wSM4xWIhv5N+beIrMfTxXSziCQCZb4KaPzLzMwd3Dt3DW1ahjP9Z6dzerf4Jn1/ESGtXSxp7WL56VndKKus5rutRWRt28/q/GIWbyxk9rK8475GeKjQq30sPxvVjTF9khjcqQ0hTTwQbpqWiDBxUDJ/X7iR/AOlJNsCi6esQS0IABFpCxSrarWItARaqequE5wzFs+qr6HAC6r6UJ39kcBrwBBgH3CVquZ6lxB/Ac9qsWHAa6r61+O9l7UgTp2q8vjCjTz5aQ4jeyTwj8mD/PKyT1XlYFkVBcWlFBwo40hF1X9n0cZHR5IYG0lqQjQRYdaF1Nxs31fCqEc/486xvfjFOXb/jobwRQsCoDee+RC1z3ntOG8aCjwNnA/kAUtFZJ6qrq112A3AflXtISKTgYeBq/DcozpSVft7i9FaEXlLVXNPIq85CVXVNfxu9mpmL8vjBxkpPHhZf8L9tI9eRIhrEU5ci3AbZDb/o3N8S4Z0acN7y3dagfCBhi73/TrwN2AkMNT7c6JVXIcBOaq6RVUrgBnAhDrHTABe9T6eBYwWz/WGCkR7i1ELoAKw5RodUlVdw69nrmT2sjxuH9OTh68Y4LfFwZgTmTioIxt2H2KdrfB6yhragsgA0vXkFl1PBnbUep4HDD/WMapaJSLFQDyeYjEBKMCzKODtqlpU9w1E5EbgRoDOne2qhcY4WhzmrdzJ78b25mZb3toEuHEDOvLH99cyd0U+fTpYC/NUNPSfiWuA9k4GqWMYUA10BFKB34hIt7oHqerzqpqhqhmJiYlNGC84qCq/n7PGioMJKm2jIzi7ZyLzVuykxlZ4PSUNLRAJeMYBFojIvKM/JzgnH+hU63mKd1u9x3i7k+LwDFZfDXykqpWqugf4ihN3aZmT9MSiTbyduYNfndfDioMJKhMGJ1NQXMaSrd/reDAnoaFdTA804rWXAmkikoqnEEzG88Vf2zzgWjw3H7oS+FRVVUS2A+cBr4tINHA68EQjMphjeHvpdv7xySauHJLCr8/v6XYcY3zq/D7tiI4I5b0V+ZzRvWkv0w4mDWpBqOpiIBcI9z5eCiw7wTlVwFRgAbAOmKmq2SIyTUTGew97EYgXkRw8s7Pv8m5/GogRkWzve72sqqtO6pOZY/p6817umbOGUT0T+evl/W0dIhN0WkSEcmHf9nywuoCyymq34wSshq7F9DM8g8Ftge54BpefBUYf7zxVnQ/Mr7PtvlqPy/Bc0lr3vMP1bTenLv9AKVOnLyc1IZp//fA0u1rJBK2Jg5N5d3k+n2/Yw9h+toBfYzT02+GXwAi8l5qq6iYgyalQxhllldXc9HoWlVU1PP/jIbbkhAlqZ3aPJyEmkrnLd7odJWA1tECUe+cyAP8dULbLAwKIqnLv3DWszi/msasG0S3RbvFhgltYaAiXDuzAp+v3UFxa6XacgNTQArFYRO4BWojI+cA7wPvOxTK+9k5WHrOy8rhldBrnp7dzO44xTWLioGQqqmv4cHWB21ECUkMLxF1AIbAa+DmecYV7nQplfGtL4WEemJfNGd3iuXV0mttxjGkyA1Li6JYQzdwVda+wNw3RoE5oVa0RkbnAXFUtdDiT8aGKqhpunbGCiLAQHrtqYJPf2tMYN4kIEwYl88QnGykoLqVDnK3wejKO24IQjwdEZC+wAdggIoUict/xzjP+4+8LN7A6v5iHLh9gfzlMszRhUEdU4b0VNlh9sk7UxXQ7nquXhqpqW1Vti2c9pREicrvj6cwp+SpnL88t3sLVwzsztl9TrpRijP/omhDNaZ1bMzsrj5NbTs6cqED8GJiiqluPblDVLcCPgGucDGZOzaGySu6ctYpuidH8YVy623GMcdUPMjqxac9hVuw44HaUgHKiAhGuqnvrbvSOQ4Q7E8n4wl8/XE9BcSl/mzSQFhGhbscxxlXjBnSgRXgoMzN3nPhg818nKhAVjdxnXPRVzl6mL9nODSNTOa1zG7fjGOO62Khwxg3owPsrCyipqHI7TsA4UYEYKCIH6/k5BPRvioDm5Bwpr+J3s1fRLSGa31zQy+04xviNH2R04nB5FfNXH/dOyaaW4xYIVQ1V1Vb1/MSqqnUx+aGHP1pP/oFSHrlyAFHh1rVkzFFDu7YhNSHauplOgq3UFkQyc4t47ZttXH9mKhld27odxxi/IiJMykjhu61FbN17xO04AcEKRJCoqq7h3rlr6BgXxR0X2v0djKnPFaelECLwjrUiGsQKRJB449ttrN91iHsvSadlhK3Sakx92rWK4txeSczKyqOqusbtOH7PCkQQKDxUzt8XbuSstAQusglxxhzXpIxO7DlUzhebbNWgE3G0QIjIWBHZICI5InJXPfsjReRt7/4lItK11r4BIvKNiGSLyGoRiXIyayB76MP1lFVW88D4vnZ3OGNOYHSfJBJiInh7qXUznYhjBUJEQvHcOvQiIB2YIiJ1p/TeAOxX1R7A48DD3nPDgDeAm1S1L3AOYAu61yNrWxGzl+Vxw8hudLd7PBhzQuGhIVw2OJlP1u2h8FC523H8mpMtiGFAjqpu8d5saAYwoc4xE4BXvY9nAaPF80/gC4BVqroSQFX3qardWLaOquoa/jA3mw5xUfzqvB5uxzEmYFw1tBNVNco7WdaKOB4nC0QyUPu/fp53W73HqGoVUAzEAz0BFZEFIrJMRO50MGfAenPJdtYWHOTecelE2+1DjWmwHkmxDE9ty/Ql26mpsQX8jsVfB6nDgJHAD71/XiYio+seJCI3ikimiGQWFjavAae9h8v528cbGNEjnov728C0MSfrR6d3IW9/KYttsPqYnCwQ+UCnWs9TvNvqPcY77hAH7MPT2vhCVfeqagmeO9idVvcNVPV5Vc1Q1YzExEQHPoL/etg7MP3H8f1sYNqYRriwb3sSYiJ589ttbkfxW04WiKVAmoikikgEMBmYV+eYecC13sdXAp+qZ8H2BUB/EWnpLRxnA2sdzBpQsrbt552sPH4yMpUeSTYwbUxjRISFcNXQFD5dv4f8A6Vux/FLjhUI75jCVDxf9uuAmaqaLSLTRGS897AXgXgRyQF+jefe16jqfhraEtQAABIcSURBVOAxPEVmBbBMVT9wKmsgqa5R7ntvDe1bRXHLeXZ/aWNOxZRhnVHgrSXb3Y7ilxwd2VTV+Xi6h2pvu6/W4zJg0jHOfQPPpa6mlulLtpG98yBPXT3YBqaNOUUpbVpyXq8kZizdwS2j04gI89dhWXfYf40Asu9wOY8u2MCZ3eMZ17+D23GMCQo/Or0Lew+X8/FaWwa8LisQAeThj9ZTUlHNtAk2Y9oYXxnVM5GUNi14wwarv8cKRIDI2rafmZl53DAylR5JsW7HMSZohIYIU4Z15tstRWzafcjtOH7FCkQAqK5R7p+3hnatIvnVaBuYNsbXJg/tRGRYCC9/net2FL9iBSIATP9uO2vyPTOmY2xg2hifi4+J5LLByby7LI/9RyrcjuM3rED4uX2Hy3n0o/Wc2T2eSwbYwLQxTrl+RCpllTVM/84ueT3KCoSfe+SjDZRUVPNHW8rbGEf1ah/LyB4JvPZNLpV2MyHACoRfW7Z9P29n7uAnI1NJa2cD08Y47Scju7L7YDnzVxe4HcUvWIHwU0dnTLdrFcktNjBtTJM4p2cS3RKieenLrXhW/WnerED4qbe8A9P3XNzHBqaNaSIhIcL1I7qyMq+YZdv3ux3HdVYg/FDRkQoeXbCB07u1ZfzAjm7HMaZZufy0FFpFhfHil1vdjuI6KxB+6JGP1nOkvIppE2wpb2OaWnRkGFcP78JHa3aRu/eI23FcZQXCz6zYcYC3M3dw3Zld6WkD08a44icjuxIWGsJzX2x2O4qrrED4kaMD04kxkdw6xgamjXFLUmwUk4akMDsrn90Hy9yO4xorEH7kre+2syqvmN+P60NsVLjbcYxp1n4+qjtVNTXNeizCCoSf2Hu4nEc+Ws8Z3eJtYNoYP9A5viWXDOjIm99uo7ik0u04rrAC4Sce+nA9pZXV/GmizZg2xl/cfE53jlRU89o3uW5HcYWjBUJExorIBhHJEZG76tkfKSJve/cvEZGudfZ3FpHDInKHkzndtjS3iFlZefz0rG62lLcxfqRPh1ac1zuJl7/OpaSiyu04Tc6xAiEiocDTwEVAOjBFRNLrHHYDsF9VewCPAw/X2f8Y8KFTGf1BVXUNf5i7huTWLfjVeT3cjmOMqeOX53an6EgFr3/T/G4o5GQLYhiQo6pbVLUCmAFMqHPMBOBV7+NZwGjx9q+IyERgK5DtYEbXvfJ1Lut3HeK+S9NpGWEzpo3xN0O6tOWstASeXbyZw+XNqxXhZIFIBnbUep7n3VbvMapaBRQD8SISA/wO+OPx3kBEbhSRTBHJLCws9FnwprKruIzHF27k3F6JXJDezu04xphj+M0FvdhfUsmrzeyGQv46SP0A8LiqHj7eQar6vKpmqGpGYmJi0yTzoT9/sJaqGuWP423GtDH+bFCn1ozuncTzX2zhYFnzuaLJyQKRD3Sq9TzFu63eY0QkDIgD9gHDgUdEJBe4DbhHRKY6mLXJLd5YyL9XFfCLc3rQOb6l23GMMSdw+/k9KS6t5KVmNC/CyQKxFEgTkVQRiQAmA/PqHDMPuNb7+ErgU/U4S1W7qmpX4AngL6r6lINZm9SR8irueXc13ROj+fnZ3dyOY4xpgH7JcVzYtx0v/mcrB0qax21JHSsQ3jGFqcACYB0wU1WzRWSaiIz3HvYinjGHHODXwPcuhQ1Gjy3cSP6BUh66YgBR4aFuxzHGNNDt5/fkcEUVzy7e4naUJuHoZTOqOh+YX2fbfbUelwGTTvAaDzgSziUrdhzg5a+28qPTOzO0a1u34xhjTkLv9q2YOCiZl7/ayo/P6EJy6xZuR3KUvw5SB6XK6hrumr2KpNgo7hzb2+04xphGuOPCXijw9wUb3I7iOCsQTej5L7awftch/jSxH61sMT5jAlJy6xbcMDKVd5fnszqv2O04jrIC0UQ2Fx7mH59sYlz/Dpxvcx6MCWi/OKc78dERPDh/bVDfu9oKRBOoqq7ht++spEV4KPePr7vaiDEm0MRGhXPbmDS+3VLEonV73I7jGCsQTeC5L7awbPsBpk3oS1JslNtxjDE+MHlYZ7onRvPnD9ZSVlntdhxHWIFw2NqdB3li0UbG9e9g93kwJoiEh4YwbUI/tu0r4dnFwXlrUisQDiqvqubXM1cQ1yKCP0205TSMCTYjeiRwyYAO/OvzzWzbd8TtOD5nBcJB/1i0ifW7DvHwFf1pGx3hdhxjjAPuHZdOeIjwwLzsoBuwtgLhkO+2FvHs4s1cldGJ0X3sqiVjglX7uChuG9OTzzYU8vHa3W7H8SkrEA7Yf6SCW2csp3PblvzhUrtqyZhgd92IrvRqF8t9762huDR4Vnu1AuFjqspvZ61i7+Fynrr6NGIi7SZAxgS78NAQHp00gL2HK/jzv9e6HcdnrED42Ktf57Jo3W7uvqgP/ZLj3I5jjGkiA1Ja8/NR3XgnK4/PNwTH3AgrED60Jr+Yv8xfz+jeSVw/oqvbcYwxTezWMWmkJcVw97urg+LGQlYgfGT/kQpueiOL+JgIHp000C5pNaYZigwL5dFJA9l9sIxp7wd+V5MVCB+orlFumbGcPQfLeeZHQ+ySVmOasUGdWvPLc3swKyuPeSt3uh3nlFiB8IFHF2zgP5v28qeJfRnUqbXbcYwxLrt1dBpDurThnndXs31fidtxGs0KxCn6YFUBzy7ezA+Hd+aqoZ3djmOM8QNhoSH8Y/IgQgR+NWM5ldU1bkdqFEcLhIiMFZENIpIjIt+7naiIRIrI2979S0Skq3f7+SKSJSKrvX+e52TOxlq54wC/eWcFp3Vuzf2X9nU7jjHGj6S0aclDVwxg5Y4DPPjBOrfjNIpjBUJEQoGngYuAdGCKiNSdNXYDsF9VewCPAw97t+8FLlXV/sC1wOtO5WysHUUl3PBqJgkxkTz34wwiwqwxZoz5Xxf378BPRqTyyte5zM7KczvOSXPyW20YkKOqW1S1ApgBTKhzzATgVe/jWcBoERFVXa6qR0d3soEWIhLpYNaTUlxayfWvLKWiqppXrh9KYqzfRDPG+Jl7Lu7NGd3iuXvOalblHXA7zklxskAkAztqPc/zbqv3GFWtAoqB+DrHXAEsU9Xyum8gIjeKSKaIZBYWFvos+PGUVVZz0+tZbNt3hOd+nEGPpNgmeV9jTGAKCw3hqasHkxgTyc9fz2LPwTK3IzWYX/eLiEhfPN1OP69vv6o+r6oZqpqRmJjoeJ7K6hqmTl/GN1v28eiVAzmje91aZowx3xcfE8nz1wyhuLSS615eyqEAmUTnZIHIBzrVep7i3VbvMSISBsQB+7zPU4A5wDWq6vrdOKprlNvfXsGidXv408R+TBxctzFkjDHH1rdjHP/64Wls2H2Im99YRkWV/1/Z5GSBWAqkiUiqiEQAk4F5dY6Zh2cQGuBK4FNVVRFpDXwA3KWqXzmYsUFqapS7313Fv1cVcPdFvfnx6V3cjmSMCUDn9Eriocv782XOXu6ctZKaGv++f4RjS42qapWITAUWAKHAS6qaLSLTgExVnQe8CLwuIjlAEZ4iAjAV6AHcJyL3ebddoKpNvgJWVXUNv521ijnL87lldBo/P7t7U0cwxgSRSRmd2HOonEcXbCAiLISHLh9ASIh/Ls0jwXIHpIyMDM3MzPTpa1ZU1XDLW8v5KHsXv72wF788t4dPX98Y03w99vEGnvw0hynDOvHgxP6uFQkRyVLVjPr22c0KjuFIeRW/eHMZizcW8odL0rlhZKrbkYwxQeT283tSrcrTn22mpgYevKwfYaH+dd2QFYh6FBSXcsMrmazfdZCHLu/P5GG2hIYxxrdEhDsu6EWoCE9+msP+kgqenDKYqPBQt6P9l3+VKz+wJr+YiU9/xfaiEl66bqgVB2OMY0SEX1/QiwcuTWfhut1c8+J3FJf4zyWwViBqmbs8n0nPfkOoCLNuPoNzeiW5HckY0wxcNyKVf04ZzIodBxj/9Jds3H3I7UiAFQjAMzv6njmrue3tFfRPjmPuL0fQu30rt2MZY5qRSwZ05K0bh1NSUc1lT3/FR2t2uR3JCkRBcSlXPvs105ds56azuzP9Z8NJahXldixjTDM0pEtb3p86kh7tYrnpjSwemJdNWWW1a3mafYGIjQonIjSEF67J4K6LevvdVQTGmOalfVwUb994+n9XgR3/1Jes3XnQlSw2DwJQVbuHtDHG7yzeWMgd76ykuKSSm87uxi/O7eHzq5yONw/C/rkMVhyMMX7p7J6JLLhtFBf3b8+Tn+Zw4RNf8PmGpltQwgqEMcb4sbbRETwxeTDTfzqcUBGue3kp17z0HWvyix1/bysQxhgTAM7skcCHt53F7y/uw6q8A1zyzy/55fRlbNjl3CWxNgZhjDEB5mBZJf/3xRZe/HIrJRXVjBvQgaemDG5Ud7mtxWSMMUGkVVQ4v7mgFz8Zkcpr32yjorrakbFUKxDGGBOg2kRHcOuYNMde38YgjDHG1MsKhDHGmHo5WiBEZKyIbBCRHBG5q579kSLytnf/EhHpWmvf3d7tG0TkQidzGmOM+T7HCoSIhAJPAxcB6cAUEUmvc9gNwH5V7QE8DjzsPTcdz+1H+wJjgX95X88YY0wTcbIFMQzIUdUtqloBzAAm1DlmAvCq9/EsYLR4huInADNUtVxVtwI53tczxhjTRJwsEMnAjlrP87zb6j1GVauAYiC+geciIjeKSKaIZBYWFvowujHGmIAepFbV51U1Q1UzEhMT3Y5jjDFBxckCkQ90qvU8xbut3mNEJAyIA/Y18FxjjDEOcmypDe8X/kZgNJ4v96XA1aqaXeuYXwL9VfUmEZkMXK6qPxCRvsB0POMOHYFPgDRVPeadM0SkENh2CpETgL2ncL6/CJbPAfZZ/FWwfJZg+Rxwap+li6rW2wXj2ExqVa0SkanAAiAUeElVs0VkGpCpqvOAF4HXRSQHKMJz5RLe42YCa4Eq4JfHKw7ec06pj0lEMo+1HkkgCZbPAfZZ/FWwfJZg+Rzg3GdxdKkNVZ0PzK+z7b5aj8uAScc490HgQSfzGWOMObaAHqQ2xhjjHCsQ/9/zbgfwkWD5HGCfxV8Fy2cJls8BDn2WoLkfhDHGGN+yFoQxxph6WYEwxhhTLysQXiLyqIisF5FVIjJHRFq7nelknWj13EAhIp1E5DMRWSsi2SJyq9uZToWIhIrIchH5t9tZToWItBaRWd6/J+tE5Ay3MzWWiNzu/d1aIyJviUiU25kaSkReEpE9IrKm1ra2IrJQRDZ5/2zji/eyAvH/LQT6qeoAPBP87nY5z0lp4Oq5gaIK+I2qpgOnA78M4M8CcCuwzu0QPvAP4CNV7Q0MJEA/k4gkA7cAGaraD888rcnupjopr+BZ5bq2u4BPVDUNz8Rin/wD0QqEl6p+7F0wEOBbPMt7BJKGrJ4bEFS1QFWXeR8fwvNF9L3FGgOBiKQA44AX3M5yKkQkDhiFZ3IrqlqhqgfcTXVKwoAW3hUfWgI7Xc7TYKr6BZ6JxbXVXhn7VWCiL97LCkT9fgJ86HaIk9SgFXADjfcmUoOBJe4mabQngDuBGreDnKJUoBB42dtd9oKIRLsdqjFUNR/4G7AdKACKVfVjd1OdsnaqWuB9vAto54sXbVYFQkQWefsc6/5MqHXM7/F0cbzpXlIDICIxwGzgNlU96HaekyUilwB7VDXL7Sw+EAacBjyjqoOBI/ioG6OpefvnJ+Apeh2BaBH5kbupfEc9cxd8Mn/B0aU2/I2qjjnefhG5DrgEGK2BN0EkqFbAFZFwPMXhTVV91+08jTQCGC8iFwNRQCsReUNVA/HLKA/IU9WjLblZBGiBAMYAW1W1EEBE3gXOBN5wNdWp2S0iHVS1QEQ6AHt88aLNqgVxPCIyFk9XwHhVLXE7TyMsBdJEJFVEIvAMus1zOVOjeO8q+CKwTlUfcztPY6nq3aqaoqpd8fz/+DRAiwOqugvYISK9vJtG41lMMxBtB04XkZbe37XRBOiAey3zgGu9j68F3vPFizarFsQJPAVEAgs9vzN8q6o3uRup4Y61eq7LsRprBPBjYLWIrPBuu8e7+KNxz6+AN73/ANkCXO9ynkZR1SUiMgtYhqc7eTkBtOyGiLwFnAMkiEgecD/wEDBTRG7Ac9uDH/jkvQKvJ8UYY0xTsC4mY4wx9bICYYwxpl5WIIwxxtTLCoQxxph6WYEwxhhTLysQxhhj6mUFwhhjTL3+H/48AhSaqm/xAAAAAElFTkSuQmCC\n",
+            "image/png": "iVBORw0KGgoAAAANSUhEUgAAAYgAAAD4CAYAAAD2FnFTAAAABHNCSVQICAgIfAhkiAAAAAlwSFlzAAALEgAACxIB0t1+/AAAADh0RVh0U29mdHdhcmUAbWF0cGxvdGxpYiB2ZXJzaW9uMy4yLjIsIGh0dHA6Ly9tYXRwbG90bGliLm9yZy+WH4yJAAAgAElEQVR4nO3deXxU1f3/8dcnOyQhQBaWhCVAWMIuAVQQF1BRFHChgm1damu1pS6ttWqtWlpbl1at1bp83RdEBEGsKIIL1g1J2MMaIEBCgEAgLNmTz++PGfpLY4AQ5ubOTD7PxyMPZu4y8x4N8+Gcc8+5oqoYY4wxdYW4HcAYY4x/sgJhjDGmXlYgjDHG1MsKhDHGmHpZgTDGGFOvMLcD+EpCQoJ27drV7RjGGBNQsrKy9qpqYn37gqZAdO3alczMTLdjGGNMQBGRbcfaZ11Mxhhj6mUFwhhjTL2sQBhjjKmXFQhjjDH1sgJhjDGmXlYgjDHG1MvRAiEiY0Vkg4jkiMhd9ewfJSLLRKRKRK6ss6+ziHwsIutEZK2IdHUyqzHGmP/l2DwIEQkFngbOB/KApSIyT1XX1jpsO3AdcEc9L/Ea8KCqLhSRGKDGqazGNDc1NcragoOsLThI4aFyamqUxNhI0trFMjAljrBQ61wwzk6UGwbkqOoWABGZAUwA/lsgVDXXu+9/vvxFJB0IU9WF3uMOO5jTmGYjb38JL3+Vy7yVOyk8VF7vMbFRYYwf2JHrR3SlR1JsEyc0/sTJApEM7Kj1PA8Y3sBzewIHRORdIBVYBNylqtW1DxKRG4EbATp37nzKgY0JVofLq3h84UZe/ToXgDF92jG2X3sGpMTRsXULQkTYfbCM1fnFLFq7m3ey8njru+1MHtaZOy/sReuWEe5+AOMKf11qIww4CxiMpxvqbTxdUS/WPkhVnweeB8jIyLBb4xlTj6W5Rdzy1nIKisuYMqwTvzovjY6tW3zvuE5tW9KpbUsu7t+Bey9J58lPNvHGt9v4bP0eHr9qEKd3i3chvXGTkx2N+UCnWs9TvNsaIg9YoapbVLUKmAuc5uN8xgS9l7/aypTnvyUiLITZN5/JXy8fUG9xqKttdAQPjO/LnF+MICo8lB++sIS3l25vgsTGnzhZIJYCaSKSKiIRwGRg3kmc21pEjq4weB61xi6MMcenqvz1w3X88f21nNMriXlTRzKkS5uTfp3+KXHMmzqCM7vH87vZq/nnJ5scSGv8lWMFwvsv/6nAAmAdMFNVs0VkmoiMBxCRoSKSB0wCnhORbO+51XiubPpERFYDAvyfU1mNCSaqyr1z1/Dc4i38+PQuPP/jIcS1CG/068VGhfPSdUO5/LRk/r5wI88u3uzDtMafOToGoarzgfl1tt1X6/FSPF1P9Z27EBjgZD5jgtEjCzbw5pLt3HR2d343thcicsqvGR4awqNXDqSiqoaHPlxPXItwpgyzC0OCnb8OUhtjGuGF/2zhmc8388PhnX1WHI4KDREev2oQh8qq+MPcNaQmRNvAdZCz2TDGBIlP1+/mwfnruLh/e6ZN6OfT4nBUeGgI/7x6MJ3jW3LzG1nk7S/x+XsY/2EFwpggsHXvEW6dsYL0Dq147AeDCA3xfXE4qlVUOC9ck0FVtXLrjBVUVdsiB8HKCoQxAe5IeRU/fz2TsBDh2R8NISo81PH37JYYw58v60fWtv089VmO4+9n3GEFwpgA98f3s9m05zBPThlMp7Ytm+x9JwxK5rLByTz5ySaythU12fuapmMFwpgA9tGaXczMzOPms7tzVlriiU/wsWkT+tIhrgV3zlpFeVX1iU8wAcUKhDEBas/BMu5+dxX9kltx25iermSIjQrnz5f1Y3PhEZ753OZHBBsrEMYEIFXlrndXU1JRzRNXDSIizL2/yuf2SmL8wI7867PN5OyxhZeDiRUIYwLQ+6sK+HT9Hu4c29svluS+79J0WkSEct97a1C1dTODhRUIYwJMcUkl097PZkBKHNed2dXtOAAkxETy6/N78vXmfSxat8ftOMZHrEAYE2D++uE69pdU8pfL+js63+FkXT28M90To/nL/HVUVNnciGBgBcKYAPLd1iJmLN3BDSNT6Zcc53ac/xEeGsK949LZuvcIb3y7ze04xgesQBgTIKqqa7jvvTUkt27BbWPS3I5Tr3N6JXJWWgL/+GQTxSWVbscxp8gKhDEBYsbSHazfdYjfj+tDywj/XGdTRLj7oj4Ul1bywpdb3I5jTpEVCGMCQHFJJX//eAPDUttyUb/2bsc5rvSOrRjXvwMvfbmVoiMVbscxp8AKhDEB4B+fbOJAaSX3X5ruyCqtvnbbmDRKKqt5/gtrRQQyRwuEiIwVkQ0ikiMid9Wzf5SILBORKhG5sp79rUQkT0SecjKnMf4sZ89hXvsml8lDO9O3o38NTB9LWrtYJgzsyKtf51J4qNztOKaRHCsQIhIKPA1cBKQDU0Qkvc5h24HrgOnHeJk/AV84ldGYQPDQh+toER7Kby5wZzmNxrpldBoV1TX833+sFRGonGxBDANyVHWLqlYAM4AJtQ9Q1VxVXQV876JpERkCtAM+djCjMX4tM7eIRev2cNM53UmIiXQ7zknplhjDJQM68Oa32+yKpgDlZIFIBnbUep7n3XZCIhIC/B244wTH3SgimSKSWVhY2OigxvgjVeXhj9aTGBvJ9SO6uh2nUW46uztHKqp5/dtct6OYRvDXQepfAPNVNe94B6nq86qaoaoZiYlNv9SxMU76fEMhS3P3c8voNL+9rPVE+nRoxbm9Enn5q1xKK2w58EDjZIHIBzrVep7i3dYQZwBTRSQX+BtwjYg85Nt4xvivmhpP66FLfEsmD+104hP82E1nd2ffkQreydpx4oONX3GyQCwF0kQkVUQigMnAvIacqKo/VNXOqtoVTzfTa6r6vaugjAlW81buZP2uQ/zmgl6Eh/prQ79hhqW25bTOrXlu8RYq7f7VAcWx3zxVrQKmAguAdcBMVc0WkWkiMh5ARIaKSB4wCXhORLKdymNMoKioquHvCzeQ3qEVl/Tv4HacUyYi3HxOD/IPlPLhml1uxzEnwdGOTVWdD8yvs+2+Wo+X4ul6Ot5rvAK84kA8Y/zSjKXb2VFUyivX9yPEj1ZrPRWjeyfRJb4lr3y1lfEDO7odxzRQYLddjQkyZZXVPP1ZDsO6tuXsnsFz4UVIiHDtGV1Ztv0AK3cccDuOaSArEMb4kZmZO9h9sJzbxqQFxJIaJ2NSRgrREaG88nWu21FMA1mBMMZPlFdV88znmxnatQ1ndI93O47PxUaFMymjE/9etZM9B8vcjmMawAqEMX5iZmYeBcVl3Dq6Z9C1Ho669syuVFYrby7Z7nYU0wBWIIzxA+VV1fzrsxyGdGnDiB7B13o4KjUhmnN7JfLmku2UV9nEOX9nBcIYP/COt/UQjGMPdV0/IpW9h8v5cLVd8urvrEAY47KKqhqe+Xwzp3VuzcgeCW7HcdzIHgl0iW/JdOtm8ntWIIxx2aysPPIPlHLrmOAde6gtJESYMqwz3+UWsWn3IbfjmOOwAmGMiyqqanj6sxwGdWrNqLTgbz0cdeWQFMJDhbe+s/WZ/JkVCGNcNHvZ0dZD8I891JYQE8mFfdsze1keZZU2WO2vrEAY45LKak/rYWCn1pwTRLOmG+rq4Z0pLq1k/uoCt6OYY7ACYYxL3l2WR97+Um4b3bxaD0ed0S2ebgnRNljtx6xAGOOCyuoanvoshwEpcZzTq/m1HsCzyuuUYZ3J3LafjTZY7ZesQBjjgjnL8tlRVMqtzbT1cNQVQ1KICA2xVoSfsgJhTBM72nronxzHeb2T3I7jqrbREVzQtx1zV+TbzGo/ZAXCmCY2d3k+24tKmn3r4ahJGZ04UFLJJ+v2uB3F1GEFwpgmVOVtPfTt2IrRfZp36+GokT0S6BAXxTuZNifC3zhaIERkrIhsEJEcEfnePaVFZJSILBORKhG5stb2QSLyjYhki8gqEbnKyZzGNJX3Vuxk2z5rPdQWGiJcfloyizcWstuWAfcrjhUIEQkFngYuAtKBKSKSXuew7cB1wPQ620uAa1S1LzAWeEJEWjuV1ZimcLT1kN6hFeent3M7jl+5ckgnahTmLM93O4qpxckWxDAgR1W3qGoFMAOYUPsAVc1V1VVATZ3tG1V1k/fxTmAP0DyvBTRB4/1VO9m69wi3WOvhe1ITosno0oZ3Mnegqm7HMV5OFohkoHanYp5320kRkWFABLC5nn03ikimiGQWFhY2OqgxTquuUf75aQ6928dygbUe6jUpI4XNhUdYbves9ht+PUgtIh2A14HrVbWm7n5VfV5VM1Q1IzHRGhjGf/171U62FHpaDyEh1nqoz7gBHWkRHso7mXluRzFeThaIfKBTrecp3m0NIiKtgA+A36vqtz7OZkyTqa5RnvxkE73axTK2b3u34/itmMgwLurfnn+v3Elphc2J8AdOFoilQJqIpIpIBDAZmNeQE73HzwFeU9VZDmY0xnEfrC5gc+ERfjW6h7UeTmDSkE4cKq9iQbbdbc4fOFYgVLUKmAosANYBM1U1W0Smich4ABEZKiJ5wCTgORHJ9p7+A2AUcJ2IrPD+DHIqqzFOqalR/vnJJtKSYri4Xwe34/i94alt6dS2BbOXWTeTPwhz8sVVdT4wv862+2o9Xoqn66nueW8AbziZzZimMH9NAZv2HObJKYOt9dAAISHCxEHJPP1ZDnsOlpHUKsrtSM2aXw9SGxPIarxjD90ToxnX31oPDTVxcDI1CvNW7nQ7SrNnBcIYh8xfU8DG3Ye5ZXQaodZ6aLDuiTEMTImzSXN+wAqEMQ6oqq7hsYUbSUuK4ZIBHd2OE3AmDk4me+dBu0+Ey6xAGOOAOcvz2VJ4hN9c0NNaD41w6cCOhIaItSJcZgXCGB8rr6rmiUWb6J8cx4U276FREmIiGZWWwHvL86mpsaU33GIFwhgfe3vpDvIPlHLHhb1szaVTMHFwMjuLy/gut8jtKM2WFQhjfKi0opp/fprDsK5tGZWW4HacgHZBenuiI0KZs8y6mdxiBcIYH3rtm1wKD5Vb68EHWkSEMrZfB+avLqCs0pbecIMVCGN85GBZJc8s3szZPRMZltrW7ThB4bLByRwqr+LT9XY7UjdYgTDGR579fDMHSir57YW93I4SNM7oHk+7VpG8a91MrrACYYwP5B8o5cUvt3LZ4GT6Jce5HSdohIYIEwYl8/mGPRQdqXA7TrNjBcIYH/jbgg0A3GGtB5+bOCiZqhrlg9UFbkdpdqxAGHOKVuUdYM7yfG4YmUpy6xZuxwk66R1b0bt9LHNshdcmZwXCmFOgqjz4wTrioyO4+ZzubscJWhMGJbNs+wG27ytxO0qzYgXCmFOwcO1ulmwt4rbzexIbFe52nKA1fpBnPav3VthgdVOyAmFMI5VVVvOnD9bSIymGyUM7nfgE02jJrVswPLUtc1fko2pLbzQVRwuEiIwVkQ0ikiMid9Wzf5SILBORKhG5ss6+a0Vkk/fnWidzGtMYz3y+mR1FpUwb35fwUPu3ltMmDk5mc+ER1uQfdDtKs+HYb7WIhAJPAxcB6cAUEUmvc9h24Dpgep1z2wL3A8OBYcD9ItLGqazGnKxt+47wzOLNXDqwI2f2sCU1msLF/ToQERrCXOtmajJO/rNnGJCjqltUtQKYAUyofYCq5qrqKqCmzrkXAgtVtUhV9wMLgbEOZjWmwVSV++dlEx4i3Duuj9txmo24luGc0yuR91fupNpWeG0SThaIZGBHred53m0+O1dEbhSRTBHJLCwsbHRQY07Gx2t38/mGQm4/vyft7J7JTeqywcnsOVTON5v3uR2lWQjojlNVfV5VM1Q1IzEx0e04phkoLq3kvvfW0Lt9LNee2dXtOM3Oub2TiI0KsxsJNREnC0Q+UPvSjhTvNqfPNcYxD36wlsJD5Txy5QAbmHZBVHgoF/Vrz4LsXbbCaxNw8jd8KZAmIqkiEgFMBuY18NwFwAUi0sY7OH2Bd5sxrlm8sZCZmXncOKo7A1Jaux2n2Zo4KJnD5VUsWrfb7ShBz7ECoapVwFQ8X+zrgJmqmi0i00RkPICIDBWRPGAS8JyIZHvPLQL+hKfILAWmebcZ44pDZZXcPXsV3ROjuW1MmttxmrXh3eJp3yqKudbN5LgwJ19cVecD8+tsu6/W46V4uo/qO/cl4CUn8xnTUPfPy2bXwTLeuelMosJD3Y7TrIWGCOMHdeSlL7ey/0gFbaIj3I4UtBrUghCRd0VknIhYp6tpduYsz+PdZflMPS+NIV1sOo4/mDCoo63w2gQa+oX/L+BqYJOIPCQitqaxaRa27j3CvXPWMKxrW245r4fbcYxXeodWpCXF2NpMDmtQgVDVRar6Q+A0IBdYJCJfi8j1ImIrlJmgVFpRzdTpywgLDeGJyYMIs6uW/IaIMHFwMktz97OjyFZ4dUqDf+NFJB7Pshg/BZYD/8BTMBY6kswYF6kqd85exdqCgzx+1UA62n0e/M4E7wqv81budDlJ8GroGMQc4D9AS+BSVR2vqm+r6q+AGCcDGuOGZxZv5v2VO7njgl6c17ud23FMPVLatGRo1zbMXW4rvDqloS2I/1PVdFX9q6oWAIhIJICqZjiWzhgXfLi6gEcXbODSgR35hd0EyK9NGJTMpj2HWVtgK7w6oaEF4s/1bPvGl0GM8Qdf5+zl1hkrOK1zGx65YgAi4nYkcxzj+ncgPFRsToRDjlsgRKS9iAwBWojIYBE5zftzDp7uJmOCxrLt+/nZa5mkJkTz0rVDaRFh8x38XZvoCM7umcQ8W+HVESeaKHchnoHpFOCxWtsPAfc4lMmYJvfN5n389NWlJMRG8toNw4hraRfnBYqJgzuyaN1ulmzZZ/fm8LHjFghVfRV4VUSuUNXZTZTJmCa1cO1upk5fRue2LXnzp8NJsiW8A8qYPu2IiQxj7op8KxA+dtwCISI/UtU3gK4i8uu6+1X1sXpOM81EdY2yKu8AWdv2s3H3IXL3llBUUsHB0kpCQ4SwUKF1iwjax0WR3LoF6R1akd6xFWntYogMc7/7RlX51+eb+dvHG+ifHMfL1w0lPibS7VjmJEWFhzK2X3s+XL2LaRP62VIoPnSiLqZo7592KasBPF+qS3P3MzNzB4vW7eZASSUACTERdEuIIS0phlZR4dSoUlldw/6SSrbvK+GrnL2UVHiWZ44KD2FIlzac2T2BM7rHMzClNaEhTTsYvO9wOffMWc2C7N2MH9iRR64cYF8sAWzioGRmZeXx6fo9XNy/g9txgsaJupie8/75x6aJY/xVTY3yUfYunvxkE+t3HSI6IpQL+7Xn7J6JnNE9nqTY43fL1NQo24pKyN5ZTNa2/XyzeR+PLtgAQHx0BOf2TmJMn3aclZZAdKRza0iqKh+t2cUf3lvDwdIqfn9xH356VqpdrRTgPL+Dkcxdnm8Fwoca9DdRRB7Bc6lrKfARMAC43dv9ZIJcZm4Rf3gvm3UFB+meGM0jVwxg3IAOJ/VFHhIipCZEk5oQzSUDPDNg9x0u56vN+/hk3W4+zt7FrKw8IsJCGNE9ntF92nFe7ySfzmBetn0/D81fz3e5RfTp0Io3fjqQ3u1b+ez1jXtCQ4TxAzvy6je5HCipoHVLW+HVF6QhMxBFZIWqDhKRy4BLgF8DX6jqQKcDNlRGRoZmZma6HSOoHC6v4sEP1vLWdzvoGBfF7y7qzSUDOjrSHVRZXcPS3CIWrd3DonW72e5dX6d7YjSjeiYyKi2RYaltT7p1UVxayaK1u3n9222s2HGAhJgIbj+/J1dldLK1lYLMmvxiLvnnl/zlsv5cPbyz23EChohkHWvCc0MLxBpV7SciLwCzVPUjEVlpBSJ4Ze8sZur05Wzbd4QbRqZy25iejnb91Kaq5Ow5zOKNhXyxaS9LtuyjvKqGEIEeSTH0T25N7/axdGzdgg6to2gVFUaICDWqFB2ppKC4lLUFB1m54wCZufupqlG6JURzzRlduDKjEzFN9DlM01JVxjy2mPiYSGb+/Ay34wSM4xWIhv5N+beIrMfTxXSziCQCZb4KaPzLzMwd3Dt3DW1ahjP9Z6dzerf4Jn1/ESGtXSxp7WL56VndKKus5rutRWRt28/q/GIWbyxk9rK8475GeKjQq30sPxvVjTF9khjcqQ0hTTwQbpqWiDBxUDJ/X7iR/AOlJNsCi6esQS0IABFpCxSrarWItARaqequE5wzFs+qr6HAC6r6UJ39kcBrwBBgH3CVquZ6lxB/Ac9qsWHAa6r61+O9l7UgTp2q8vjCjTz5aQ4jeyTwj8mD/PKyT1XlYFkVBcWlFBwo40hF1X9n0cZHR5IYG0lqQjQRYdaF1Nxs31fCqEc/486xvfjFOXb/jobwRQsCoDee+RC1z3ntOG8aCjwNnA/kAUtFZJ6qrq112A3AflXtISKTgYeBq/DcozpSVft7i9FaEXlLVXNPIq85CVXVNfxu9mpmL8vjBxkpPHhZf8L9tI9eRIhrEU5ci3AbZDb/o3N8S4Z0acN7y3dagfCBhi73/TrwN2AkMNT7c6JVXIcBOaq6RVUrgBnAhDrHTABe9T6eBYwWz/WGCkR7i1ELoAKw5RodUlVdw69nrmT2sjxuH9OTh68Y4LfFwZgTmTioIxt2H2KdrfB6yhragsgA0vXkFl1PBnbUep4HDD/WMapaJSLFQDyeYjEBKMCzKODtqlpU9w1E5EbgRoDOne2qhcY4WhzmrdzJ78b25mZb3toEuHEDOvLH99cyd0U+fTpYC/NUNPSfiWuA9k4GqWMYUA10BFKB34hIt7oHqerzqpqhqhmJiYlNGC84qCq/n7PGioMJKm2jIzi7ZyLzVuykxlZ4PSUNLRAJeMYBFojIvKM/JzgnH+hU63mKd1u9x3i7k+LwDFZfDXykqpWqugf4ihN3aZmT9MSiTbyduYNfndfDioMJKhMGJ1NQXMaSrd/reDAnoaFdTA804rWXAmkikoqnEEzG88Vf2zzgWjw3H7oS+FRVVUS2A+cBr4tINHA68EQjMphjeHvpdv7xySauHJLCr8/v6XYcY3zq/D7tiI4I5b0V+ZzRvWkv0w4mDWpBqOpiIBcI9z5eCiw7wTlVwFRgAbAOmKmq2SIyTUTGew97EYgXkRw8s7Pv8m5/GogRkWzve72sqqtO6pOZY/p6817umbOGUT0T+evl/W0dIhN0WkSEcmHf9nywuoCyymq34wSshq7F9DM8g8Ftge54BpefBUYf7zxVnQ/Mr7PtvlqPy/Bc0lr3vMP1bTenLv9AKVOnLyc1IZp//fA0u1rJBK2Jg5N5d3k+n2/Yw9h+toBfYzT02+GXwAi8l5qq6iYgyalQxhllldXc9HoWlVU1PP/jIbbkhAlqZ3aPJyEmkrnLd7odJWA1tECUe+cyAP8dULbLAwKIqnLv3DWszi/msasG0S3RbvFhgltYaAiXDuzAp+v3UFxa6XacgNTQArFYRO4BWojI+cA7wPvOxTK+9k5WHrOy8rhldBrnp7dzO44xTWLioGQqqmv4cHWB21ECUkMLxF1AIbAa+DmecYV7nQplfGtL4WEemJfNGd3iuXV0mttxjGkyA1Li6JYQzdwVda+wNw3RoE5oVa0RkbnAXFUtdDiT8aGKqhpunbGCiLAQHrtqYJPf2tMYN4kIEwYl88QnGykoLqVDnK3wejKO24IQjwdEZC+wAdggIoUict/xzjP+4+8LN7A6v5iHLh9gfzlMszRhUEdU4b0VNlh9sk7UxXQ7nquXhqpqW1Vti2c9pREicrvj6cwp+SpnL88t3sLVwzsztl9TrpRijP/omhDNaZ1bMzsrj5NbTs6cqED8GJiiqluPblDVLcCPgGucDGZOzaGySu6ctYpuidH8YVy623GMcdUPMjqxac9hVuw44HaUgHKiAhGuqnvrbvSOQ4Q7E8n4wl8/XE9BcSl/mzSQFhGhbscxxlXjBnSgRXgoMzN3nPhg818nKhAVjdxnXPRVzl6mL9nODSNTOa1zG7fjGOO62Khwxg3owPsrCyipqHI7TsA4UYEYKCIH6/k5BPRvioDm5Bwpr+J3s1fRLSGa31zQy+04xviNH2R04nB5FfNXH/dOyaaW4xYIVQ1V1Vb1/MSqqnUx+aGHP1pP/oFSHrlyAFHh1rVkzFFDu7YhNSHauplOgq3UFkQyc4t47ZttXH9mKhld27odxxi/IiJMykjhu61FbN17xO04AcEKRJCoqq7h3rlr6BgXxR0X2v0djKnPFaelECLwjrUiGsQKRJB449ttrN91iHsvSadlhK3Sakx92rWK4txeSczKyqOqusbtOH7PCkQQKDxUzt8XbuSstAQusglxxhzXpIxO7DlUzhebbNWgE3G0QIjIWBHZICI5InJXPfsjReRt7/4lItK11r4BIvKNiGSLyGoRiXIyayB76MP1lFVW88D4vnZ3OGNOYHSfJBJiInh7qXUznYhjBUJEQvHcOvQiIB2YIiJ1p/TeAOxX1R7A48DD3nPDgDeAm1S1L3AOYAu61yNrWxGzl+Vxw8hudLd7PBhzQuGhIVw2OJlP1u2h8FC523H8mpMtiGFAjqpu8d5saAYwoc4xE4BXvY9nAaPF80/gC4BVqroSQFX3qardWLaOquoa/jA3mw5xUfzqvB5uxzEmYFw1tBNVNco7WdaKOB4nC0QyUPu/fp53W73HqGoVUAzEAz0BFZEFIrJMRO50MGfAenPJdtYWHOTecelE2+1DjWmwHkmxDE9ty/Ql26mpsQX8jsVfB6nDgJHAD71/XiYio+seJCI3ikimiGQWFjavAae9h8v528cbGNEjnov728C0MSfrR6d3IW9/KYttsPqYnCwQ+UCnWs9TvNvqPcY77hAH7MPT2vhCVfeqagmeO9idVvcNVPV5Vc1Q1YzExEQHPoL/etg7MP3H8f1sYNqYRriwb3sSYiJ589ttbkfxW04WiKVAmoikikgEMBmYV+eYecC13sdXAp+qZ8H2BUB/EWnpLRxnA2sdzBpQsrbt552sPH4yMpUeSTYwbUxjRISFcNXQFD5dv4f8A6Vux/FLjhUI75jCVDxf9uuAmaqaLSLTRGS897AXgXgRyQF+jefe16jqfhraEtQAABIcSURBVOAxPEVmBbBMVT9wKmsgqa5R7ntvDe1bRXHLeXZ/aWNOxZRhnVHgrSXb3Y7ilxwd2VTV+Xi6h2pvu6/W4zJg0jHOfQPPpa6mlulLtpG98yBPXT3YBqaNOUUpbVpyXq8kZizdwS2j04gI89dhWXfYf40Asu9wOY8u2MCZ3eMZ17+D23GMCQo/Or0Lew+X8/FaWwa8LisQAeThj9ZTUlHNtAk2Y9oYXxnVM5GUNi14wwarv8cKRIDI2rafmZl53DAylR5JsW7HMSZohIYIU4Z15tstRWzafcjtOH7FCkQAqK5R7p+3hnatIvnVaBuYNsbXJg/tRGRYCC9/net2FL9iBSIATP9uO2vyPTOmY2xg2hifi4+J5LLByby7LI/9RyrcjuM3rED4uX2Hy3n0o/Wc2T2eSwbYwLQxTrl+RCpllTVM/84ueT3KCoSfe+SjDZRUVPNHW8rbGEf1ah/LyB4JvPZNLpV2MyHACoRfW7Z9P29n7uAnI1NJa2cD08Y47Scju7L7YDnzVxe4HcUvWIHwU0dnTLdrFcktNjBtTJM4p2cS3RKieenLrXhW/WnerED4qbe8A9P3XNzHBqaNaSIhIcL1I7qyMq+YZdv3ux3HdVYg/FDRkQoeXbCB07u1ZfzAjm7HMaZZufy0FFpFhfHil1vdjuI6KxB+6JGP1nOkvIppE2wpb2OaWnRkGFcP78JHa3aRu/eI23FcZQXCz6zYcYC3M3dw3Zld6WkD08a44icjuxIWGsJzX2x2O4qrrED4kaMD04kxkdw6xgamjXFLUmwUk4akMDsrn90Hy9yO4xorEH7kre+2syqvmN+P60NsVLjbcYxp1n4+qjtVNTXNeizCCoSf2Hu4nEc+Ws8Z3eJtYNoYP9A5viWXDOjIm99uo7ik0u04rrAC4Sce+nA9pZXV/GmizZg2xl/cfE53jlRU89o3uW5HcYWjBUJExorIBhHJEZG76tkfKSJve/cvEZGudfZ3FpHDInKHkzndtjS3iFlZefz0rG62lLcxfqRPh1ac1zuJl7/OpaSiyu04Tc6xAiEiocDTwEVAOjBFRNLrHHYDsF9VewCPAw/X2f8Y8KFTGf1BVXUNf5i7huTWLfjVeT3cjmOMqeOX53an6EgFr3/T/G4o5GQLYhiQo6pbVLUCmAFMqHPMBOBV7+NZwGjx9q+IyERgK5DtYEbXvfJ1Lut3HeK+S9NpGWEzpo3xN0O6tOWstASeXbyZw+XNqxXhZIFIBnbUep7n3VbvMapaBRQD8SISA/wO+OPx3kBEbhSRTBHJLCws9FnwprKruIzHF27k3F6JXJDezu04xphj+M0FvdhfUsmrzeyGQv46SP0A8LiqHj7eQar6vKpmqGpGYmJi0yTzoT9/sJaqGuWP423GtDH+bFCn1ozuncTzX2zhYFnzuaLJyQKRD3Sq9TzFu63eY0QkDIgD9gHDgUdEJBe4DbhHRKY6mLXJLd5YyL9XFfCLc3rQOb6l23GMMSdw+/k9KS6t5KVmNC/CyQKxFEgTkVQRiQAmA/PqHDMPuNb7+ErgU/U4S1W7qmpX4AngL6r6lINZm9SR8irueXc13ROj+fnZ3dyOY4xpgH7JcVzYtx0v/mcrB0qax21JHSsQ3jGFqcACYB0wU1WzRWSaiIz3HvYinjGHHODXwPcuhQ1Gjy3cSP6BUh66YgBR4aFuxzHGNNDt5/fkcEUVzy7e4naUJuHoZTOqOh+YX2fbfbUelwGTTvAaDzgSziUrdhzg5a+28qPTOzO0a1u34xhjTkLv9q2YOCiZl7/ayo/P6EJy6xZuR3KUvw5SB6XK6hrumr2KpNgo7hzb2+04xphGuOPCXijw9wUb3I7iOCsQTej5L7awftch/jSxH61sMT5jAlJy6xbcMDKVd5fnszqv2O04jrIC0UQ2Fx7mH59sYlz/Dpxvcx6MCWi/OKc78dERPDh/bVDfu9oKRBOoqq7ht++spEV4KPePr7vaiDEm0MRGhXPbmDS+3VLEonV73I7jGCsQTeC5L7awbPsBpk3oS1JslNtxjDE+MHlYZ7onRvPnD9ZSVlntdhxHWIFw2NqdB3li0UbG9e9g93kwJoiEh4YwbUI/tu0r4dnFwXlrUisQDiqvqubXM1cQ1yKCP0205TSMCTYjeiRwyYAO/OvzzWzbd8TtOD5nBcJB/1i0ifW7DvHwFf1pGx3hdhxjjAPuHZdOeIjwwLzsoBuwtgLhkO+2FvHs4s1cldGJ0X3sqiVjglX7uChuG9OTzzYU8vHa3W7H8SkrEA7Yf6SCW2csp3PblvzhUrtqyZhgd92IrvRqF8t9762huDR4Vnu1AuFjqspvZ61i7+Fynrr6NGIi7SZAxgS78NAQHp00gL2HK/jzv9e6HcdnrED42Ktf57Jo3W7uvqgP/ZLj3I5jjGkiA1Ja8/NR3XgnK4/PNwTH3AgrED60Jr+Yv8xfz+jeSVw/oqvbcYwxTezWMWmkJcVw97urg+LGQlYgfGT/kQpueiOL+JgIHp000C5pNaYZigwL5dFJA9l9sIxp7wd+V5MVCB+orlFumbGcPQfLeeZHQ+ySVmOasUGdWvPLc3swKyuPeSt3uh3nlFiB8IFHF2zgP5v28qeJfRnUqbXbcYwxLrt1dBpDurThnndXs31fidtxGs0KxCn6YFUBzy7ezA+Hd+aqoZ3djmOM8QNhoSH8Y/IgQgR+NWM5ldU1bkdqFEcLhIiMFZENIpIjIt+7naiIRIrI2979S0Skq3f7+SKSJSKrvX+e52TOxlq54wC/eWcFp3Vuzf2X9nU7jjHGj6S0aclDVwxg5Y4DPPjBOrfjNIpjBUJEQoGngYuAdGCKiNSdNXYDsF9VewCPAw97t+8FLlXV/sC1wOtO5WysHUUl3PBqJgkxkTz34wwiwqwxZoz5Xxf378BPRqTyyte5zM7KczvOSXPyW20YkKOqW1S1ApgBTKhzzATgVe/jWcBoERFVXa6qR0d3soEWIhLpYNaTUlxayfWvLKWiqppXrh9KYqzfRDPG+Jl7Lu7NGd3iuXvOalblHXA7zklxskAkAztqPc/zbqv3GFWtAoqB+DrHXAEsU9Xyum8gIjeKSKaIZBYWFvos+PGUVVZz0+tZbNt3hOd+nEGPpNgmeV9jTGAKCw3hqasHkxgTyc9fz2LPwTK3IzWYX/eLiEhfPN1OP69vv6o+r6oZqpqRmJjoeJ7K6hqmTl/GN1v28eiVAzmje91aZowx3xcfE8nz1wyhuLSS615eyqEAmUTnZIHIBzrVep7i3VbvMSISBsQB+7zPU4A5wDWq6vrdOKprlNvfXsGidXv408R+TBxctzFkjDHH1rdjHP/64Wls2H2Im99YRkWV/1/Z5GSBWAqkiUiqiEQAk4F5dY6Zh2cQGuBK4FNVVRFpDXwA3KWqXzmYsUFqapS7313Fv1cVcPdFvfnx6V3cjmSMCUDn9Eriocv782XOXu6ctZKaGv++f4RjS42qapWITAUWAKHAS6qaLSLTgExVnQe8CLwuIjlAEZ4iAjAV6AHcJyL3ebddoKpNvgJWVXUNv521ijnL87lldBo/P7t7U0cwxgSRSRmd2HOonEcXbCAiLISHLh9ASIh/Ls0jwXIHpIyMDM3MzPTpa1ZU1XDLW8v5KHsXv72wF788t4dPX98Y03w99vEGnvw0hynDOvHgxP6uFQkRyVLVjPr22c0KjuFIeRW/eHMZizcW8odL0rlhZKrbkYwxQeT283tSrcrTn22mpgYevKwfYaH+dd2QFYh6FBSXcsMrmazfdZCHLu/P5GG2hIYxxrdEhDsu6EWoCE9+msP+kgqenDKYqPBQt6P9l3+VKz+wJr+YiU9/xfaiEl66bqgVB2OMY0SEX1/QiwcuTWfhut1c8+J3FJf4zyWwViBqmbs8n0nPfkOoCLNuPoNzeiW5HckY0wxcNyKVf04ZzIodBxj/9Jds3H3I7UiAFQjAMzv6njmrue3tFfRPjmPuL0fQu30rt2MZY5qRSwZ05K0bh1NSUc1lT3/FR2t2uR3JCkRBcSlXPvs105ds56azuzP9Z8NJahXldixjTDM0pEtb3p86kh7tYrnpjSwemJdNWWW1a3mafYGIjQonIjSEF67J4K6LevvdVQTGmOalfVwUb994+n9XgR3/1Jes3XnQlSw2DwJQVbuHtDHG7yzeWMgd76ykuKSSm87uxi/O7eHzq5yONw/C/rkMVhyMMX7p7J6JLLhtFBf3b8+Tn+Zw4RNf8PmGpltQwgqEMcb4sbbRETwxeTDTfzqcUBGue3kp17z0HWvyix1/bysQxhgTAM7skcCHt53F7y/uw6q8A1zyzy/55fRlbNjl3CWxNgZhjDEB5mBZJf/3xRZe/HIrJRXVjBvQgaemDG5Ud7mtxWSMMUGkVVQ4v7mgFz8Zkcpr32yjorrakbFUKxDGGBOg2kRHcOuYNMde38YgjDHG1MsKhDHGmHo5WiBEZKyIbBCRHBG5q579kSLytnf/EhHpWmvf3d7tG0TkQidzGmOM+T7HCoSIhAJPAxcB6cAUEUmvc9gNwH5V7QE8DjzsPTcdz+1H+wJjgX95X88YY0wTcbIFMQzIUdUtqloBzAAm1DlmAvCq9/EsYLR4huInADNUtVxVtwI53tczxhjTRJwsEMnAjlrP87zb6j1GVauAYiC+geciIjeKSKaIZBYWFvowujHGmIAepFbV51U1Q1UzEhMT3Y5jjDFBxckCkQ90qvU8xbut3mNEJAyIA/Y18FxjjDEOcmypDe8X/kZgNJ4v96XA1aqaXeuYXwL9VfUmEZkMXK6qPxCRvsB0POMOHYFPgDRVPeadM0SkENh2CpETgL2ncL6/CJbPAfZZ/FWwfJZg+Rxwap+li6rW2wXj2ExqVa0SkanAAiAUeElVs0VkGpCpqvOAF4HXRSQHKMJz5RLe42YCa4Eq4JfHKw7ec06pj0lEMo+1HkkgCZbPAfZZ/FWwfJZg+Rzg3GdxdKkNVZ0PzK+z7b5aj8uAScc490HgQSfzGWOMObaAHqQ2xhjjHCsQ/9/zbgfwkWD5HGCfxV8Fy2cJls8BDn2WoLkfhDHGGN+yFoQxxph6WYEwxhhTLysQXiLyqIisF5FVIjJHRFq7nelknWj13EAhIp1E5DMRWSsi2SJyq9uZToWIhIrIchH5t9tZToWItBaRWd6/J+tE5Ay3MzWWiNzu/d1aIyJviUiU25kaSkReEpE9IrKm1ra2IrJQRDZ5/2zji/eyAvH/LQT6qeoAPBP87nY5z0lp4Oq5gaIK+I2qpgOnA78M4M8CcCuwzu0QPvAP4CNV7Q0MJEA/k4gkA7cAGaraD888rcnupjopr+BZ5bq2u4BPVDUNz8Rin/wD0QqEl6p+7F0wEOBbPMt7BJKGrJ4bEFS1QFWXeR8fwvNF9L3FGgOBiKQA44AX3M5yKkQkDhiFZ3IrqlqhqgfcTXVKwoAW3hUfWgI7Xc7TYKr6BZ6JxbXVXhn7VWCiL97LCkT9fgJ86HaIk9SgFXADjfcmUoOBJe4mabQngDuBGreDnKJUoBB42dtd9oKIRLsdqjFUNR/4G7AdKACKVfVjd1OdsnaqWuB9vAto54sXbVYFQkQWefsc6/5MqHXM7/F0cbzpXlIDICIxwGzgNlU96HaekyUilwB7VDXL7Sw+EAacBjyjqoOBI/ioG6OpefvnJ+Apeh2BaBH5kbupfEc9cxd8Mn/B0aU2/I2qjjnefhG5DrgEGK2BN0EkqFbAFZFwPMXhTVV91+08jTQCGC8iFwNRQCsReUNVA/HLKA/IU9WjLblZBGiBAMYAW1W1EEBE3gXOBN5wNdWp2S0iHVS1QEQ6AHt88aLNqgVxPCIyFk9XwHhVLXE7TyMsBdJEJFVEIvAMus1zOVOjeO8q+CKwTlUfcztPY6nq3aqaoqpd8fz/+DRAiwOqugvYISK9vJtG41lMMxBtB04XkZbe37XRBOiAey3zgGu9j68F3vPFizarFsQJPAVEAgs9vzN8q6o3uRup4Y61eq7LsRprBPBjYLWIrPBuu8e7+KNxz6+AN73/ANkCXO9ynkZR1SUiMgtYhqc7eTkBtOyGiLwFnAMkiEgecD/wEDBTRG7Ac9uDH/jkvQKvJ8UYY0xTsC4mY4wx9bICYYwxpl5WIIwxxtTLCoQxxph6WYEwxhhTLysQxhhj6mUFwhhjTL3+H/48AhSaqm/xAAAAAElFTkSuQmCC",
             "text/plain": [
               "<Figure size 432x288 with 1 Axes>"
             ]
           },
           "metadata": {
             "needs_background": "light"
-          }
+          },
+          "output_type": "display_data"
         }
+      ],
+      "source": [
+        "df = pd.DataFrame(np.random.randint(10, size=(10,4)), columns=list(\"ABCD\"))\n",
+        "\n",
+        "df.A.plot.density()\n",
+        "plt.show()"
       ]
     },
     {
@@ -6201,34 +6178,34 @@
     },
     {
       "cell_type": "code",
+      "execution_count": 108,
       "metadata": {
         "colab": {
           "base_uri": "https://localhost:8080/",
           "height": 265
         },
         "id": "0jZ43AtaA9xk",
-        "outputId": "dba10184-7095-43a5-bf76-ca472f008468"
+        "outputId": "f9c00f1b-ea32-4020-8534-4a2b582f3885"
       },
-      "source": [
-        "df = pd.DataFrame(np.random.randint(10, size=(20,4)), columns=list(\"ABCD\"))\n",
-        "\n",
-        "df.A.plot.hist()\n",
-        "plt.show()"
-      ],
-      "execution_count": 454,
       "outputs": [
         {
-          "output_type": "display_data",
           "data": {
-            "image/png": "iVBORw0KGgoAAAANSUhEUgAAAXgAAAD4CAYAAADmWv3KAAAABHNCSVQICAgIfAhkiAAAAAlwSFlzAAALEgAACxIB0t1+/AAAADh0RVh0U29mdHdhcmUAbWF0cGxvdGxpYiB2ZXJzaW9uMy4yLjIsIGh0dHA6Ly9tYXRwbG90bGliLm9yZy+WH4yJAAANQ0lEQVR4nO3dfYxldX3H8feHXRoeJGLDlLYs42BjoEShbAe1pdqI1aKr9CltMcU/TOM0KW2hNdGFmNb+0QSTVrFN27BFWxXUKg/GAlohPjQmLbgLtAIr0eCKPDQsbegulLg8fPvH3O3OwO7Omb33zJn57fuVTLj3zr33990T5p0zZ86cSVUhSWrPEUMPIEnqh4GXpEYZeElqlIGXpEYZeElq1PqhB1johBNOqJmZmaHHkKQ1Y9u2bY9V1dT+PreqAj8zM8PWrVuHHkOS1owk3zvQ5zxEI0mNMvCS1CgDL0mNMvCS1CgDL0mNMvCS1KheT5NMsgPYDTwLPFNVs32uJ0naZyXOg399VT22AutIkhbwEI0kNarvPfgCvpSkgCurasvzn5BkDpgDmJ6e7nkcaW2Z2XzTYGvvuHzTYGtrMvreg/+5qtoIvBm4KMnrnv+EqtpSVbNVNTs1td/LKUiSDkGvga+qh0b/fRS4AXhVn+tJkvbpLfBJjk1y3N7bwJuAu/taT5K0WJ/H4E8Ebkiyd51PVtUXe1xPkrRAb4GvqvuBM/t6f0nSwXmapCQ1ysBLUqMMvCQ1ysBLUqMMvCQ1ysBLUqMMvCQ1ysBLUqMMvCQ1ysBLUqMMvCQ1ysBLUqMMvCQ1ysBLUqMMvCQ1ysBLUqMMvCQ1ysBLUqMMvCQ1ysBLUqMMvCQ1ysBLUqMMvCQ1ysBLUqMMvCQ1ysBLUqMMvCQ1ysBLUqMMvCQ1ysBLUqMMvCQ1ysBLUqN6D3ySdUnuTHJj32tJkvZZiT34i4HtK7COJGmBXgOfZAOwCbiqz3UkSS/U9x78FcB7gOcO9IQkc0m2Jtm6c+fOnseRpMNHb4FP8lbg0aradrDnVdWWqpqtqtmpqam+xpGkw06fe/DnAOcn2QF8Gjg3ydU9ridJWqC3wFfVpVW1oapmgAuAL1fVhX2tJ0lazPPgJalR61dikar6KvDVlVhLkjTPPXhJapSBl6RGGXhJapSBl6RGGXhJapSBl6RGGXhJapSBl6RGGXhJapSBl6RGGXhJapSBl6RGGXhJapSBl6RGGXhJapSBl6RGGXhJapSBl6RGGXhJapSBl6RGGXhJapSBl6RGGXhJapSBl6RGGXhJapSBl6RGGXhJapSBl6RGdQp8klf2PYgkabK67sH/TZLbk/xukhf3OpEkaSI6Bb6qXgv8FnAysC3JJ5O8sdfJJElj6XwMvqq+DbwPeC/w88BfJvlWkl/tazhJ0qHregz+jCQfArYD5wJvq6qfHN3+0AFec9TosM6/J7knyZ9ObGpJ0pLWd3zeXwFXAZdV1VN7H6yqh5O87wCv+QFwblU9keRI4OtJvlBV/zbeyJKkLroGfhPwVFU9C5DkCOCoqvrfqvrE/l5QVQU8Mbp75OijxpxXktRR12PwtwJHL7h/zOixg0qyLsldwKPALVV12/JHlCQdiq578EdV1d69cUaHXY5Z6kWjPf6fSnI8cEOSV1TV3Qufk2QOmAOYnp7uPrkkTdjM5psGWXfH5Zt6ed+ue/BPJtm4906SnwaeOsjzF6mqx4GvAOft53Nbqmq2qmanpqa6vqUkaQld9+AvAT6b5GEgwI8Cv3mwFySZAp6uqseTHA28EfjAOMNKkrrrFPiq+kaS04BTRw/dV1VPL/GyHwM+lmQd898pfKaqbjz0USVJy9F1Dx7gbGBm9JqNSaiqjx/oyVX1H8BZ440nSTpUnQKf5BPATwB3Ac+OHi7ggIGXJA2r6x78LHD66Nx2SdIa0PUsmruZ/8GqJGmN6LoHfwJwb5Lbmb8EAQBVdX4vU0mSxtY18O/vcwhJ0uR1PU3ya0leCry8qm4d/Rbrun5HkySNo+vlgt8FXAtcOXroJOBzfQ0lSRpf1x+yXgScA+yC///jHz/S11CSpPF1DfwPqmrP3jtJ1uOlfyVpVesa+K8luQw4evS3WD8L/FN/Y0mSxtU18JuBncA3gd8Bbmb+77NKklaprmfRPAf83ehDkrQGdL0WzXfZzzH3qnrZxCeSJE3Ecq5Fs9dRwK8DPzz5cSRJk9LpGHxV/deCj4eq6grm/xC3JGmV6nqIZuOCu0cwv0e/nGvJS5JWWNdI/8WC288AO4DfmPg0kqSJ6XoWzev7HkSSNFldD9H80cE+X1UfnMw4kqRJWc5ZNGcDnx/dfxtwO/DtPoaSJI2va+A3ABurajdAkvcDN1XVhX0NJkkaT9dLFZwI7Flwf8/oMUnSKtV1D/7jwO1Jbhjd/2XgY/2MJEmahK5n0fxZki8Arx099M6qurO/sSRJ4+p6iAbgGGBXVX0YeDDJKT3NJEmagK5/su9PgPcCl44eOhK4uq+hJEnj67oH/yvA+cCTAFX1MHBcX0NJksbXNfB7qqoYXTI4ybH9jSRJmoSugf9MkiuB45O8C7gV//iHJK1qS55FkyTAPwKnAbuAU4E/rqpbep5NkjSGJQNfVZXk5qp6JWDUJWmN6HqI5o4kZ/c6iSRporr+JuurgQuT7GD+TJowv3N/Rl+DSZLGc9DAJ5muqgeAX1zuGyc5mflLHJzI/Nk3W0a/JCVJWgFL7cF/jvmrSH4vyXVV9WvLeO9ngHdX1R1JjgO2Jbmlqu495GklSZ0tdQw+C26/bDlvXFWPVNUdo9u7ge3AScsbT5J0qJbag68D3F6WJDPAWcBt+/ncHDAHMD09fahLMLP5pkN+7Vq14/JNg6w75LYe6t+slXM4fi33Zak9+DOT7EqyGzhjdHtXkt1JdnVZIMmLgOuAS6rqBa+pqi1VNVtVs1NTU8v/F0iS9uuge/BVtW6cN09yJPNxv6aqrh/nvSRJy7OcywUvy+g3YD8CbPePckvSyust8MA5wDuAc5PcNfp4S4/rSZIW6PqLTstWVV9n8Vk4kqQV1OcevCRpQAZekhpl4CWpUQZekhpl4CWpUQZekhpl4CWpUQZekhpl4CWpUQZekhpl4CWpUQZekhpl4CWpUQZekhpl4CWpUQZekhpl4CWpUQZekhpl4CWpUQZekhpl4CWpUQZekhpl4CWpUQZekhpl4CWpUQZekhpl4CWpUQZekhpl4CWpUQZekhpl4CWpUQZekhrVW+CTfDTJo0nu7msNSdKB9bkH/w/AeT2+vyTpIHoLfFX9C/Dffb2/JOng1g89QJI5YA5genp64GnWlpnNNw09woo7HP/NQ3Fbr32D/5C1qrZU1WxVzU5NTQ09jiQ1Y/DAS5L6YeAlqVF9nib5KeBfgVOTPJjkt/taS5L0Qr39kLWq3t7Xe0uSluYhGklqlIGXpEYZeElqlIGXpEYZeElqlIGXpEYZeElqlIGXpEYZeElqlIGXpEYZeElqlIGXpEYZeElqlIGXpEYZeElqlIGXpEYZeElqlIGXpEYZeElqlIGXpEYZeElqlIGXpEYZeElqlIGXpEYZeElqlIGXpEYZeElqlIGXpEYZeElqlIGXpEYZeElqlIGXpEYZeElqVK+BT3JekvuSfCfJ5j7XkiQt1lvgk6wD/hp4M3A68PYkp/e1niRpsT734F8FfKeq7q+qPcCngV/qcT1J0gLre3zvk4DvL7j/IPDq5z8pyRwwN7r7RJL7DnG9E4DHDvG1rXFbLOb2WMztsc+q2Bb5wFgvf+mBPtFn4Dupqi3AlnHfJ8nWqpqdwEhrnttiMbfHYm6PfVrfFn0eonkIOHnB/Q2jxyRJK6DPwH8DeHmSU5L8EHAB8Pke15MkLdDbIZqqeibJ7wH/DKwDPlpV9/S1HhM4zNMQt8Vibo/F3B77NL0tUlVDzyBJ6oG/ySpJjTLwktSoNR94L4ewT5KTk3wlyb1J7kly8dAzDS3JuiR3Jrlx6FmGluT4JNcm+VaS7Ul+ZuiZhpTkD0dfJ3cn+VSSo4aeadLWdOC9HMILPAO8u6pOB14DXHSYbw+Ai4HtQw+xSnwY+GJVnQacyWG8XZKcBPwBMFtVr2D+RJALhp1q8tZ04PFyCItU1SNVdcfo9m7mv4BPGnaq4STZAGwCrhp6lqEleTHwOuAjAFW1p6oeH3aqwa0Hjk6yHjgGeHjgeSZurQd+f5dDOGyDtlCSGeAs4LZhJxnUFcB7gOeGHmQVOAXYCfz96JDVVUmOHXqooVTVQ8CfAw8AjwD/U1VfGnaqyVvrgdd+JHkRcB1wSVXtGnqeISR5K/BoVW0bepZVYj2wEfjbqjoLeBI4bH9mleQlzH+3fwrw48CxSS4cdqrJW+uB93IIz5PkSObjfk1VXT/0PAM6Bzg/yQ7mD92dm+TqYUca1IPAg1W19zu6a5kP/uHqF4DvVtXOqnoauB742YFnmri1Hngvh7BAkjB/jHV7VX1w6HmGVFWXVtWGqpph/v+LL1dVc3toXVXVfwLfT3Lq6KE3APcOONLQHgBek+SY0dfNG2jwh86DX01yHANcDmG1Owd4B/DNJHeNHrusqm4ecCatHr8PXDPaGbofeOfA8wymqm5Lci1wB/Nnn91Jg5ct8FIFktSotX6IRpJ0AAZekhpl4CWpUQZekhpl4CWpUQZekhpl4CWpUf8HuJ0Y64FW+QQAAAAASUVORK5CYII=\n",
+            "image/png": "iVBORw0KGgoAAAANSUhEUgAAAXgAAAD4CAYAAADmWv3KAAAABHNCSVQICAgIfAhkiAAAAAlwSFlzAAALEgAACxIB0t1+/AAAADh0RVh0U29mdHdhcmUAbWF0cGxvdGxpYiB2ZXJzaW9uMy4yLjIsIGh0dHA6Ly9tYXRwbG90bGliLm9yZy+WH4yJAAANQ0lEQVR4nO3dfYxldX3H8feHXRoeJGLDlLYs42BjoEShbAe1pdqI1aKr9CltMcU/TOM0KW2hNdGFmNb+0QSTVrFN27BFWxXUKg/GAlohPjQmLbgLtAIr0eCKPDQsbegulLg8fPvH3O3OwO7Omb33zJn57fuVTLj3zr33990T5p0zZ86cSVUhSWrPEUMPIEnqh4GXpEYZeElqlIGXpEYZeElq1PqhB1johBNOqJmZmaHHkKQ1Y9u2bY9V1dT+PreqAj8zM8PWrVuHHkOS1owk3zvQ5zxEI0mNMvCS1CgDL0mNMvCS1CgDL0mNMvCS1KheT5NMsgPYDTwLPFNVs32uJ0naZyXOg399VT22AutIkhbwEI0kNarvPfgCvpSkgCurasvzn5BkDpgDmJ6e7nkcaW2Z2XzTYGvvuHzTYGtrMvreg/+5qtoIvBm4KMnrnv+EqtpSVbNVNTs1td/LKUiSDkGvga+qh0b/fRS4AXhVn+tJkvbpLfBJjk1y3N7bwJuAu/taT5K0WJ/H4E8Ebkiyd51PVtUXe1xPkrRAb4GvqvuBM/t6f0nSwXmapCQ1ysBLUqMMvCQ1ysBLUqMMvCQ1ysBLUqMMvCQ1ysBLUqMMvCQ1ysBLUqMMvCQ1ysBLUqMMvCQ1ysBLUqMMvCQ1ysBLUqMMvCQ1ysBLUqMMvCQ1ysBLUqMMvCQ1ysBLUqMMvCQ1ysBLUqMMvCQ1ysBLUqMMvCQ1ysBLUqMMvCQ1ysBLUqMMvCQ1ysBLUqN6D3ySdUnuTHJj32tJkvZZiT34i4HtK7COJGmBXgOfZAOwCbiqz3UkSS/U9x78FcB7gOcO9IQkc0m2Jtm6c+fOnseRpMNHb4FP8lbg0aradrDnVdWWqpqtqtmpqam+xpGkw06fe/DnAOcn2QF8Gjg3ydU9ridJWqC3wFfVpVW1oapmgAuAL1fVhX2tJ0lazPPgJalR61dikar6KvDVlVhLkjTPPXhJapSBl6RGGXhJapSBl6RGGXhJapSBl6RGGXhJapSBl6RGGXhJapSBl6RGGXhJapSBl6RGGXhJapSBl6RGGXhJapSBl6RGGXhJapSBl6RGGXhJapSBl6RGGXhJapSBl6RGGXhJapSBl6RGGXhJapSBl6RGGXhJapSBl6RGdQp8klf2PYgkabK67sH/TZLbk/xukhf3OpEkaSI6Bb6qXgv8FnAysC3JJ5O8sdfJJElj6XwMvqq+DbwPeC/w88BfJvlWkl/tazhJ0qHregz+jCQfArYD5wJvq6qfHN3+0AFec9TosM6/J7knyZ9ObGpJ0pLWd3zeXwFXAZdV1VN7H6yqh5O87wCv+QFwblU9keRI4OtJvlBV/zbeyJKkLroGfhPwVFU9C5DkCOCoqvrfqvrE/l5QVQU8Mbp75OijxpxXktRR12PwtwJHL7h/zOixg0qyLsldwKPALVV12/JHlCQdiq578EdV1d69cUaHXY5Z6kWjPf6fSnI8cEOSV1TV3Qufk2QOmAOYnp7uPrkkTdjM5psGWXfH5Zt6ed+ue/BPJtm4906SnwaeOsjzF6mqx4GvAOft53Nbqmq2qmanpqa6vqUkaQld9+AvAT6b5GEgwI8Cv3mwFySZAp6uqseTHA28EfjAOMNKkrrrFPiq+kaS04BTRw/dV1VPL/GyHwM+lmQd898pfKaqbjz0USVJy9F1Dx7gbGBm9JqNSaiqjx/oyVX1H8BZ440nSTpUnQKf5BPATwB3Ac+OHi7ggIGXJA2r6x78LHD66Nx2SdIa0PUsmruZ/8GqJGmN6LoHfwJwb5Lbmb8EAQBVdX4vU0mSxtY18O/vcwhJ0uR1PU3ya0leCry8qm4d/Rbrun5HkySNo+vlgt8FXAtcOXroJOBzfQ0lSRpf1x+yXgScA+yC///jHz/S11CSpPF1DfwPqmrP3jtJ1uOlfyVpVesa+K8luQw4evS3WD8L/FN/Y0mSxtU18JuBncA3gd8Bbmb+77NKklaprmfRPAf83ehDkrQGdL0WzXfZzzH3qnrZxCeSJE3Ecq5Fs9dRwK8DPzz5cSRJk9LpGHxV/deCj4eq6grm/xC3JGmV6nqIZuOCu0cwv0e/nGvJS5JWWNdI/8WC288AO4DfmPg0kqSJ6XoWzev7HkSSNFldD9H80cE+X1UfnMw4kqRJWc5ZNGcDnx/dfxtwO/DtPoaSJI2va+A3ABurajdAkvcDN1XVhX0NJkkaT9dLFZwI7Flwf8/oMUnSKtV1D/7jwO1Jbhjd/2XgY/2MJEmahK5n0fxZki8Arx099M6qurO/sSRJ4+p6iAbgGGBXVX0YeDDJKT3NJEmagK5/su9PgPcCl44eOhK4uq+hJEnj67oH/yvA+cCTAFX1MHBcX0NJksbXNfB7qqoYXTI4ybH9jSRJmoSugf9MkiuB45O8C7gV//iHJK1qS55FkyTAPwKnAbuAU4E/rqpbep5NkjSGJQNfVZXk5qp6JWDUJWmN6HqI5o4kZ/c6iSRporr+JuurgQuT7GD+TJowv3N/Rl+DSZLGc9DAJ5muqgeAX1zuGyc5mflLHJzI/Nk3W0a/JCVJWgFL7cF/jvmrSH4vyXVV9WvLeO9ngHdX1R1JjgO2Jbmlqu495GklSZ0tdQw+C26/bDlvXFWPVNUdo9u7ge3AScsbT5J0qJbag68D3F6WJDPAWcBt+/ncHDAHMD09fahLMLP5pkN+7Vq14/JNg6w75LYe6t+slXM4fi33Zak9+DOT7EqyGzhjdHtXkt1JdnVZIMmLgOuAS6rqBa+pqi1VNVtVs1NTU8v/F0iS9uuge/BVtW6cN09yJPNxv6aqrh/nvSRJy7OcywUvy+g3YD8CbPePckvSyust8MA5wDuAc5PcNfp4S4/rSZIW6PqLTstWVV9n8Vk4kqQV1OcevCRpQAZekhpl4CWpUQZekhpl4CWpUQZekhpl4CWpUQZekhpl4CWpUQZekhpl4CWpUQZekhpl4CWpUQZekhpl4CWpUQZekhpl4CWpUQZekhpl4CWpUQZekhpl4CWpUQZekhpl4CWpUQZekhpl4CWpUQZekhpl4CWpUQZekhpl4CWpUQZekhpl4CWpUQZekhrVW+CTfDTJo0nu7msNSdKB9bkH/w/AeT2+vyTpIHoLfFX9C/Dffb2/JOng1g89QJI5YA5genp64GnWlpnNNw09woo7HP/NQ3Fbr32D/5C1qrZU1WxVzU5NTQ09jiQ1Y/DAS5L6YeAlqVF9nib5KeBfgVOTPJjkt/taS5L0Qr39kLWq3t7Xe0uSluYhGklqlIGXpEYZeElqlIGXpEYZeElqlIGXpEYZeElqlIGXpEYZeElqlIGXpEYZeElqlIGXpEYZeElqlIGXpEYZeElqlIGXpEYZeElqlIGXpEYZeElqlIGXpEYZeElqlIGXpEYZeElqlIGXpEYZeElqlIGXpEYZeElqlIGXpEYZeElqlIGXpEYZeElqlIGXpEYZeElqVK+BT3JekvuSfCfJ5j7XkiQt1lvgk6wD/hp4M3A68PYkp/e1niRpsT734F8FfKeq7q+qPcCngV/qcT1J0gLre3zvk4DvL7j/IPDq5z8pyRwwN7r7RJL7DnG9E4DHDvG1rXFbLOb2WMztsc+q2Bb5wFgvf+mBPtFn4Dupqi3AlnHfJ8nWqpqdwEhrnttiMbfHYm6PfVrfFn0eonkIOHnB/Q2jxyRJK6DPwH8DeHmSU5L8EHAB8Pke15MkLdDbIZqqeibJ7wH/DKwDPlpV9/S1HhM4zNMQt8Vibo/F3B77NL0tUlVDzyBJ6oG/ySpJjTLwktSoNR94L4ewT5KTk3wlyb1J7kly8dAzDS3JuiR3Jrlx6FmGluT4JNcm+VaS7Ul+ZuiZhpTkD0dfJ3cn+VSSo4aeadLWdOC9HMILPAO8u6pOB14DXHSYbw+Ai4HtQw+xSnwY+GJVnQacyWG8XZKcBPwBMFtVr2D+RJALhp1q8tZ04PFyCItU1SNVdcfo9m7mv4BPGnaq4STZAGwCrhp6lqEleTHwOuAjAFW1p6oeH3aqwa0Hjk6yHjgGeHjgeSZurQd+f5dDOGyDtlCSGeAs4LZhJxnUFcB7gOeGHmQVOAXYCfz96JDVVUmOHXqooVTVQ8CfAw8AjwD/U1VfGnaqyVvrgdd+JHkRcB1wSVXtGnqeISR5K/BoVW0bepZVYj2wEfjbqjoLeBI4bH9mleQlzH+3fwrw48CxSS4cdqrJW+uB93IIz5PkSObjfk1VXT/0PAM6Bzg/yQ7mD92dm+TqYUca1IPAg1W19zu6a5kP/uHqF4DvVtXOqnoauB742YFnmri1Hngvh7BAkjB/jHV7VX1w6HmGVFWXVtWGqpph/v+LL1dVc3toXVXVfwLfT3Lq6KE3APcOONLQHgBek+SY0dfNG2jwh86DX01yHANcDmG1Owd4B/DNJHeNHrusqm4ecCatHr8PXDPaGbofeOfA8wymqm5Lci1wB/Nnn91Jg5ct8FIFktSotX6IRpJ0AAZekhpl4CWpUQZekhpl4CWpUQZekhpl4CWpUf8HuJ0Y64FW+QQAAAAASUVORK5CYII=",
             "text/plain": [
               "<Figure size 432x288 with 1 Axes>"
             ]
           },
           "metadata": {
             "needs_background": "light"
-          }
+          },
+          "output_type": "display_data"
         }
+      ],
+      "source": [
+        "df = pd.DataFrame(np.random.randint(10, size=(20,4)), columns=list(\"ABCD\"))\n",
+        "\n",
+        "df.A.plot.hist()\n",
+        "plt.show()"
       ]
     },
     {
@@ -6242,34 +6219,34 @@
     },
     {
       "cell_type": "code",
+      "execution_count": 109,
       "metadata": {
         "colab": {
           "base_uri": "https://localhost:8080/",
           "height": 265
         },
         "id": "QEYYh7wGA9xk",
-        "outputId": "8d7cacf7-ae41-42cb-cf1e-db39ec790a9a"
+        "outputId": "e51b5048-4149-4541-e557-10e5479e2afa"
       },
-      "source": [
-        "df = pd.DataFrame(np.random.randint(10, size=(10,4)), columns=list(\"ABCD\"))\n",
-        "\n",
-        "df.A.plot.kde()\n",
-        "plt.show()"
-      ],
-      "execution_count": 455,
       "outputs": [
         {
-          "output_type": "display_data",
           "data": {
-            "image/png": "iVBORw0KGgoAAAANSUhEUgAAAYgAAAD4CAYAAAD2FnFTAAAABHNCSVQICAgIfAhkiAAAAAlwSFlzAAALEgAACxIB0t1+/AAAADh0RVh0U29mdHdhcmUAbWF0cGxvdGxpYiB2ZXJzaW9uMy4yLjIsIGh0dHA6Ly9tYXRwbG90bGliLm9yZy+WH4yJAAAgAElEQVR4nO3deVxV1f7/8deHeRBwACdQAcEBZ8Upc0hT00qbs0nzWjbZrVvdvlb3dxvuvX2bJ7NuZvNog5WVpZZDZjmgqYSKIqjgBAIiqCDD+v1xjvfLpaOics4+w+f5eJwHh73XgTeHc/iw9tp7LTHGoJRSStXlZ3UApZRS7kkLhFJKKYe0QCillHJIC4RSSimHtEAopZRyKMDqAA0lOjraxMfHWx1DKaU8ytq1aw8YY2Ic7fOaAhEfH09aWprVMZRSyqOIyM4T7dNDTEoppRzSAqGUUsohLRBKKaUc0gKhlFLKIS0QSimlHNICoZRSyiEtEEoppRzymusglPIGhWUVbN5byt6SoxSUVVBTYxARohsF0bpxKJ1aRhITEWx1TOUjtEAoZaHDFVX8tLWARZv3syq7iN0Hj57yMYnR4QzpEMMlvWLpEReFiLggqfJFWiCUcjFjDOt2HeTDVbv4ZuMeKqpqaBwWyKD20Uw6px1dY6OIaxxGTEQw/n5CjTEUlFaQV3yUjXkHWZ1TxIerd/H2Lzvo2CKC289rz0XdW+Pvp4VCNSzxlhXlUlNTjU61odxZTY3h+4x9zFySRcaeQ4QH+TO+VywXd29N3/gmBPjXf0jwUHkl8zfu5c0VOWzdX0b7mHAeHdeVc5OjnfgTKG8kImuNMakO92mBUMq5jDF8m76Xl37cxtb9ZSRGhzNlcALje8bSKPjsOvE1NYYFGft44vst7Cw8wrgerXlsfBcahwU1UHrl7U5WIPQQk1JOtG5XMY99vYn1uQdJbt6IFyf0bNDDQX5+wphurTivU3NeXbqdV5ZmsXZnMS9d05M+7Zo2yPdQvkt7EEo5wZ6DR3niuy3M27CHmIhg/jq6I5f3jnP6OMGG3INM+2gdew6W8+i4Llw/oJ1Tv5/yfNqDUMpFqmsM7/66g2cWZFJVY7hzeBK3Dm1P+FkeSqqvHm0a8+2fB3P3x+v525e/s7PwMA+M6YyfDmCrM6AFQqkGsnnvIabPTWdD7kGGdojhn5d0pU3TMJfniAwJZNYNfXjsm028vjyHwrJjPH1lDz3LSZ02p15JLSIXiEimiGSJyHQH+4eIyDoRqRKRK+rsmyQi2+y3Sc7MqdTZKK+s5snvt3DxjJ/JKzrCixN68vbkvpYUh+MC/P14dFwX7h3Zgbm/7eaeT9ZTVV1jWR7lmZzWgxARf2AmMBLIA9aIyDxjzKZazXYBNwL31XlsU+BhIBUwwFr7Y4udlVepM7Eh9yD3fLKe7QWHuSo1jgfHdnabM4hEhDtHJOPnJzy9IBNj4IWre+rhJlVvzjzE1A/IMsZkA4jIx8B44D8Fwhizw76v7r82o4FFxpgi+/5FwAXAR07Mq1S9Hauq4eXF25i5dDstIoJ5f0p/t70G4Y7zkhCBp77PpGl4EA9fnKJXX6t6cWaBiAVya32eB/Q/i8fG1m0kIlOBqQBt27Y9s5RKnabMfaXc88l6MvYc4vLecTw8LoXIkECrY53UbUPbU1h2jDd+zqFlVAi3Dm1vdSTlATx6kNoYMwuYBbbTXC2Oo7xcdY1h9vJsnl24lYiQAF67oQ+ju7S0Ola9iAgPje1MfmkFT3y3hdjGoVzco7XVsZSbc2aB2A20qfV5nH1bfR87rM5jlzZIKqXOQG7REe75ZD1rdhQzKqUFj1/WjehGnjWrqp+f8MyV3dl78Ch//WwDiTHhdGkdZXUs5caceRbTGiBZRBJEJAiYAMyr52MXAKNEpImINAFG2bcp5XJfrd/NmBeXs2VvKc9e2YPXbujjccXhuOAAf165vjeNQ4OY+u5aCssqrI6k3JjTCoQxpgqYhu0P+2bgE2NMhog8JiLjAESkr4jkAVcCr4lIhv2xRcA/sBWZNcBjxweslXKVsooq7vlkPXd9vJ6OLSOYf9dgLu8T5/EDvM0jQpg1sQ8FZRXc8eE6Pf1VnZBOtaGUAxtyD3LXx7+xq+gI04Yn8+fhSac126on+GxtHvd9uoE/j0jmnpEdrI6jLKJTbShVTzU1hlnLs3lmQSbNI4L5eOpA+iV456R3V/SJ49fthcxYvI0BiU05p717nqarrONd/xIpdRYOlFUw6a3VPPHdFkamtOC7u4Z4bXE47rHxXUhoFs5f5qzX8Qj1B1oglALSdhRx0Us/szqniP+9rBuvXNebqDD3vrahIYQHBzDj2l4UH67kvk834C2HnFXD0AKhfJoxtmsbJsxaSXCgH3NvP4dr+rX1+IHo09GldRQPju3EkswCPly9y+o4yo3oGITyWYfKK7n/0418n7GPUSktePrKHkSFen+vwZGJA+NZtHk///p2M0OSYyydaFC5D+1BKJ+UXVDGJTNXsGjzfh4c24nXbujjs8UBbBfRPXVFD/xE+OtnG6ip0UNNSguE8kE/bzvAJTNXcPBIJR/c1J+pQ9r71CGlE4ltHMr/u6gzK7OLePfXHVbHUW5AC4TyGcbYVnub9NZqWkWF8tUdgxiQ2MzqWG7lqtQ2nNcxhie+30LOgcNWx1EW0wKhfEJ1jeHheRn8/asMzusYw+e3n6PH2R0QEZ64vDuB/n48ODddz2rycVoglNcrr6xm2ofrePfXnUwdkshrN6TSyEVrRHuiFpEhTB/TiV+zC/lsbZ7VcZSFtEAor3aovJIb31rNd7/v428XdubBsZ11beZ6uKZvW1LbNeFf8zfrBXQ+TAuE8loFpRVMeG0laTuKeeHqntw0ONHqSB7Dz094/LJuHK6o4l/fbrY6jrKIFgjllfJLy7nm9ZXkHDjMGzf25ZJef1iQUJ1ChxYR3DKkPXN/283P2w5YHUdZQAuE8jr5peVcM2slu4uP8vbkvgztEGN1JI81bXgS8c3CeOjLdMorq62Oo1xMC4TyKseLw96Sct6e3Jf+ehrrWQkJ9Oefl3RjZ+ERXv8p2+o4ysW0QCivcfDIMa6fvYq9JeW8daMWh4ZybnI0Y7u1ZObSLPKKj1gdR7mQFgjlFY4eq2bKO2nsOHCE2ZNStTg0sIcuTAHg8fk6YO1LtEAoj1dZXcMdH65j3a5iXpzQUxe+cYLYxqHcMSyJ+en7WJGlA9a+QguE8mjGGB76Ip3FW/L5x/iujOnWyupIXuvmIYm0bRrGw/MyqNR1rH2CFgjl0WYvz+GTtDz+PDyJ6we0szqOVwsJ9OfvF6WQlV/GO7/ssDqOcgEtEMpjLdmSz+PfbebCbq24+/wOVsfxCSM6N2dYxxhe+GEb+aXlVsdRTqYFQnmkbftLufOj3+jSOpJnruyBn06f4RIiwsMXd6GiqppnF2y1Oo5yMi0QyuMcKq/k5nfTCA3y5/WJqYQG+VsdyackRIczaWA8n6zNZdOeQ1bHUU6kBUJ5FGMM0z/fSG7xUV69rjetokKtjuST7hyeTFRoIP/8dpNOCe7FtEAoj/LOLzuYn76P+0d3JDW+qdVxfFZUWCB3j0jml+2FLN6Sb3Uc5SRaIJTH2JB7kH/N38yITs25WWdmtdx1A9qRGBPOv+Zv1tNevZQWCOURyiqqmPbROppHhPDsVToo7Q4C/f14aGxnsgsO8+GqXVbHUU6gBUJ5hH98vYndxUd5cUJPGocFWR1H2Q3v1JxBSc14/oetlByptDqOamBaIJTbW5ixjzlpudw6tL2OO7gZEeGhsSmUHK1kxuJtVsdRDcypBUJELhCRTBHJEpHpDvYHi8gc+/5VIhJv3x4oIu+ISLqIbBaRB5yZU7mvA2UVPDA3nZRWkXoxnJtKaR3JVX3a8M6vO9hx4LDVcVQDclqBEBF/YCYwBkgBrhGRlDrNpgDFxpgk4HngSfv2K4FgY0w3oA9wy/HioXyHMYYH56ZTWl7F81f3JChAO7zu6t7RHQj09+OpBVusjqIakDPfcf2ALGNMtjHmGPAxML5Om/HAO/b7nwEjREQAA4SLSAAQChwD9IocHzM/fR8LN+3n3lEd6Ngywuo46iSaR4Rw8+BE5qfvY33uQavjqAbizAIRC+TW+jzPvs1hG2NMFVACNMNWLA4De4FdwDPGmKK630BEpopImoikFRQUNPxPoCxTcqSSh+dl0DU2kinnJlgdR9XDzUMSiW4UxBPfbdaL57yEu/bZ+wHVQGsgAbhXRP5w4rsxZpYxJtUYkxoTo+sOe5Mnvt9C0eEKnrisOwH+7voyVbU1Cg7gzyOSWZldxNKt+g+bN3DmO2830KbW53H2bQ7b2A8nRQGFwLXA98aYSmNMPrACSHViVuVGVucU8dHqXUw5N4GusVFWx1GnYULftrRrFsaT322hukZ7EZ7OmQViDZAsIgkiEgRMAObVaTMPmGS/fwWw2Nj6pruA4QAiEg4MAHT0ywdUVFXzwNyNxDUJ5S8j9awlTxMU4Md9ozqyZV8pX62v+/+g8jROKxD2MYVpwAJgM/CJMSZDRB4TkXH2Zm8AzUQkC7gHOH4q7EygkYhkYCs0bxljNjorq3Ifs5fnsL3gMP+8pCthQQFWx1Fn4MJuregWG8WzC7dSXlltdRx1Fpz6DjTGzAfm19n291r3y7Gd0lr3cWWOtivvtq+knJlLshiV0oJhHZtbHUedIT8/YfqYTlw3exXvr9zJTTpvlsfS0T/lNp74bjNVNYa/XVj3chnlaQYlRTM4OZqXl2RxqFyn4PBUWiCUW0jbUcSX6/cwdXAibZuFWR1HNYD/uaATB49U8tqy7VZHUWdIC4SyXHWN4ZGvM2gZGcLt57W3Oo5qIF1joxjfszVv/JzD/kO6frUn0gKhLPdpWi6/7z7EA2M76cC0l7l3ZEeqawwv/KAT+XkiLRDKUkeOVfHsoq30adeEcT1aWx1HNbC2zcK4tl9bPk3L1Yn8PJAWCGWp2ctzKCit4MGxnbBNw6W8zR3DkwjwF174YavVUdRp0gKhLFNYVsFry7YzKqUFfdrpOg/eqnlECJPOieerDXvI3FdqdRx1GrRAKMvMWJxFeVUN91/QyeooysluHdKeRkEBPLco0+oo6jRogVCW2Fl4mA9W7eSq1DYkNW9kdRzlZE3Cg7hpcCILMvazMU+nA/cUWiCUJZ5ekIm/n3D3+clWR1Eu8qdz42kSFsgzC3UswlNogVAul55Xwjcb93LTuYm0iAyxOo5ykYiQQG4b1p6fthawOucPy7soN6QFQrnc8z9sJSo0kKlDdY4eXzNxYDzNI4J5esEWXVTIA2iBUC61Pvcgi7fkM3VIIpEhgVbHUS4WEujPnSOSWbOjmGW6qJDb0wKhXOr5RVtpEhbIpHPirY6iLHJ1ahvimoTy7MKt2otwc1oglMus3Wn7r3HqkPY0CtYpNXxVUIAfd5/fgfTdJSzI2Gd1HHUSWiCUy7zww1aahQcxcWA7q6Moi13aK5b2MeE8u3CrLk3qxrRAKJdYs6OI5dsOcMvQRMK19+Dz/P2Ee0Z2ZFt+GV9v2GN1HHUCWiCUSzy/aCvRjYK5YUC81VGUmxjTtSWdWkbw0o/bqKqusTqOckALhHK6VdmF/LK9kFuHJhIa5G91HOUm/PyEu8/vQPaBw3y9UXsR7kgLhHK6mUu30yw8iOv669iD+m+jUlrQuVUkL/2Ypb0IN6QFQjlVel4JP20tYMrgBO09qD/ws0+3knPgMPN0LMLtaIFQTvXqsiwiQgK4foD2HpRjo1JakNIqUsci3JAWCOU0WfllfPf7PiYNjNerptUJidh6ETsKj/Dleu1FuBMtEMpp/r1sO8EBfkweFG91FOXmRqa0oEvrSGYs1l6EO9ECoZwir/gIX/62m2v6taVZo2Cr4yg3Z+tFdGBn4RG++G231XGUnRYI5RSv/5SNCNw8WGdsVfVzfufmdI2N5OUlekaTu9ACoRpcQWkFH6/J5bJecbRuHGp1HOUhRIS7R9h6EXO1F+EWtECoBvfmihwqq2u4dVh7q6MoDzOic3O6xUYxY/E2KrUXYbl6FQgRmSsiF4qIFhR1UiVHK3nv152M7daKhOhwq+MoD3P8jKbcoqN8sU57EVar7x/8V4BrgW0i8oSIdKzPg0TkAhHJFJEsEZnuYH+wiMyx718lIvG19nUXkV9FJENE0kVE16b0AB+t3kVZRRW3DtXegzozwzs1p0dcFDOWaC/CavUqEMaYH4wx1wG9gR3ADyLyi4hMFhGHJ7iLiD8wExgDpADXiEhKnWZTgGJjTBLwPPCk/bEBwPvArcaYLsAwoPI0fzblYseqanhrRQ6DkprRNTbK6jjKQx0/oym36Chz1+VZHcen1fuQkYg0A24EbgJ+A17EVjAWneAh/YAsY0y2MeYY8DEwvk6b8cA79vufASNERIBRwEZjzAYAY0yhMaa6vlmVNb7esIf9hyr0zCV11oZ1jKFbbBSvLN2uZzRZqL5jEF8Ay4Ew4GJjzDhjzBxjzJ1AoxM8LBbIrfV5nn2bwzbGmCqgBGgGdACMiCwQkXUicv8Jck0VkTQRSSso0PVtrWSM4fXl2XRsEcHQDjFWx1EeTkSYNjyJnYVH+GbjXqvj+Kz69iBeN8akGGP+1xizF2zjBwDGmFQn5AoAzgWus3+8VERG1G1kjJlljEk1xqTGxOgfJSst33aALftKuWlwArZOoFJnZ2TnFnRsEcHLS7Ko0VXnLFHfAvFPB9t+PcVjdgNtan0eZ9/msI193CEKKMTW2/jJGHPAGHMEmI/tcJZyU68vz6Z5RDDjera2OoryEn5+tl5EVn4Z3+va1ZY4aYEQkZYi0gcIFZFeItLbfhuG7XDTyawBkkUkQUSCgAnAvDpt5gGT7PevABYbYwywAOgmImH2wjEU2HRaP5lymU17DrF82wFuHBRPcIBO6a0azthurUiMCWfG4ixsfxqUK51qceDR2Aam44Dnam0vBR482QONMVUiMg3bH3t/4E1jTIaIPAakGWPmAW8A74lIFlCErYhgjCkWkeewFRkDzDfGfHu6P5xyjdnLswkL8ue6fjqlt2pY/n7CHcOSuPfTDfy4OZ/zU1pYHcmnSH2qsohcboz53AV5zlhqaqpJS0uzOobP2VtylMFPLuGGge14+OIuVsdRXqiyuobhzy6laVgQX94xSMe4GpiIrD3RWPKpDjFdb78bLyL31L01eFLlcd5esYMaY/jToASroygvFejvx+3DktiQV8LybQesjuNTTjVIfXyuhEZAhIOb8mGl5ZV8uGoXY7u1ok3TUw1JKXXmLusdS6uoEGYs3qZjES500jEIY8xr9o+PuiaO8iRz1uRSWlHF1CF6YZxyruAAf24ZksgjX29iVU4RAxKbWR3JJ9T3QrmnRCRSRAJF5EcRKah1+En5oMrqGt78OYf+CU3pHtfY6jjKB0zo15boRsHMWLzN6ig+o77XQYwyxhwCLsI2F1MS8FdnhVLub376XvaUlGvvQblMSKA/U4cksCKrkLU7i62O4xPqWyCOH4q6EPjUGFPipDzKAxhjmPVTNu1jwjmvY3Or4ygfcl3/djQJC+Rl7UW4RH0LxDcisgXoA/woIjFAufNiKXf26/ZCMvYc4ubBifj56SmHynXCgwOYcm4CSzIL+H23/p/qbPWd7ns6cA6QaoypBA7zx5lZlY+YtTyb6EZBXNKr7tyLSjnfxHPiiQgJ0LEIFzjVldS1dcJ2PUTtx7zbwHmUm9u2v5SlmQXcM7IDIYE6rYZyvciQQCafE89Li7PI3FdKx5Z6xr2z1PcspveAZ7DNrNrXfnPGLK7Kzc1enkNIoB/XD9BpNZR1Jg9KICzIn5lLsqyO4tXq24NIBVKMXqHi0wpKK/hi/W6u7BNH0/Agq+MoH9YkPIgbBrTj9eXZ/GVkB13/3EnqO0j9O9DSmUGU+3tv5U6OVdXwp3N1Wg1lvSmDEwjw9+PVpdqLcJb6FohoYJN9hbd5x2/ODKbcS3llNe+v3Mn5nZvTPuZEiwgq5TrNI0K4pm8b5q7bze6DR62O45Xqe4jpEWeGUO5v7rrdFB0+xk263rRyI1OHtueDVbt4bdl2Hhvf1eo4Xqe+p7kuw3YFdaD9/hpgnRNzKTdSU2OY/XM2XWMj6Z/Q1Oo4Sv1HbONQLu8dx8drcsk/pJdmNbT6nsV0M/AZ8Jp9UyzwpbNCKfeyJDOf7ILD3Dw4UefiV27ntmHtqaquYfbPOVZH8Tr1HYO4AxgEHAIwxmwDdI4FH/H68mxaRYUwtlsrq6Mo9Qfx0eFc3KM176/cSfHhY1bH8Sr1LRAVxpj/PPP2i+X0lFcf8PvuElZmFzF5UDyB/vV9uSjlWnecl8SRY9W8tUJ7EQ2pvu/4ZSLyIBAqIiOBT4GvnRdLuYvZy7MJD/Ln6r5trY6i1Al1aBHB6C4teOuXHRwqr7Q6jteob4GYDhQA6cAtwHzgb84KpdzD3pKjfLNxL1f3bUtUaKDVcZQ6qWnnJVNaXsV7v+60OorXqNdprsaYGhH5EvjSGFPg5EzKTbz9i2296cmD4q2OotQpdYuLYmiHGN74OYfJg+IJCzqdqeaUIyftQYjNIyJyAMgEMu2ryf3dNfGUVcoqqvhw1S7GdNX1ppXnuHN4EkWHj/HR6lyro3iFUx1i+gu2s5f6GmOaGmOaAv2BQSLyF6enU5b5ZE0upeVV3DRYp9VQniM1vikDEpsy66ftlFdWWx3H452qQNwAXGOM+c+pAcaYbOB6YKIzgynrVFXX8OaKHFLbNaFX2yZWx1HqtEw7L5n9hyr4bG2e1VE83qkKRKAx5kDdjfZxCB219FILN+0nr/io9h6URxqU1IyebRrz72XbqayusTqORztVgTjZVSd6RYqXen15Nu2ahTEyRSfwVZ5HRJh2XhJ5xUf5av0eq+N4tFMViB4icsjBrRTo5oqAyrXW7izit10H+dOgBPx1vWnloUZ0bk7nVpG8sjSL6hq9pvdMnbRAGGP8jTGRDm4Rxhg9xOSF/r0sm8ZhgVzRJ87qKEqdMRHhjvPak11wmO9+32t1HI+lcyeo/8jKL2XRpv1MHBhPeLCeQ64825iurUiMCeflxVnoYphnxqkFQkQuEJFMEckSkekO9geLyBz7/lUiEl9nf1sRKROR+5yZU9m8tiybkEA/Jg3U9aaV5/P3E24flsSWfaX8uDnf6jgeyWkFQkT8gZnAGCAFuEZEUuo0mwIUG2OSgOeBJ+vsfw74zlkZ1f/ZV1LOl+t3c1VqG5o1CrY6jlINYnzP1sQ1CWXGEu1FnAln9iD6AVnGmGz7TLAfA+PrtBkPvGO//xkwQuwLDojIJUAOkOHEjMruzRU51Bi4WVeMU14k0N+P24a1Z0PuQVZkFVodx+M4s0DEArWvd8+zb3PYxhhTBZQAzUSkEfA/wKMn+wYiMlVE0kQkraBAp4g6UyVHK/lw1S4u7KbTaijvc0WfOFpEBjNj8Taro3gcdx2kfgR43hhTdrJGxphZxphUY0xqTEyMa5J5oQ9W7aSsoopbhmrvQXmf4AB/pg5pz6qcItbsKLI6jkdxZoHYDbSp9XmcfZvDNvZFiKKAQmzzPT0lIjuAu4EHRWSaE7P6rPLKat78eQeDk6Pp0jrK6jhKOcU1/drQNDyIlxdnWR3FozizQKwBkkUkQUSCgAnAvDpt5gGT7PevABYbm8HGmHhjTDzwAvC4MeZlJ2b1WXPX7eZAWQW3DW1vdRSlnCYsKIAp5yawbGsB6XklVsfxGE4rEPYxhWnAAmAz8IkxJkNEHhORcfZmb2Abc8gC7sG2MJFykeoaw+vLs+keF8XA9s2sjqOUU90wsB0RIQG8vETHIurLqVdDGWPmY1t9rva2v9e6Xw5ceYqv8YhTwikWZuwj58BhXrmuN/aTx5TyWpEhgUw+J56XFmexdX8pHVpEWB3J7bnrILVyMmMMLy/JIiE6nNFddFI+5RsmD0ogLMifmUt0LKI+tED4qMVb8snYc4jbh7XXSfmUz2gSHsT1A9rx9YY97Dhw2Oo4bk8LhA8yxjBjcRZxTUK5pFfdS1OU8m43DU4gwN+PV5dutzqK29MC4YN+zjrA+tyD3DasPYH++hJQvqV5RAgT+rbh83V57D541Oo4bk3/OvigGT9m0SoqRKf0Vj7rFvtp3bOWaS/iZLRA+JhV2YWs3lHELUMSCQ7wtzqOUpaIbRzKZb1j+WhNLvml5VbHcVtaIHzMjMVZRDcKZkK/tlZHUcpStw1Loqq6hjeW51gdxW1pgfAh63YV83PWAaYOSSAkUHsPyrclRIdzcY/WvPvrTg6UVVgdxy1pgfAhL/24jSZhgVzXXxcEUgrgzuHJVFRV6xlNJ6AFwkes3VnE0swCbhqcqMuJKmWX1LwRl/WO472VO9lXomMRdWmB8BHPLtxKdKMgJg+KtzqKUm7lrhHJ9pkFdI6murRA+IBfsg7wy/ZCbhuWRFiQ9h6Uqq1N0zCu7tuGOWtyyS06YnUct6IFwssZY3h20VZaRoZwXX89c0kpR6adl4yI8OKP2ouoTQuEl1u2tYC1O4uZNjxJz1xS6gRaRoVww4B2zF2Xx/aCky5k6VO0QHgxYwzPLtxKXJNQrkptc+oHKOXDbhvWnpBAf174QXsRx2mB8GILN+0nfXcJd41IJihAf9VKnUx0o2AmD4rn6w172Lz3kNVx3IL+1fBSVdU1PLMgk8TocC7VGVuVqpepg9sTERLAswu3Wh3FLWiB8FKfpOWxLb+M+y/oSIDO2KpUvUSFBXLr0Pb8sHk/q3OKrI5jOf3L4YUOV1Tx3KKtpLZroqvFKXWa/jQogZaRITw+fzPGGKvjWEoLhBea9VM2B8oqeGBsZ11rWqnTFBrkzz2jOrA+9yDfpu+1Oo6ltEB4mfxD5cz6KZux3VrSp10Tq+Mo5ZEu7x1Hp5YRPPV9JhVV1VbHsYwWCC/z/A9bqaqp4f7RnayOopTH8vcTHhjbmV1FR/hg5S6r41hGC4QX2bq/lDlrcrmufzvio8OtjqOURxuSHM25SdG8tHgbJUcrrY5jCS0QXsIYwyPzMmgUHMCfRyRbHUcpjyciPDC2EyVHK4mSB3EAAA+fSURBVHllSZbVcSyhBcJLfPf7Pn7ZXsi9ozrSNDzI6jhKeYUuraO4rFccb63YQc6Bw1bHcTktEF7g6LFq/vXtZjq1jNAJ+ZRqYP8zpiNBAX7845tNVkdxOS0QXuDVpVnsPniUR8d10YvilGpgzSNCuGtEMou35LN4y36r47iU/jXxcLsKj/Dvn7IZ16M1/RObWR1HKa806Zx4EmPCeezrTT512qsWCA9mjOHRrzMI8BMeHNvZ6jhKea2gAD8eubgLOwqP8MbPOVbHcRmnFggRuUBEMkUkS0SmO9gfLCJz7PtXiUi8fftIEVkrIun2j8OdmdNTfZu+lx+35POX8zvQMirE6jhKebUhHWIYldKClxdnsbfkqNVxXMJpBUJE/IGZwBggBbhGRFLqNJsCFBtjkoDngSft2w8AFxtjugGTgPecldNTHTxyjEfmZdA9LkrXmVbKRf7fRSlU1xgenecbA9bO7EH0A7KMMdnGmGPAx8D4Om3GA+/Y738GjBARMcb8ZozZY9+eAYSKSLATs3qcx+dvpvhIJU9c1l0HppVykTZNw7jr/GS+z9jHgox9VsdxOmf+ZYkFcmt9nmff5rCNMaYKKAHqjrReDqwzxlTU/QYiMlVE0kQkraCgoMGCu7sVWQf4JC2PqUMSSWkdaXUcpXzKzYMT6dQygoe/yqC03LuvsHbrfz1FpAu2w063ONpvjJlljEk1xqTGxMS4NpxFjhyr4sEv0olvFsZdesW0Ui4X6O/HE5d3Z39pOU8vyLQ6jlM5s0DsBmovhBxn3+awjYgEAFFAof3zOOALYKIxZrsTc3qUx+dvZlfREf73su6EBPpbHUcpn9SzTWMmDYznvZU7Wbuz2Oo4TuPMArEGSBaRBBEJAiYA8+q0mYdtEBrgCmCxMcaISGPgW2C6MWaFEzN6lCWZ+by/chdTBiUwsL1e86CUle4b3ZFWkSHc/9kGyiu989oIpxUI+5jCNGABsBn4xBiTISKPicg4e7M3gGYikgXcAxw/FXYakAT8XUTW22/NnZXVExQfPsb9n22kQ4tG3De6o9VxlPJ5jYIDePKK7mwvOMxT33vnoaYAZ35xY8x8YH6dbX+vdb8cuNLB4/4J/NOZ2TyJMYa/ffk7B48c4+3JffXQklJuYnByDJMGtuPNFTmc37k55yRFWx2pQbn1ILWy+XhNLt+m7+UvIzvQpXWU1XGUUrVMH9OZxOhw7vt0g9etG6EFws1l7Cnh4XkZDE6O5tYh7a2Oo5SqIzTIn+eu7sn+0goenZdhdZwGpQXCjZWWV3LHB+toGhbEC1f3xM9PrI6klHKgZ5vGTDsvibm/7Wbuujyr4zQYLRBuyhjD9M/TyS0+yoxre9GskV5IrpQ7u3N4Ev0SmvLQF7+zbX+p1XEahBYIN/Xqsu18m76X+0Z1pG98U6vjKKVOIcDfjxnX9CI82J/bPljH4YoqqyOdNS0Qbmhhxj6eXpDJxT1ac+vQRKvjKKXqqUVkCC9O6MX2gjIe+iIdY4zVkc6KFgg3s3nvIe6es57usVE8fUV3RHTcQSlPMigpmrtHdODL9Xt4c8UOq+OcFS0QbiT/UDk3vZNGZEggsyam6vUOSnmoO4cnMbpLC/717SaWbMm3Os4Z0wLhJkqOVDLxzdUUHznG6xNTaRGpCwAp5an8/ITnr+5Jp5aR3PnRb2Tu88xBay0QbuDosWqmvLOG7QVlzLohlW5xejGcUp4uLCiAN25MJTTInynvrCG/tNzqSKdNC4TFKqtruOPDdazdVcwLV/fi3GTvulRfKV/WKiqU2RNTKSw7xqQ313jcldZaICxUUVXN7R+sY/GWfP55SVcu7N7K6khKqQbWo01jXruhD1n5pUx5ew1Hj3nOzK9aICxSXlnNbe+vY9Gm/Tw2vgvX9W9ndSSllJMM6RDDC1f3Yu2uYm59f63HTA+uBcIChyuquPndNBZvyefxS7sxcWC81ZGUUk52YfdWPHFZN5ZtLeDmd9M8oiehBcLF8kvLuXrWr/yyvZCnrujOtf3bWh1JKeUiV/dty9NXdGdF1gFufGu1219trQXChbLyS7l05i9kFxxm9sRUrkptc+oHKaW8ypWpbXhhQi/SdhZz7esrKSitsDrSCWmBcJHvf9/HJTN/oaKqhjlTB3JeJ59eIE8pnzauR2teu74PW/eXccnMFW47uZ8WCCerqq7hie+2cOv7a2nfvBHzpg3S6xyUUpyf0oI5twygoqqGy179haWZ7nfFtRYIJ8otOsK1s1fx72Xbua5/Wz65ZQCtG4daHUsp5Sa6xzXmyzvOIbZxKJPfXsNzCzOprnGfCf60QDiBMYY5a3ZxwQs/sWnPIZ69sgf/urQbwQE6t5JS6r/FNQnji9sHcUXvOF5anMXEN1exr8Q9rrrWAtHAcg4c5sa31vA/n6fTLS6K7+8ezOV94qyOpZRyY6FB/jx9ZQ+eurw763YeZOTzy/hsbZ7l04UHWPrdvciRY1XMXJLF6z/lEBTgx8MXpzBpYLwuE6qUqrer+rahf2JT/vrpRu77dAPfbNzDwxd3ISE63JI8YnWFaiipqakmLS3N5d+3oqqaOWtymbkki/2HKrisVyzTx3Siuc7GqpQ6QzU1hrd/2cFzi7ZSUVXN5EEJTBueRGRIYIN/LxFZa4xJdbhPC8SZOXqsms/X5fHKkiz2lJTTL74p91/QkVRdHlQp1UDyS8t5ZkEmn67No0lYEDcNTmDiwHgaBTfcwR8tEA1o98GjvPvrDj5enUvJ0Up6tmnMvaM6cG5StK7+ppRyivS8Ep5dlMnSzAIahwVy4znxXNu/Lc0jzv5IhRaIs3S4ooqFm/bxxW97+HlbAQCju7Rk8qAE+sY30cKglHKJDbkHmbF4Gz9szifATxjdtSXX9W/LgIRmZzzeqQXiDBSUVrA0M58lmfks2VLA0cpqYhuHcmmvWCb0a0Nck7AG+15KKXU6sgvK+HDVLj5dm0fJ0UpGd2nBazc4/Bt/SicrEHoWk11hWQVpO4tZu7OYldmFbMwrAaBFZDCX9o7lkp6xpLZromclKaUslxjTiL9dlMJ9ozvy/e/7iAhxzp9ypxYIEbkAeBHwB2YbY56osz8YeBfoAxQCVxtjdtj3PQBMAaqBPxtjFjgjY3peCXd9/BvZBw4DEOTvR/e4KO4d2YHzOjWnS+tIPYSklHJLIYH+XNIr1mlf32kFQkT8gZnASCAPWCMi84wxm2o1mwIUG2OSRGQC8CRwtYikABOALkBr4AcR6WCMafAJ1FtEBpMYE85VfduQ2q4JXWOjCAnUK56VUsqZPYh+QJYxJhtARD4GxgO1C8R44BH7/c+Al8X27/p44GNjTAWQIyJZ9q/3a0OHbB4ZwuxJfRv6yyqllMdz5lQbsUBurc/z7NsctjHGVAElQLN6PlYppZQTefRcTCIyVUTSRCStoKDA6jhKKeVVnFkgdgO1l0yLs29z2EZEAoAobIPV9XksxphZxphUY0xqTExMA0ZXSinlzAKxBkgWkQQRCcI26DyvTpt5wCT7/SuAxcZ2YcY8YIKIBItIApAMrHZiVqWUUnU4bZDaGFMlItOABdhOc33TGJMhIo8BacaYecAbwHv2QegibEUEe7tPsA1oVwF3OOMMJqWUUiemV1IrpZQPO9mV1B49SK2UUsp5tEAopZRyyGsOMYlIAbDzBLujgQMujHOmPCUneE5WzdmwPCUneE5Wq3O2M8Y4PA3UawrEyYhI2omOsbkTT8kJnpNVczYsT8kJnpPVnXPqISallFIOaYFQSinlkK8UiFlWB6gnT8kJnpNVczYsT8kJnpPVbXP6xBiEUkqp0+crPQillFKnSQuEUkoph7yyQIjIIyKyW0TW229jT9DuAhHJFJEsEZluQc6nRWSLiGwUkS9EpPEJ2u0QkXT7z+Ky+URO9fzYJ1OcY9+/SkTiXZWtTo42IrJERDaJSIaI3OWgzTARKan1mvi7RVlP+rsUm5fsz+lGEeltQcaOtZ6n9SJySETurtPGsudTRN4UkXwR+b3WtqYiskhEttk/NjnBYyfZ22wTkUmO2jg5p1u/5//AGON1N2yr1N13ijb+wHYgEQgCNgApLs45Cgiw338SePIE7XYA0S7OdsrnB7gd+Lf9/gRgjkW/71ZAb/v9CGCrg6zDgG+syHc6v0tgLPAdIMAAYJXFef2BfdgupnKL5xMYAvQGfq+17Slguv3+dEfvJaApkG3/2MR+v4mLc7rte97RzSt7EPX0nyVRjTHHgONLorqMMWahsa2kB7AS27oX7qI+z8944B37/c+AEfYlY13KGLPXGLPOfr8U2IznrkA4HnjX2KwEGotIKwvzjAC2G2NONEuByxljfsI2+3NttV+L7wCXOHjoaGCRMabIGFMMLAIucGVON3/P/4E3F4hp9m7cmyfobrrbsqZ/wvafoyMGWCgia0VkqovynM2SsZaxH+bqBaxysHugiGwQke9EpItLg/2fU/0u3e11OQH46AT73OH5PK6FMWav/f4+oIWDNu723Lrbe/4PnLYehLOJyA9ASwe7HgJeBf6B7Un+B/Astl+Gy50spzHmK3ubh7Cte/HBCb7MucaY3SLSHFgkIlvs/52oWkSkEfA5cLcx5lCd3euwHSYps49JfYltISpX85jfpdgW+hoHPOBgt7s8n39gjDEi4tbn73vKe95jC4Qx5vz6tBOR14FvHOyq17KmZ+tUOUXkRuAiYISxH3x08DV22z/mi8gX2A7/OPvFcjpLxubJfy8Z63IiEoitOHxgjJlbd3/tgmGMmS8ir4hItDHGpZOk1eN36ZLXZT2NAdYZY/bX3eEuz2ct+0WklTFmr/2QXL6DNruxjZ0cFwcsdUG2/+LG7/k/8MpDTHWO2V4K/O6gWX2WRHUqEbkAuB8YZ4w5coI24SIScfw+tkEuRz9PQzubJWNdyj7u8Qaw2Rjz3AnatDw+PiIi/bC99l1azOr5u5wHTLSfzTQAKKl16MTVruEEh5fc4fmso/ZrcRLwlYM2C4BRItLEfth5lH2by7j5e/6PrB4ld8YNeA9IBzZie+G0sm9vDcyv1W4stjNetmM75OPqnFnYjomut9/+XTcntrOINthvGa7M6ej5AR7D9uIGCAE+tf8cq4FEi37f52I7nLix1nM5FrgVuNXeZpr9+duAbXDwHAtyOvxd1skpwEz7c54OpFr0nIZj+4MfVWubWzyf2IrWXqAS2zjCFGxjXz8C24AfgKb2tqnA7FqP/ZP99ZoFTLYgp1u/5+vedKoNpZRSDnnlISallFJnTwuEUkoph7RAKKWUckgLhFJKKYe0QCillHJIC4RSSimHtEAopZRy6P8DFmmBGetZ90cAAAAASUVORK5CYII=\n",
+            "image/png": "iVBORw0KGgoAAAANSUhEUgAAAYgAAAD4CAYAAAD2FnFTAAAABHNCSVQICAgIfAhkiAAAAAlwSFlzAAALEgAACxIB0t1+/AAAADh0RVh0U29mdHdhcmUAbWF0cGxvdGxpYiB2ZXJzaW9uMy4yLjIsIGh0dHA6Ly9tYXRwbG90bGliLm9yZy+WH4yJAAAgAElEQVR4nO3deVxV1f7/8deHeRBwACdQAcEBZ8Upc0hT00qbs0nzWjbZrVvdvlb3dxvuvX2bJ7NuZvNog5WVpZZDZjmgqYSKIqjgBAIiqCDD+v1xjvfLpaOics4+w+f5eJwHh73XgTeHc/iw9tp7LTHGoJRSStXlZ3UApZRS7kkLhFJKKYe0QCillHJIC4RSSimHtEAopZRyKMDqAA0lOjraxMfHWx1DKaU8ytq1aw8YY2Ic7fOaAhEfH09aWprVMZRSyqOIyM4T7dNDTEoppRzSAqGUUsohLRBKKaUc0gKhlFLKIS0QSimlHNICoZRSyiEtEEoppRzymusglPIGhWUVbN5byt6SoxSUVVBTYxARohsF0bpxKJ1aRhITEWx1TOUjtEAoZaHDFVX8tLWARZv3syq7iN0Hj57yMYnR4QzpEMMlvWLpEReFiLggqfJFWiCUcjFjDOt2HeTDVbv4ZuMeKqpqaBwWyKD20Uw6px1dY6OIaxxGTEQw/n5CjTEUlFaQV3yUjXkHWZ1TxIerd/H2Lzvo2CKC289rz0XdW+Pvp4VCNSzxlhXlUlNTjU61odxZTY3h+4x9zFySRcaeQ4QH+TO+VywXd29N3/gmBPjXf0jwUHkl8zfu5c0VOWzdX0b7mHAeHdeVc5OjnfgTKG8kImuNMakO92mBUMq5jDF8m76Xl37cxtb9ZSRGhzNlcALje8bSKPjsOvE1NYYFGft44vst7Cw8wrgerXlsfBcahwU1UHrl7U5WIPQQk1JOtG5XMY99vYn1uQdJbt6IFyf0bNDDQX5+wphurTivU3NeXbqdV5ZmsXZnMS9d05M+7Zo2yPdQvkt7EEo5wZ6DR3niuy3M27CHmIhg/jq6I5f3jnP6OMGG3INM+2gdew6W8+i4Llw/oJ1Tv5/yfNqDUMpFqmsM7/66g2cWZFJVY7hzeBK3Dm1P+FkeSqqvHm0a8+2fB3P3x+v525e/s7PwMA+M6YyfDmCrM6AFQqkGsnnvIabPTWdD7kGGdojhn5d0pU3TMJfniAwJZNYNfXjsm028vjyHwrJjPH1lDz3LSZ02p15JLSIXiEimiGSJyHQH+4eIyDoRqRKRK+rsmyQi2+y3Sc7MqdTZKK+s5snvt3DxjJ/JKzrCixN68vbkvpYUh+MC/P14dFwX7h3Zgbm/7eaeT9ZTVV1jWR7lmZzWgxARf2AmMBLIA9aIyDxjzKZazXYBNwL31XlsU+BhIBUwwFr7Y4udlVepM7Eh9yD3fLKe7QWHuSo1jgfHdnabM4hEhDtHJOPnJzy9IBNj4IWre+rhJlVvzjzE1A/IMsZkA4jIx8B44D8Fwhizw76v7r82o4FFxpgi+/5FwAXAR07Mq1S9Hauq4eXF25i5dDstIoJ5f0p/t70G4Y7zkhCBp77PpGl4EA9fnKJXX6t6cWaBiAVya32eB/Q/i8fG1m0kIlOBqQBt27Y9s5RKnabMfaXc88l6MvYc4vLecTw8LoXIkECrY53UbUPbU1h2jDd+zqFlVAi3Dm1vdSTlATx6kNoYMwuYBbbTXC2Oo7xcdY1h9vJsnl24lYiQAF67oQ+ju7S0Ola9iAgPje1MfmkFT3y3hdjGoVzco7XVsZSbc2aB2A20qfV5nH1bfR87rM5jlzZIKqXOQG7REe75ZD1rdhQzKqUFj1/WjehGnjWrqp+f8MyV3dl78Ch//WwDiTHhdGkdZXUs5caceRbTGiBZRBJEJAiYAMyr52MXAKNEpImINAFG2bcp5XJfrd/NmBeXs2VvKc9e2YPXbujjccXhuOAAf165vjeNQ4OY+u5aCssqrI6k3JjTCoQxpgqYhu0P+2bgE2NMhog8JiLjAESkr4jkAVcCr4lIhv2xRcA/sBWZNcBjxweslXKVsooq7vlkPXd9vJ6OLSOYf9dgLu8T5/EDvM0jQpg1sQ8FZRXc8eE6Pf1VnZBOtaGUAxtyD3LXx7+xq+gI04Yn8+fhSac126on+GxtHvd9uoE/j0jmnpEdrI6jLKJTbShVTzU1hlnLs3lmQSbNI4L5eOpA+iV456R3V/SJ49fthcxYvI0BiU05p717nqarrONd/xIpdRYOlFUw6a3VPPHdFkamtOC7u4Z4bXE47rHxXUhoFs5f5qzX8Qj1B1oglALSdhRx0Us/szqniP+9rBuvXNebqDD3vrahIYQHBzDj2l4UH67kvk834C2HnFXD0AKhfJoxtmsbJsxaSXCgH3NvP4dr+rX1+IHo09GldRQPju3EkswCPly9y+o4yo3oGITyWYfKK7n/0418n7GPUSktePrKHkSFen+vwZGJA+NZtHk///p2M0OSYyydaFC5D+1BKJ+UXVDGJTNXsGjzfh4c24nXbujjs8UBbBfRPXVFD/xE+OtnG6ip0UNNSguE8kE/bzvAJTNXcPBIJR/c1J+pQ9r71CGlE4ltHMr/u6gzK7OLePfXHVbHUW5AC4TyGcbYVnub9NZqWkWF8tUdgxiQ2MzqWG7lqtQ2nNcxhie+30LOgcNWx1EW0wKhfEJ1jeHheRn8/asMzusYw+e3n6PH2R0QEZ64vDuB/n48ODddz2rycVoglNcrr6xm2ofrePfXnUwdkshrN6TSyEVrRHuiFpEhTB/TiV+zC/lsbZ7VcZSFtEAor3aovJIb31rNd7/v428XdubBsZ11beZ6uKZvW1LbNeFf8zfrBXQ+TAuE8loFpRVMeG0laTuKeeHqntw0ONHqSB7Dz094/LJuHK6o4l/fbrY6jrKIFgjllfJLy7nm9ZXkHDjMGzf25ZJef1iQUJ1ChxYR3DKkPXN/283P2w5YHUdZQAuE8jr5peVcM2slu4uP8vbkvgztEGN1JI81bXgS8c3CeOjLdMorq62Oo1xMC4TyKseLw96Sct6e3Jf+ehrrWQkJ9Oefl3RjZ+ERXv8p2+o4ysW0QCivcfDIMa6fvYq9JeW8daMWh4ZybnI0Y7u1ZObSLPKKj1gdR7mQFgjlFY4eq2bKO2nsOHCE2ZNStTg0sIcuTAHg8fk6YO1LtEAoj1dZXcMdH65j3a5iXpzQUxe+cYLYxqHcMSyJ+en7WJGlA9a+QguE8mjGGB76Ip3FW/L5x/iujOnWyupIXuvmIYm0bRrGw/MyqNR1rH2CFgjl0WYvz+GTtDz+PDyJ6we0szqOVwsJ9OfvF6WQlV/GO7/ssDqOcgEtEMpjLdmSz+PfbebCbq24+/wOVsfxCSM6N2dYxxhe+GEb+aXlVsdRTqYFQnmkbftLufOj3+jSOpJnruyBn06f4RIiwsMXd6GiqppnF2y1Oo5yMi0QyuMcKq/k5nfTCA3y5/WJqYQG+VsdyackRIczaWA8n6zNZdOeQ1bHUU6kBUJ5FGMM0z/fSG7xUV69rjetokKtjuST7hyeTFRoIP/8dpNOCe7FtEAoj/LOLzuYn76P+0d3JDW+qdVxfFZUWCB3j0jml+2FLN6Sb3Uc5SRaIJTH2JB7kH/N38yITs25WWdmtdx1A9qRGBPOv+Zv1tNevZQWCOURyiqqmPbROppHhPDsVToo7Q4C/f14aGxnsgsO8+GqXVbHUU6gBUJ5hH98vYndxUd5cUJPGocFWR1H2Q3v1JxBSc14/oetlByptDqOamBaIJTbW5ixjzlpudw6tL2OO7gZEeGhsSmUHK1kxuJtVsdRDcypBUJELhCRTBHJEpHpDvYHi8gc+/5VIhJv3x4oIu+ISLqIbBaRB5yZU7mvA2UVPDA3nZRWkXoxnJtKaR3JVX3a8M6vO9hx4LDVcVQDclqBEBF/YCYwBkgBrhGRlDrNpgDFxpgk4HngSfv2K4FgY0w3oA9wy/HioXyHMYYH56ZTWl7F81f3JChAO7zu6t7RHQj09+OpBVusjqIakDPfcf2ALGNMtjHmGPAxML5Om/HAO/b7nwEjREQAA4SLSAAQChwD9IocHzM/fR8LN+3n3lEd6Ngywuo46iSaR4Rw8+BE5qfvY33uQavjqAbizAIRC+TW+jzPvs1hG2NMFVACNMNWLA4De4FdwDPGmKK630BEpopImoikFRQUNPxPoCxTcqSSh+dl0DU2kinnJlgdR9XDzUMSiW4UxBPfbdaL57yEu/bZ+wHVQGsgAbhXRP5w4rsxZpYxJtUYkxoTo+sOe5Mnvt9C0eEKnrisOwH+7voyVbU1Cg7gzyOSWZldxNKt+g+bN3DmO2830KbW53H2bQ7b2A8nRQGFwLXA98aYSmNMPrACSHViVuVGVucU8dHqXUw5N4GusVFWx1GnYULftrRrFsaT322hukZ7EZ7OmQViDZAsIgkiEgRMAObVaTMPmGS/fwWw2Nj6pruA4QAiEg4MAHT0ywdUVFXzwNyNxDUJ5S8j9awlTxMU4Md9ozqyZV8pX62v+/+g8jROKxD2MYVpwAJgM/CJMSZDRB4TkXH2Zm8AzUQkC7gHOH4q7EygkYhkYCs0bxljNjorq3Ifs5fnsL3gMP+8pCthQQFWx1Fn4MJuregWG8WzC7dSXlltdRx1Fpz6DjTGzAfm19n291r3y7Gd0lr3cWWOtivvtq+knJlLshiV0oJhHZtbHUedIT8/YfqYTlw3exXvr9zJTTpvlsfS0T/lNp74bjNVNYa/XVj3chnlaQYlRTM4OZqXl2RxqFyn4PBUWiCUW0jbUcSX6/cwdXAibZuFWR1HNYD/uaATB49U8tqy7VZHUWdIC4SyXHWN4ZGvM2gZGcLt57W3Oo5qIF1joxjfszVv/JzD/kO6frUn0gKhLPdpWi6/7z7EA2M76cC0l7l3ZEeqawwv/KAT+XkiLRDKUkeOVfHsoq30adeEcT1aWx1HNbC2zcK4tl9bPk3L1Yn8PJAWCGWp2ctzKCit4MGxnbBNw6W8zR3DkwjwF174YavVUdRp0gKhLFNYVsFry7YzKqUFfdrpOg/eqnlECJPOieerDXvI3FdqdRx1GrRAKMvMWJxFeVUN91/QyeooysluHdKeRkEBPLco0+oo6jRogVCW2Fl4mA9W7eSq1DYkNW9kdRzlZE3Cg7hpcCILMvazMU+nA/cUWiCUJZ5ekIm/n3D3+clWR1Eu8qdz42kSFsgzC3UswlNogVAul55Xwjcb93LTuYm0iAyxOo5ykYiQQG4b1p6fthawOucPy7soN6QFQrnc8z9sJSo0kKlDdY4eXzNxYDzNI4J5esEWXVTIA2iBUC61Pvcgi7fkM3VIIpEhgVbHUS4WEujPnSOSWbOjmGW6qJDb0wKhXOr5RVtpEhbIpHPirY6iLHJ1ahvimoTy7MKt2otwc1oglMus3Wn7r3HqkPY0CtYpNXxVUIAfd5/fgfTdJSzI2Gd1HHUSWiCUy7zww1aahQcxcWA7q6Moi13aK5b2MeE8u3CrLk3qxrRAKJdYs6OI5dsOcMvQRMK19+Dz/P2Ee0Z2ZFt+GV9v2GN1HHUCWiCUSzy/aCvRjYK5YUC81VGUmxjTtSWdWkbw0o/bqKqusTqOckALhHK6VdmF/LK9kFuHJhIa5G91HOUm/PyEu8/vQPaBw3y9UXsR7kgLhHK6mUu30yw8iOv669iD+m+jUlrQuVUkL/2Ypb0IN6QFQjlVel4JP20tYMrgBO09qD/ws0+3knPgMPN0LMLtaIFQTvXqsiwiQgK4foD2HpRjo1JakNIqUsci3JAWCOU0WfllfPf7PiYNjNerptUJidh6ETsKj/Dleu1FuBMtEMpp/r1sO8EBfkweFG91FOXmRqa0oEvrSGYs1l6EO9ECoZwir/gIX/62m2v6taVZo2Cr4yg3Z+tFdGBn4RG++G231XGUnRYI5RSv/5SNCNw8WGdsVfVzfufmdI2N5OUlekaTu9ACoRpcQWkFH6/J5bJecbRuHGp1HOUhRIS7R9h6EXO1F+EWtECoBvfmihwqq2u4dVh7q6MoDzOic3O6xUYxY/E2KrUXYbl6FQgRmSsiF4qIFhR1UiVHK3nv152M7daKhOhwq+MoD3P8jKbcoqN8sU57EVar7x/8V4BrgW0i8oSIdKzPg0TkAhHJFJEsEZnuYH+wiMyx718lIvG19nUXkV9FJENE0kVE16b0AB+t3kVZRRW3DtXegzozwzs1p0dcFDOWaC/CavUqEMaYH4wx1wG9gR3ADyLyi4hMFhGHJ7iLiD8wExgDpADXiEhKnWZTgGJjTBLwPPCk/bEBwPvArcaYLsAwoPI0fzblYseqanhrRQ6DkprRNTbK6jjKQx0/oym36Chz1+VZHcen1fuQkYg0A24EbgJ+A17EVjAWneAh/YAsY0y2MeYY8DEwvk6b8cA79vufASNERIBRwEZjzAYAY0yhMaa6vlmVNb7esIf9hyr0zCV11oZ1jKFbbBSvLN2uZzRZqL5jEF8Ay4Ew4GJjzDhjzBxjzJ1AoxM8LBbIrfV5nn2bwzbGmCqgBGgGdACMiCwQkXUicv8Jck0VkTQRSSso0PVtrWSM4fXl2XRsEcHQDjFWx1EeTkSYNjyJnYVH+GbjXqvj+Kz69iBeN8akGGP+1xizF2zjBwDGmFQn5AoAzgWus3+8VERG1G1kjJlljEk1xqTGxOgfJSst33aALftKuWlwArZOoFJnZ2TnFnRsEcHLS7Ko0VXnLFHfAvFPB9t+PcVjdgNtan0eZ9/msI193CEKKMTW2/jJGHPAGHMEmI/tcJZyU68vz6Z5RDDjera2OoryEn5+tl5EVn4Z3+va1ZY4aYEQkZYi0gcIFZFeItLbfhuG7XDTyawBkkUkQUSCgAnAvDpt5gGT7PevABYbYwywAOgmImH2wjEU2HRaP5lymU17DrF82wFuHBRPcIBO6a0azthurUiMCWfG4ixsfxqUK51qceDR2Aam44Dnam0vBR482QONMVUiMg3bH3t/4E1jTIaIPAakGWPmAW8A74lIFlCErYhgjCkWkeewFRkDzDfGfHu6P5xyjdnLswkL8ue6fjqlt2pY/n7CHcOSuPfTDfy4OZ/zU1pYHcmnSH2qsohcboz53AV5zlhqaqpJS0uzOobP2VtylMFPLuGGge14+OIuVsdRXqiyuobhzy6laVgQX94xSMe4GpiIrD3RWPKpDjFdb78bLyL31L01eFLlcd5esYMaY/jToASroygvFejvx+3DktiQV8LybQesjuNTTjVIfXyuhEZAhIOb8mGl5ZV8uGoXY7u1ok3TUw1JKXXmLusdS6uoEGYs3qZjES500jEIY8xr9o+PuiaO8iRz1uRSWlHF1CF6YZxyruAAf24ZksgjX29iVU4RAxKbWR3JJ9T3QrmnRCRSRAJF5EcRKah1+En5oMrqGt78OYf+CU3pHtfY6jjKB0zo15boRsHMWLzN6ig+o77XQYwyxhwCLsI2F1MS8FdnhVLub376XvaUlGvvQblMSKA/U4cksCKrkLU7i62O4xPqWyCOH4q6EPjUGFPipDzKAxhjmPVTNu1jwjmvY3Or4ygfcl3/djQJC+Rl7UW4RH0LxDcisgXoA/woIjFAufNiKXf26/ZCMvYc4ubBifj56SmHynXCgwOYcm4CSzIL+H23/p/qbPWd7ns6cA6QaoypBA7zx5lZlY+YtTyb6EZBXNKr7tyLSjnfxHPiiQgJ0LEIFzjVldS1dcJ2PUTtx7zbwHmUm9u2v5SlmQXcM7IDIYE6rYZyvciQQCafE89Li7PI3FdKx5Z6xr2z1PcspveAZ7DNrNrXfnPGLK7Kzc1enkNIoB/XD9BpNZR1Jg9KICzIn5lLsqyO4tXq24NIBVKMXqHi0wpKK/hi/W6u7BNH0/Agq+MoH9YkPIgbBrTj9eXZ/GVkB13/3EnqO0j9O9DSmUGU+3tv5U6OVdXwp3N1Wg1lvSmDEwjw9+PVpdqLcJb6FohoYJN9hbd5x2/ODKbcS3llNe+v3Mn5nZvTPuZEiwgq5TrNI0K4pm8b5q7bze6DR62O45Xqe4jpEWeGUO5v7rrdFB0+xk263rRyI1OHtueDVbt4bdl2Hhvf1eo4Xqe+p7kuw3YFdaD9/hpgnRNzKTdSU2OY/XM2XWMj6Z/Q1Oo4Sv1HbONQLu8dx8drcsk/pJdmNbT6nsV0M/AZ8Jp9UyzwpbNCKfeyJDOf7ILD3Dw4UefiV27ntmHtqaquYfbPOVZH8Tr1HYO4AxgEHAIwxmwDdI4FH/H68mxaRYUwtlsrq6Mo9Qfx0eFc3KM176/cSfHhY1bH8Sr1LRAVxpj/PPP2i+X0lFcf8PvuElZmFzF5UDyB/vV9uSjlWnecl8SRY9W8tUJ7EQ2pvu/4ZSLyIBAqIiOBT4GvnRdLuYvZy7MJD/Ln6r5trY6i1Al1aBHB6C4teOuXHRwqr7Q6jteob4GYDhQA6cAtwHzgb84KpdzD3pKjfLNxL1f3bUtUaKDVcZQ6qWnnJVNaXsV7v+60OorXqNdprsaYGhH5EvjSGFPg5EzKTbz9i2296cmD4q2OotQpdYuLYmiHGN74OYfJg+IJCzqdqeaUIyftQYjNIyJyAMgEMu2ryf3dNfGUVcoqqvhw1S7GdNX1ppXnuHN4EkWHj/HR6lyro3iFUx1i+gu2s5f6GmOaGmOaAv2BQSLyF6enU5b5ZE0upeVV3DRYp9VQniM1vikDEpsy66ftlFdWWx3H452qQNwAXGOM+c+pAcaYbOB6YKIzgynrVFXX8OaKHFLbNaFX2yZWx1HqtEw7L5n9hyr4bG2e1VE83qkKRKAx5kDdjfZxCB219FILN+0nr/io9h6URxqU1IyebRrz72XbqayusTqORztVgTjZVSd6RYqXen15Nu2ahTEyRSfwVZ5HRJh2XhJ5xUf5av0eq+N4tFMViB4icsjBrRTo5oqAyrXW7izit10H+dOgBPx1vWnloUZ0bk7nVpG8sjSL6hq9pvdMnbRAGGP8jTGRDm4Rxhg9xOSF/r0sm8ZhgVzRJ87qKEqdMRHhjvPak11wmO9+32t1HI+lcyeo/8jKL2XRpv1MHBhPeLCeQ64825iurUiMCeflxVnoYphnxqkFQkQuEJFMEckSkekO9geLyBz7/lUiEl9nf1sRKROR+5yZU9m8tiybkEA/Jg3U9aaV5/P3E24flsSWfaX8uDnf6jgeyWkFQkT8gZnAGCAFuEZEUuo0mwIUG2OSgOeBJ+vsfw74zlkZ1f/ZV1LOl+t3c1VqG5o1CrY6jlINYnzP1sQ1CWXGEu1FnAln9iD6AVnGmGz7TLAfA+PrtBkPvGO//xkwQuwLDojIJUAOkOHEjMruzRU51Bi4WVeMU14k0N+P24a1Z0PuQVZkFVodx+M4s0DEArWvd8+zb3PYxhhTBZQAzUSkEfA/wKMn+wYiMlVE0kQkraBAp4g6UyVHK/lw1S4u7KbTaijvc0WfOFpEBjNj8Taro3gcdx2kfgR43hhTdrJGxphZxphUY0xqTEyMa5J5oQ9W7aSsoopbhmrvQXmf4AB/pg5pz6qcItbsKLI6jkdxZoHYDbSp9XmcfZvDNvZFiKKAQmzzPT0lIjuAu4EHRWSaE7P6rPLKat78eQeDk6Pp0jrK6jhKOcU1/drQNDyIlxdnWR3FozizQKwBkkUkQUSCgAnAvDpt5gGT7PevABYbm8HGmHhjTDzwAvC4MeZlJ2b1WXPX7eZAWQW3DW1vdRSlnCYsKIAp5yawbGsB6XklVsfxGE4rEPYxhWnAAmAz8IkxJkNEHhORcfZmb2Abc8gC7sG2MJFykeoaw+vLs+keF8XA9s2sjqOUU90wsB0RIQG8vETHIurLqVdDGWPmY1t9rva2v9e6Xw5ceYqv8YhTwikWZuwj58BhXrmuN/aTx5TyWpEhgUw+J56XFmexdX8pHVpEWB3J7bnrILVyMmMMLy/JIiE6nNFddFI+5RsmD0ogLMifmUt0LKI+tED4qMVb8snYc4jbh7XXSfmUz2gSHsT1A9rx9YY97Dhw2Oo4bk8LhA8yxjBjcRZxTUK5pFfdS1OU8m43DU4gwN+PV5dutzqK29MC4YN+zjrA+tyD3DasPYH++hJQvqV5RAgT+rbh83V57D541Oo4bk3/OvigGT9m0SoqRKf0Vj7rFvtp3bOWaS/iZLRA+JhV2YWs3lHELUMSCQ7wtzqOUpaIbRzKZb1j+WhNLvml5VbHcVtaIHzMjMVZRDcKZkK/tlZHUcpStw1Loqq6hjeW51gdxW1pgfAh63YV83PWAaYOSSAkUHsPyrclRIdzcY/WvPvrTg6UVVgdxy1pgfAhL/24jSZhgVzXXxcEUgrgzuHJVFRV6xlNJ6AFwkes3VnE0swCbhqcqMuJKmWX1LwRl/WO472VO9lXomMRdWmB8BHPLtxKdKMgJg+KtzqKUm7lrhHJ9pkFdI6murRA+IBfsg7wy/ZCbhuWRFiQ9h6Uqq1N0zCu7tuGOWtyyS06YnUct6IFwssZY3h20VZaRoZwXX89c0kpR6adl4yI8OKP2ouoTQuEl1u2tYC1O4uZNjxJz1xS6gRaRoVww4B2zF2Xx/aCky5k6VO0QHgxYwzPLtxKXJNQrkptc+oHKOXDbhvWnpBAf174QXsRx2mB8GILN+0nfXcJd41IJihAf9VKnUx0o2AmD4rn6w172Lz3kNVx3IL+1fBSVdU1PLMgk8TocC7VGVuVqpepg9sTERLAswu3Wh3FLWiB8FKfpOWxLb+M+y/oSIDO2KpUvUSFBXLr0Pb8sHk/q3OKrI5jOf3L4YUOV1Tx3KKtpLZroqvFKXWa/jQogZaRITw+fzPGGKvjWEoLhBea9VM2B8oqeGBsZ11rWqnTFBrkzz2jOrA+9yDfpu+1Oo6ltEB4mfxD5cz6KZux3VrSp10Tq+Mo5ZEu7x1Hp5YRPPV9JhVV1VbHsYwWCC/z/A9bqaqp4f7RnayOopTH8vcTHhjbmV1FR/hg5S6r41hGC4QX2bq/lDlrcrmufzvio8OtjqOURxuSHM25SdG8tHgbJUcrrY5jCS0QXsIYwyPzMmgUHMCfRyRbHUcpjyciPDC2EyVHK4mSB3EAAA+fSURBVHllSZbVcSyhBcJLfPf7Pn7ZXsi9ozrSNDzI6jhKeYUuraO4rFccb63YQc6Bw1bHcTktEF7g6LFq/vXtZjq1jNAJ+ZRqYP8zpiNBAX7845tNVkdxOS0QXuDVpVnsPniUR8d10YvilGpgzSNCuGtEMou35LN4y36r47iU/jXxcLsKj/Dvn7IZ16M1/RObWR1HKa806Zx4EmPCeezrTT512qsWCA9mjOHRrzMI8BMeHNvZ6jhKea2gAD8eubgLOwqP8MbPOVbHcRmnFggRuUBEMkUkS0SmO9gfLCJz7PtXiUi8fftIEVkrIun2j8OdmdNTfZu+lx+35POX8zvQMirE6jhKebUhHWIYldKClxdnsbfkqNVxXMJpBUJE/IGZwBggBbhGRFLqNJsCFBtjkoDngSft2w8AFxtjugGTgPecldNTHTxyjEfmZdA9LkrXmVbKRf7fRSlU1xgenecbA9bO7EH0A7KMMdnGmGPAx8D4Om3GA+/Y738GjBARMcb8ZozZY9+eAYSKSLATs3qcx+dvpvhIJU9c1l0HppVykTZNw7jr/GS+z9jHgox9VsdxOmf+ZYkFcmt9nmff5rCNMaYKKAHqjrReDqwzxlTU/QYiMlVE0kQkraCgoMGCu7sVWQf4JC2PqUMSSWkdaXUcpXzKzYMT6dQygoe/yqC03LuvsHbrfz1FpAu2w063ONpvjJlljEk1xqTGxMS4NpxFjhyr4sEv0olvFsZdesW0Ui4X6O/HE5d3Z39pOU8vyLQ6jlM5s0DsBmovhBxn3+awjYgEAFFAof3zOOALYKIxZrsTc3qUx+dvZlfREf73su6EBPpbHUcpn9SzTWMmDYznvZU7Wbuz2Oo4TuPMArEGSBaRBBEJAiYA8+q0mYdtEBrgCmCxMcaISGPgW2C6MWaFEzN6lCWZ+by/chdTBiUwsL1e86CUle4b3ZFWkSHc/9kGyiu989oIpxUI+5jCNGABsBn4xBiTISKPicg4e7M3gGYikgXcAxw/FXYakAT8XUTW22/NnZXVExQfPsb9n22kQ4tG3De6o9VxlPJ5jYIDePKK7mwvOMxT33vnoaYAZ35xY8x8YH6dbX+vdb8cuNLB4/4J/NOZ2TyJMYa/ffk7B48c4+3JffXQklJuYnByDJMGtuPNFTmc37k55yRFWx2pQbn1ILWy+XhNLt+m7+UvIzvQpXWU1XGUUrVMH9OZxOhw7vt0g9etG6EFws1l7Cnh4XkZDE6O5tYh7a2Oo5SqIzTIn+eu7sn+0goenZdhdZwGpQXCjZWWV3LHB+toGhbEC1f3xM9PrI6klHKgZ5vGTDsvibm/7Wbuujyr4zQYLRBuyhjD9M/TyS0+yoxre9GskV5IrpQ7u3N4Ev0SmvLQF7+zbX+p1XEahBYIN/Xqsu18m76X+0Z1pG98U6vjKKVOIcDfjxnX9CI82J/bPljH4YoqqyOdNS0Qbmhhxj6eXpDJxT1ac+vQRKvjKKXqqUVkCC9O6MX2gjIe+iIdY4zVkc6KFgg3s3nvIe6es57usVE8fUV3RHTcQSlPMigpmrtHdODL9Xt4c8UOq+OcFS0QbiT/UDk3vZNGZEggsyam6vUOSnmoO4cnMbpLC/717SaWbMm3Os4Z0wLhJkqOVDLxzdUUHznG6xNTaRGpCwAp5an8/ITnr+5Jp5aR3PnRb2Tu88xBay0QbuDosWqmvLOG7QVlzLohlW5xejGcUp4uLCiAN25MJTTInynvrCG/tNzqSKdNC4TFKqtruOPDdazdVcwLV/fi3GTvulRfKV/WKiqU2RNTKSw7xqQ313jcldZaICxUUVXN7R+sY/GWfP55SVcu7N7K6khKqQbWo01jXruhD1n5pUx5ew1Hj3nOzK9aICxSXlnNbe+vY9Gm/Tw2vgvX9W9ndSSllJMM6RDDC1f3Yu2uYm59f63HTA+uBcIChyuquPndNBZvyefxS7sxcWC81ZGUUk52YfdWPHFZN5ZtLeDmd9M8oiehBcLF8kvLuXrWr/yyvZCnrujOtf3bWh1JKeUiV/dty9NXdGdF1gFufGu1219trQXChbLyS7l05i9kFxxm9sRUrkptc+oHKaW8ypWpbXhhQi/SdhZz7esrKSitsDrSCWmBcJHvf9/HJTN/oaKqhjlTB3JeJ59eIE8pnzauR2teu74PW/eXccnMFW47uZ8WCCerqq7hie+2cOv7a2nfvBHzpg3S6xyUUpyf0oI5twygoqqGy179haWZ7nfFtRYIJ8otOsK1s1fx72Xbua5/Wz65ZQCtG4daHUsp5Sa6xzXmyzvOIbZxKJPfXsNzCzOprnGfCf60QDiBMYY5a3ZxwQs/sWnPIZ69sgf/urQbwQE6t5JS6r/FNQnji9sHcUXvOF5anMXEN1exr8Q9rrrWAtHAcg4c5sa31vA/n6fTLS6K7+8ezOV94qyOpZRyY6FB/jx9ZQ+eurw763YeZOTzy/hsbZ7l04UHWPrdvciRY1XMXJLF6z/lEBTgx8MXpzBpYLwuE6qUqrer+rahf2JT/vrpRu77dAPfbNzDwxd3ISE63JI8YnWFaiipqakmLS3N5d+3oqqaOWtymbkki/2HKrisVyzTx3Siuc7GqpQ6QzU1hrd/2cFzi7ZSUVXN5EEJTBueRGRIYIN/LxFZa4xJdbhPC8SZOXqsms/X5fHKkiz2lJTTL74p91/QkVRdHlQp1UDyS8t5ZkEmn67No0lYEDcNTmDiwHgaBTfcwR8tEA1o98GjvPvrDj5enUvJ0Up6tmnMvaM6cG5StK7+ppRyivS8Ep5dlMnSzAIahwVy4znxXNu/Lc0jzv5IhRaIs3S4ooqFm/bxxW97+HlbAQCju7Rk8qAE+sY30cKglHKJDbkHmbF4Gz9szifATxjdtSXX9W/LgIRmZzzeqQXiDBSUVrA0M58lmfks2VLA0cpqYhuHcmmvWCb0a0Nck7AG+15KKXU6sgvK+HDVLj5dm0fJ0UpGd2nBazc4/Bt/SicrEHoWk11hWQVpO4tZu7OYldmFbMwrAaBFZDCX9o7lkp6xpLZromclKaUslxjTiL9dlMJ9ozvy/e/7iAhxzp9ypxYIEbkAeBHwB2YbY56osz8YeBfoAxQCVxtjdtj3PQBMAaqBPxtjFjgjY3peCXd9/BvZBw4DEOTvR/e4KO4d2YHzOjWnS+tIPYSklHJLIYH+XNIr1mlf32kFQkT8gZnASCAPWCMi84wxm2o1mwIUG2OSRGQC8CRwtYikABOALkBr4AcR6WCMafAJ1FtEBpMYE85VfduQ2q4JXWOjCAnUK56VUsqZPYh+QJYxJhtARD4GxgO1C8R44BH7/c+Al8X27/p44GNjTAWQIyJZ9q/3a0OHbB4ZwuxJfRv6yyqllMdz5lQbsUBurc/z7NsctjHGVAElQLN6PlYppZQTefRcTCIyVUTSRCStoKDA6jhKKeVVnFkgdgO1l0yLs29z2EZEAoAobIPV9XksxphZxphUY0xqTExMA0ZXSinlzAKxBkgWkQQRCcI26DyvTpt5wCT7/SuAxcZ2YcY8YIKIBItIApAMrHZiVqWUUnU4bZDaGFMlItOABdhOc33TGJMhIo8BacaYecAbwHv2QegibEUEe7tPsA1oVwF3OOMMJqWUUiemV1IrpZQPO9mV1B49SK2UUsp5tEAopZRyyGsOMYlIAbDzBLujgQMujHOmPCUneE5WzdmwPCUneE5Wq3O2M8Y4PA3UawrEyYhI2omOsbkTT8kJnpNVczYsT8kJnpPVnXPqISallFIOaYFQSinlkK8UiFlWB6gnT8kJnpNVczYsT8kJnpPVbXP6xBiEUkqp0+crPQillFKnSQuEUkoph7yyQIjIIyKyW0TW229jT9DuAhHJFJEsEZluQc6nRWSLiGwUkS9EpPEJ2u0QkXT7z+Ky+URO9fzYJ1OcY9+/SkTiXZWtTo42IrJERDaJSIaI3OWgzTARKan1mvi7RVlP+rsUm5fsz+lGEeltQcaOtZ6n9SJySETurtPGsudTRN4UkXwR+b3WtqYiskhEttk/NjnBYyfZ22wTkUmO2jg5p1u/5//AGON1N2yr1N13ijb+wHYgEQgCNgApLs45Cgiw338SePIE7XYA0S7OdsrnB7gd+Lf9/gRgjkW/71ZAb/v9CGCrg6zDgG+syHc6v0tgLPAdIMAAYJXFef2BfdgupnKL5xMYAvQGfq+17Slguv3+dEfvJaApkG3/2MR+v4mLc7rte97RzSt7EPX0nyVRjTHHgONLorqMMWahsa2kB7AS27oX7qI+z8944B37/c+AEfYlY13KGLPXGLPOfr8U2IznrkA4HnjX2KwEGotIKwvzjAC2G2NONEuByxljfsI2+3NttV+L7wCXOHjoaGCRMabIGFMMLAIucGVON3/P/4E3F4hp9m7cmyfobrrbsqZ/wvafoyMGWCgia0VkqovynM2SsZaxH+bqBaxysHugiGwQke9EpItLg/2fU/0u3e11OQH46AT73OH5PK6FMWav/f4+oIWDNu723Lrbe/4PnLYehLOJyA9ASwe7HgJeBf6B7Un+B/Astl+Gy50spzHmK3ubh7Cte/HBCb7MucaY3SLSHFgkIlvs/52oWkSkEfA5cLcx5lCd3euwHSYps49JfYltISpX85jfpdgW+hoHPOBgt7s8n39gjDEi4tbn73vKe95jC4Qx5vz6tBOR14FvHOyq17KmZ+tUOUXkRuAiYISxH3x08DV22z/mi8gX2A7/OPvFcjpLxubJfy8Z63IiEoitOHxgjJlbd3/tgmGMmS8ir4hItDHGpZOk1eN36ZLXZT2NAdYZY/bX3eEuz2ct+0WklTFmr/2QXL6DNruxjZ0cFwcsdUG2/+LG7/k/8MpDTHWO2V4K/O6gWX2WRHUqEbkAuB8YZ4w5coI24SIScfw+tkEuRz9PQzubJWNdyj7u8Qaw2Rjz3AnatDw+PiIi/bC99l1azOr5u5wHTLSfzTQAKKl16MTVruEEh5fc4fmso/ZrcRLwlYM2C4BRItLEfth5lH2by7j5e/6PrB4ld8YNeA9IBzZie+G0sm9vDcyv1W4stjNetmM75OPqnFnYjomut9/+XTcntrOINthvGa7M6ej5AR7D9uIGCAE+tf8cq4FEi37f52I7nLix1nM5FrgVuNXeZpr9+duAbXDwHAtyOvxd1skpwEz7c54OpFr0nIZj+4MfVWubWzyf2IrWXqAS2zjCFGxjXz8C24AfgKb2tqnA7FqP/ZP99ZoFTLYgp1u/5+vedKoNpZRSDnnlISallFJnTwuEUkoph7RAKKWUckgLhFJKKYe0QCillHJIC4RSSimHtEAopZRy6P8DFmmBGetZ90cAAAAASUVORK5CYII=",
             "text/plain": [
               "<Figure size 432x288 with 1 Axes>"
             ]
           },
           "metadata": {
             "needs_background": "light"
-          }
+          },
+          "output_type": "display_data"
         }
+      ],
+      "source": [
+        "df = pd.DataFrame(np.random.randint(10, size=(10,4)), columns=list(\"ABCD\"))\n",
+        "\n",
+        "df.A.plot.kde()\n",
+        "plt.show()"
       ]
     },
     {
@@ -6283,34 +6260,34 @@
     },
     {
       "cell_type": "code",
+      "execution_count": 110,
       "metadata": {
         "colab": {
           "base_uri": "https://localhost:8080/",
           "height": 265
         },
         "id": "SgXXLkiaA9xl",
-        "outputId": "63b5d68f-d5d3-407d-88cd-c638c4fd935b"
+        "outputId": "4a155eb2-2fe4-4568-eda9-48a391ad0b69"
       },
-      "source": [
-        "df = pd.DataFrame(np.random.randint(10, size=(10,4)), columns=list(\"ABCD\"))\n",
-        "\n",
-        "df.A.plot.line()\n",
-        "plt.show()"
-      ],
-      "execution_count": 456,
       "outputs": [
         {
-          "output_type": "display_data",
           "data": {
-            "image/png": "iVBORw0KGgoAAAANSUhEUgAAAWoAAAD4CAYAAADFAawfAAAABHNCSVQICAgIfAhkiAAAAAlwSFlzAAALEgAACxIB0t1+/AAAADh0RVh0U29mdHdhcmUAbWF0cGxvdGxpYiB2ZXJzaW9uMy4yLjIsIGh0dHA6Ly9tYXRwbG90bGliLm9yZy+WH4yJAAAgAElEQVR4nO3dd3jb5bk38O8tydvySLwdz8QZdoaTmJBl05ZQEmZJIUCb0EKJ4XQQaPu2cM7pyxm051ysUwo9bUwgpWWvQpuw2jKyQyzHSeQ407FsS96WJW9b0nP+sB2S4CHbkn7r/lwXF0ksSzfC+frxs24SQoAxxph86aQugDHG2Ng4qBljTOY4qBljTOY4qBljTOY4qBljTOYM/njSuLg4kZmZ6Y+nZowxVTKZTC1CiPiRPuaXoM7MzERpaak/npoxxlSJiCyjfYynPhhjTOY4qBljTOY4qBljTOY4qBljTOY4qBljTOa8CmoieoCIKojITESvEFGovwtjjDE2aNygJqJUAPcBKBBCzAegB3CbvwtjjDE2yNupDwOAMCIyAAgHYPNfSYzJ174zLSirsUtdhiw4ugfw8sEa9A64pS5F9cY98CKEsBLR4wBqAPQA+EgI8dGljyOiYgDFAJCenu7rOhmTnMcjcM+LJnT2ufCjr87CfVfmwKDX5jJPaXUbtrxaDmt7D5y9A7j3iplSl6Rq3kx9xAK4EUAWgBQAEUS08dLHCSFKhBAFQoiC+PgRT0EypminmjrQ0evCnEQjfvPxGdz+7AFY23ukLiug3B6Bp/9xGreWHIBeR5ifGoXte8+h3+WRujRV82Y4sAbAOSFEsxBiAMDbAFb6tyzG5MdkGZzy+P3Gpfj1rfk4bnPimqd24wNzg8SVBUaDoxcbtx3EE387hesWJmPnfavx/66ei0ZnH94tt0pdnqp5E9Q1AJYTUTgREYArAVT6tyzG5MdUbUdcZDAypofjG4tTsfO+QqRPC8e9L5rwr+8cU/Vc7T8qG7HuqV0or23HYzcvxK9vzYcxNAhFOXGYm2TEs7urwG39/GfcoBZCHATwJoAyAMeGPqfEz3UxJjumGjuWpMdicLwCZMZF4K1/WonNhVl48UANvvHbvTjd2CFxlb7V53Lj3/9age+9UIrk6DDsuG81bilIO/8eEBE2F2bjVGMnPj3VLHG16uXVSogQ4mEhxFwhxHwhxCYhRJ+/C2NMTpo7+mBp7UZBZuxFfx5s0OFfrs3F9jsvQ3NHH65/Zg9e+bxGFaPLquZOrP/ffdi+txrfXZmJt7+/EjPjI7/0uOsXpSApKhQln1VJUKU2aHPJmrEJGp6fXpoRO+LHvzonAe9vKURBxjQ89PYx/PDlw3D0DASyRJ96y1SH657eA1t7D7bdUYB/uyEPoUH6ER8bbNDhrtWZ2F/VimN1jgBXqg0c1Ix5oazGjmC9Dnkp0aM+JiEqFH+8axl+tnYOPqhowLW/2X0+4JWis8+FB14rx0/eOIIFqdF4f0sR1uQmjvt5ty9LhzHEgK27zgagSu3hoGbMCyaLHQtmRI86qhym0xG+/5VZeOPeFQCADVv347efnIHHI/+pkKN17bj2N7vxbrkVD6yZjZc3L0dStHe3RRhDg3D75el471g9atu6/Vyp9nBQMzaO3gE3jtU5Rp32GMmS9FjsvK8Qa+cn4bEPT2LT8wfR5Oz1Y5WT5/EIbNtdhW/+bh8GXB68WrwCW9bkQK+jCT3PnasyoSPCc3vO+alS7eKgZmwcFTYH+t2eCQU1AESHBeGZ2xfjv9cvgMlix7qnduOTk01+qnJyWjr7cNcLh/DIzkp8dU4C3ttSiGVZ0yb1XMnRYbghPwWvHapFe3e/jyvVNg5qxsZRWj04z7wkfWJBDQxuX7ttWTr++sPViDeG4M7th/DIjuOyOMm390wL1j21G/vOtuI/b8zD1k1LERMePKXnLC7KRs+AGy8eGLX9H5sEDmrGxmGy2JExPRzxxpBJP0dOohHv/GAVNi3PwLY953Dz7/ehuqXLh1V6b8DtwaMfnMDG5w4iOiwI7/5gFTatyDy/N3oq5iZF4YrZ8fjDPouqDwAFGgc1Y2MQQqCsxj7haY+RhAbp8Z/fmI/fb1yK6pYuXPub3XjncGCPXte2dWPD1v3430/P4taCNPzlh6swLznKp69RXJSNls6+gP+3qRkHNWNjsLR2o6Wz3ydBPWzt/CS8f38RclOicP9r5fjJ60fQ1efy2fOPZufRelzzm90409iJp29fjP/+5kKEB497geaErZw5HXkpUSjZXaWI3S5KwEHN2BiG90EXZExugW00qTFheGXzctx3ZQ7ePlyH65/eA7PVP4dFevrdeOjto/jBy2WYGR+J97YU4vpFKX55LWBwXr64KBtVzV34xwl5LZ4qFQc1Y2MotdhhDDEgJ+HLR6enyqDX4cdXzcbLdy9Hd78b6/93H57fc86nx89PNDhxwzN78OqhWvzTV2bijXtXIG1auM+efzTXLkhGakwYSvgAjE9wUDM2hjKLHYszYqGb4J7iiVgxczre21KIotlx+I8dx3H3C6Vo65ra9jYhBP50wIIbn9kLe/cA/njXMvx87VwEBajRgUGvw/dWZ+FQtZ074vgABzVjo3D0DOBUUwcKfDg/PZppEcF49o4CPHx9LnafbsG6p3Zh39mWST1Xe3c//unFMvziHTMuz56O97cUojAn8M08br0sDVGhBjy7iy9rmioOasZGcbjGDiFGv4jJ14gId67KwtvfX4mIYAO+ve0gnvjoJFxu7/dcH6puwzVP7cbfKxvxL9fMwx++e9mUthVORUSIARuXZ+CDigbJtiKqBQc1Y6Mos9ihIyA/LSagrzs/NRp//dFqfHPJDDz98RncVjJ+y6/zLbK27odBrxu8J7so269TNt747spMBOl02LaHR9VTwUHN2ChKLXbMS45CRIjvt7CNJyLEgMdvWYSnbsvHiYYOrPv1Lnxgrh/xsQ2OXnx72wE88bdTuH5RCnbetxqLAvzNZTQJUaG4aXEq3iitQ2snX2M/Wd40t51DROUX/OMkovsDURxjUnG5PSivbQ/YtMdobsxPxc77ViMzLgL3vliGf/nzxS2/hltkHal1XNQiS042F2Whz+XBn/hY+aSNO1QQQpwEkA8ARKQHYAXwZz/XxZikTjR0oLvfLXlQA0DG9Ai8ee9KPP7RSZTsqkJptR1PbFiEt8rqsH1vNXKTo/D0txaP2H1FDmYlGHHl3AT8cb8F9xTNRFjw2FfFKpXHI0AEnxzFv9REf6a7EsBZIYRqvzV297tw74tlsE9xe5QvTIsIxqM3L0RilHd3AjPfGa+jS6AFG3T452vmYeXM6fjpG0dw3dN7AAzOAT+4bu6492RLrbgoG7eWHMCbZXXYtDxD6nL84vm957DrdAt+v3GJz098TvTZbgPwykgfIKJiAMUAkJ6ePsWypHO4ph27TjWjICMWUWHS/gi572wLfv7WUWz/7mV++S7NRmey2JEUFYrUmDCpS7nIV4auIv2fv53GmnkJuHLe+N1X5GBZ1jQsSovBtt1V+Nay9AnfdS13pxs78OiHJ1GUE48wP3zT9DqoiSgYwA0AHhrp40KIEgx1Jy8oKFDsAf/hY7wldxRgWsTUrnycqhf2VePhv1Tg1UO1uH2Zcr/5KZHJMngRkxy/QSYYQ/Ff6xdIXcaEEBHuKcrG918qw0cVDVi3IFnqknxmwO3BA6+XIzLEgP9av8AvXzMT2fWxDkCZEKLR51XIiNnmRGpMmOQhDQCblmdg1azp+M8dx1HTyu2NAqXe0QNrew+WyGTaQy2uzktC+rRwbN1VpYou7cOe+fgMzFYnfvmN+X7bsz6RoL4do0x7qEmF1YG8FN9e+zhZOh3hsZsXQU+En75xBG6+iSwgyiztABCQE4laotcR7i7MQnltO0oV1vR3NEfr2vHMJ2dw0+JUv/6U4FVQE1EEgKsAvO23SmSgo3cAVS1dWJA6eqfpQEuJCcPDN+Th8+o2PM+96AKi1NKG0CAdcmXyDVtNblmahtjwIGz9TPkHYHoH3Pjx60cQHxmCf7shz6+v5VVQCyG6hBDThRD+uYdRJirrOwAMngyTk28uScVVuYl47KOTONXYIXU5qldmsWPRjJiAXWCkJWHBemxakYm/VzbiTFOn1OVMyeMfnsSZpk48evNCRPt54wF/JV5geCExL1VeIykiwn+tXwBjiAE/fr0cAxO4+4FNTE+/GxU2p2y25anRHSsyEGLQ4TkFHys/UNWK5/aew8bl6Sia7f8LrzioL2C2OZBgDEGCUX77luMiQ/DLmxbAbHXi6Y/PSF2Oah2pa4fLIzio/SguMgTfXDoDb5VZ0dyhvGPlnX0u/PSNI0ifFo5/vmZeQF6Tg/oCZqtDdtMeF1o7PwnrF6fit5+cwZHadqnLUaXhgy6T6TjOvLe5MBsDbg9e2FctdSkT9siO47C19+DJDYv80spsJBzUQ3r63TjT1In5Ml9AeviGPCQYQ/Dj18u5y7MfmCx2zIyPQKwMtmeqWVZcBL6em4g/HbAEpF+kr3x8ohGvHqpFcdFMLPVxe7axcFAPqWxwwiOAPBmPqAEgOiwIj968EGebu/DYhyelLkdVPJ7BjuO+7o/IRlZcNBOOngG8XlordSlesXf14+dvHcPcJCMeuConoK/NQT2kYmghUc5TH8MKc+Jxx4oMPL/3HPafbZW6HNWoaulEe/cAz08HyNKMWBRkxOK5Pecm1BxBKv/6rhnt3f14YsMihBgCe7cKB/UQs9WJ2PAgpETLbyFxJA+um4uMaeH46RtH0NE7IHU5qnB+fpqDOmA2F2Wjzt6D980NUpcypr8csWHn0XpsuTIHeSmBH8xxUA8x2wYXEuV4t8NIwoMNeGJDPuodPXhkR6XU5aiCyWJHTHgQZsZHSF2KZlw1LxHZcREokfGx8kZnL37xjhn5aTG494qZktTAQQ2gz+XGqcYOSb5TTsXSjFjcc8VMvFZai49PqPoKloAotdixNF2eFzGplU5HuLswG8esDuyvkt80nhACP3/rKPpcbjy5YREMEh2C4qAGcLqxEwNugfkyO+jijfvX5GBukhE/f+uYLO7QVqq2rn5UNXdhaSZPewTa+iWpiIsMRokMu5W/eqgWn55sxoNr5yJbwsYMHNT44kTifIWNqAEgxKDHkxvy0d7dj3991yx1OYpVNtwogPdPB1xokB7fWZGJT08242SDfK5IqGntxiM7jmPlzOm4Y0WmpLVwUGNwftoYYkD6tHCpS5mU3JQo3L9mNnYercdfjtikLkeRTDV2GHSEhTPk0RRWazYuz0BYkB7P7pbHqNrtEfjpG0egI8JjtyySvJs7BzUGd3zkpkRJ/j9jKu4pysbi9Bj84h0zGp29UpejOCaLHXmp0art5yd3sRHB2FAwA++WW9HgkP7r9/k95/B5dRseviFPFl1+NB/ULrcHlfVOReyfHotBr8OTG/LR53LjZ28ele0Kuhz1uzw4UtvO0x4Su7swG26PwPZ90l7ne6qxA499dBJX5Sbim0tSJa1lmOaD+mxzF/pcHkUuJF4qKy4CD62bh89ONeOVz5Vx2ksOjtc70efyoIAXEiWVNi0c6xYk4+UDNZKdDRhwe/BjP7fVmgzNB7WSFxJHMty+65Gd3L7LW6XVbQDk03Fcy4oLs9HR58Jrh6QZaAy31frVTfMRF+mftlqT4W2HlxgiepOIThBRJRGt8HdhgWK2ORAWpJd0640vnW/fpeP2Xd4qq7EjNSYMiVHKOJWqZovSYnB51jQ8v+dcwO9dP1L7RVuttfPl1XzX2xH1UwA+EELMBbAIgGqOwlUMLSSqqX19SkwY/u36wfZdSr6cPRCEEDBZ7DztISP3XJENm6MXO44GbgfTYFut8oC01ZqMcYOaiKIBFAF4DgCEEP1CCFVchuzxCFTYHLK/2nQy1i9JxddzE/H4h6e4fdcY6uw9aHT28bSHjHxldgJyEiKx9bPAHSt/7MOTgzdS3uL/tlqT4c2IOgtAM4DtRHSYiLYNNbu9CBEVE1EpEZU2Nzf7vFB/qG7tQle/W/ZXm04GEeFX6xfAGMrtu8ZSVjN00IWDWjZ0OsLmomycaOjAnjMtfn+9A1WteH7vOWxanoHCHP+31ZoMb4LaAGAJgN8JIRYD6ALw4KUPEkKUCCEKhBAF8fHy/I+9lNnmBKCehcRLcfuu8ZVW2xERrMecRKPUpbAL3JifggRjiN+PlXf0DuCnbxxBxrRwPHTNXL++1lR4E9R1AOqEEAeHfv8mBoNb8cxWB4L1OuQkqmMhcSRr5ydh/RJu3zUak8WO/PQYyS7bYSMLMejx3VWZ2H26BRU2h99e55EdlbC19+CJALbVmoxxvzqFEA0AaoloztAfXQnguF+rChCz1YG5yUYEqfwv6cPXc/uukXT2uXCiwRnQlkrMe9++PAMRwXo866dR9ccnGvFaaS3uuSKwbbUmw9uE+hGAl4joKIB8AL/yX0mBIYSA2epQ3NWmkxEdFoTHbl6Es81dePQDbt81rLymHR7B89NyFR0WhNuWpeOvR+thbe/x6XNf2Fbr/jWBbas1GV4FtRCifGj+eaEQ4htCCLu/C/O3OnsPnL0uVZxI9MbqnDhu33UJk8UOImBxOl/EJFd3rc4CAGzf49tj5cNttZ7ckB/wtlqToe6f+cegthOJ3nhw3VxkTuf2XcNMNXbMSTQiKlR+27HYoNSYMFy3MBmvfF4DR49vvmaH22rdv2Y2chWyNVe7QW1zQK8jzEnSzmo/t+/6gtsjcNhi5/6IClBclI2ufjdePlgz5ecabqu1OD0G9xRl+6C6wNBuUFudyEmIRGiQ/H/s8aWlGbG4d6h91z8qtdu+63RTBzr6XCjgoJa9vJRorJ4Vh+17z6HPNfnFcCEEfvbmYFutJ26Rrq3WZCinUh8aXkhU+tWmk7XlgvZdbRpt31VazQddlKS4KBtNHX14t3zyx8pf+bwWn51qxkPr5inubh9NBnWjsw+tXf2qPDrujRCDHv9zaz4cPf34xTtmTd5dXWaxIy4yRLFdfbSmMCcOc5OMeHaS3cprWrvxyM7jWDVrOjYtz/BDhf6lyaA+v5Co0RE1AMxLHmrfdUyb7btMNXYszYiRzX3DbGxEhOKibJxu6sSnJyd2RcVwWy09Dd4sqcROTtoMapsDRINhpWXD7bv+/7sVmmrf1dzRB0trN097KMz1i1KQHB2KrbvOTujzLmyrlSKDtlqToc2gtjqRHReBiBD5HhkNhOH2Xf0uj6bad5mGO47L/DQau1iQXoe7VmXhQFUbjtZ5dx3CqcYOPPbhSXxdRm21JkOTQV1h0+5C4qWy4iLw0DVz8dmpZrz8+dS3PymBydKGYINOM4ed1OS2ZWkwhhiw1Ytj5cNttYyhBvxKRm21JkNzQd3S2Yd6R6+mDrqMZ+PlGVg9Kw6/3FkJS2uX1OX4nclix8LUaEWcSGMXM4YG4VvL0/H+sXrUto3dau7pobZav7xpgazaak2G5oK6YvhqUx5Rn6fTER69eaEm2nf1Drhhtjp5flrB7lyZBb2O8NwYx8qP1Lbjt5+cwfrFqVg7PymA1fmH5oJ6eMeHUo6OBspw+65D1XZVt+8yWx3od3v4RKKCJUWH4oZFqXjtUC3sI5wDGG6rlWAMwcMybKs1GZoL6gqbAxnTw2XZbkdq65ek4uo8dbfv+mIhkYNayYqLstEz4MaLByxf+tijHwy21Xr0Znm21ZoMzQW12erk+elREBF+ddNg+64HXitHv0t97btKLXZkTg9X/Jyl1s1JMuIrc+Lxwv7qi+5Y3392sK3WHSvk21ZrMjQV1I7uAdS0dSOPV/tHNT0yBL9avwAVNiee+fi01OX4lBACZRY7b8tTieLCbLR09uPPh60AvmirlTk9HA+uk29brcnwKqiJqJqIjhFRORGV+rsofxlu6cMj6rFdnTfUvuvTs6pq32Vp7UZrVz9Pe6jEipnTMT81Cs/uroLHI/DIjkrUO3rwxIZ8WbfVmoyJjKi/KoTIF0IU+K0aPzMPBXUeLySOS43tu0p5flpVBo+Vz0RVcxd+8a75grZa6vv/q6mpD7PViZToUEzn+clxqbF9l8lihzHUgJwEZd2cxkZ3zfwkzIgNw0sHaxTTVmsyvA1qAeAjIjIRUfFIDyCiYiIqJaLS5uaJXZoSKGabA3m8f9prq3PisGl5BrbvO4fqFuUfhDFZ2rAkPVaRl/KwkRn0Otz3tRwYQwyKaas1Gd4G9WohxBIA6wD8gIiKLn2AEKJkqK9iQXy8/FZbO/tcONfSxfPTE/SjK2chSKfDNoXvrXb0DOBUYyc3ClChDZelofQXa1R9NsLb5rbWoX83AfgzgGX+LMofKuudEAJ8v8MEJRhDcdPiVLxRWofWzj6py5m0wzU8P61mah1JDxs3qIkogoiMw78G8HUAZn8X5mt8B/XkbS7KQp/Lgz/u//LhAqUwWezQ6wiL0rjjOFMeb0bUiQD2ENERAJ8D2CmE+MC/Zfme2epEXGQIEoy8kDhRsxKMWDMvAX/cX42efmXuADFZ7JiXbNT81bZMmcYNaiFElRBi0dA/eUKIXwaiMF8bvNo0StFXHUqpuGgm7N0DeLOsTupSJszl9qC8th1L03nagymTJrbn9Q64cbqpkxcSp+CyzFjkp8Vg2+4qxd2ud6KhA939bizN5BOJTJk0EdQnGjrg9gheSJyC4Z51ltZufFTRIHU5E8IXMTGl00RQDy8k5vGIekquzktCxvRwbJ1kJ2iplFrsSIoKRUp0qNSlMDYpmgjqCpsD0WFBmBGrzMaWcqHXEe5enYXy2nYcqrZLXY7Xyix2LM2M5fUJpliaCGqz1ckLiT5y89I0xIYHocSLnnVyUO/ogbW9hxcSmaKpPqj7XR6cbOjg/dM+Ehasx6YVmfh7ZSPONHVKXc64huenCzI5qJlyqT6oTzd1oN/t4R0fPvSdFRkIMeiwbbf8R9Umix2hQTrMS+aFZKZcqg/qCis3s/W16ZEhuHnpDLxdZkVTR6/U5YzJZLFj0YwYBOlV/6XOVEz1X71mmwORIQZkTAuXuhRVubswGwMeD17YVy11KaPq7nehwubkaQ+meOoPaqsDuSlRfLWlj2XFReDq3CS8eKAGXX0uqcsZ0ZFaB9wewfunmeKpOqhdbg+O13MzW3/ZXJQNR88AXi+tlbqUEZUN3Zi3hHd8MIVTdVBXtXShd8DDJxL9ZGlGLAoyYvHcnnNwueXXsdxksWNWQiRiwoOlLoWxKVF1UPPVpv5XXJSNOnsP3jPL61i5xyNgsth5/zRTBZUHtROhQTpkx0VIXYpqrZmXiOz4CJTsOiurY+VVLZ1w9AxgKS8kMhVQd1DbHJiXHAUDb83yG52OsLkwG2arE/urWqUu57zSar6IiamHahPM4xE4buOFxEC4aXEq4iKDZXWs3GSxIzY8iH+aYqrgdVATkZ6IDhPRDn8W5CuWtm509rl4ITEAQoP0+M6KTHx6shknGzqkLgcAYKqxY2kGX8TE1GEiI+otACr9VYiv8dWmgbVxeQbCgvSyGFW3dfWjqrkLS3jag6mEV0FNRDMAXAtgm3/L8R2zzYEgPWF2olHqUjQhNiIYt16Whr8csaLBIe2x8rLhi5gyuKMLUwdvR9S/BvAzAKNuliWiYiIqJaLS5uZmnxQ3FRVWJ+YkGRFsUO00vOx8b3UW3B6B7fvOSVqHqcaOID1h4Qz+aYqpw7gpRkTXAWgSQpjGepwQokQIUSCEKIiPj/dZgZMhhIDZ5uCFxABLmxaOdQuS8fKBGnT0DkhWh6najryUaIQG6SWrgTFf8ma4uQrADURUDeBVAF8johf9WtUUWdt70N49gDw+6BJw9xRlo6PPhVc/l+ZYeb/LgyN17bwtj6nKuEEthHhICDFDCJEJ4DYAHwshNvq9sikwD19tmsI7PgJt4YwYLM+ehuf3nsOABMfKK2wO9Lk8HNRMVVQ5gVthc0CvI74sXiL3FM1EvaMXfz1iC/hrc8dxpkYTCmohxKdCiOv8VYyvmK0O5CRE8hylRK6YHY+chEiUSNCtvKzGjhmxYUiM4o7jTD1UOaI225y8f1pCOh1hc1E2TjR0YPfploC9rhACpdV2FPBomqmM6oK6ydmL5o4+PpEosRvzU5BgDAnoAZg6ew+aOvp42oOpjuqC2mzjq03lIMSgx52rsrDnTMv5U6L+Njw/zScSmdqoL6itThCBFxJl4FuXpyMiWB+wbuUmix0RwXrMTeL/90xdVBfUx6wOZMVFIDLEIHUpmhcdFoTblqXjr0frYW3v8fvrmSx2LE6PhZ77YzKVUV1QV1j5RKKc3LU6CwDw/B7/Hivv7HPhRIOT56eZKqkqqFs7+2Bz9PJCooykxoTh+oXJePXzGjh6/HesvLymHR7B+6eZOqkqqCtswycSeUQtJ8VFM9HV78ZLBy1+e41SSxuIgPz0GL+9BmNSUVVQD+/44D3U8pKbEoXCnDj8YW81+lxuv7yGyWLHnEQjokKD/PL8jElJVUFdYXUibVoYosP5L6vcbC7MRlNHH94t9/2xcrdHoLyGL2Ji6qWqoOarTeWrMCcO85Kj8OyuKng8vj1WfqqxAx19LhRwx3GmUqoJakfPACyt3XzQRaaICMVFWTjd1IlPTzX59LnPX8SUzh1dmDqpJqiPDy0k5vHVprJ13cIUJEeHYutnvj0AY7LYERcZgrRpYT59XsbkQjVBXcELibIXpNfhrlVZOHiuDUdq2332vCbL4EVM3HGcqZVqgtpsdSApKhTxxhCpS2FjuG1ZGowhBpT46Fh5U0cvatq6eSGRqZp6gtrm5IMuCmAMDcK3lqfj/WP1qGntnvLzDXccX8oLiUzFvGluG0pEnxPRESKqIKJ/D0RhE9Hd78LZ5k6e9lCIu1ZlQa8jPLdn6qNqk8WOYIOO1yaYqnkzou4D8DUhxCIA+QDWEtFy/5Y1MZX1TggBLOAdH4qQGBWKG/NT8XppHexd/VN6rlKLHQtToxFi4G4+TL28aW4rhBCdQ78NGvonsP2VxnG+mS0HtWJsLsxGz4AbLx6Y/LHy3gE3zFYHT3sw1fNqjpqI9ERUDqAJwN+EEDsIr18AAAtPSURBVAdHeEwxEZUSUWlzc7Ov6xyT2epAXGQwEqN4IVEp5iQZ8ZU58XhhfzV6ByZ3rNxsdWDALbA0nYOaqZtXQS2EcAsh8gHMALCMiOaP8JgSIUSBEKIgPj7e13WOabhHIm/PUpbiomy0dPbj7TLrpD6/lDuOM42YaBfydgCfAFjrn3ImrnfAjdONHbzjQ4FWZE/HgtRobNs9uWPlJosdWXERmB7JP0kxdfNm10c8EcUM/ToMwFUATvi7MG+dauyAyyP4jg8FGjxWno2qli78rbJxQp8rhECZxY4lPO3BNMCbEXUygE+I6CiAQxico97h37K8xwuJyrZufhJmxIbh2Ql2K69u7UZrVz9fxMQ0wZtdH0eFEIuFEAuFEPOFEP8RiMK8dczqQFSoATNi+Z4HJTLodfje6iyUWuznL1fyhonnp5mGKP5kYoXNgfmpvJCoZBsK0hAdFoSSXWe9/hyTpQ1RoQbMio/0Y2WMyYOig3rA7cGJ+g6e9lC4iBADNi3PwEfHG1HV3Dn+J2BwRL0kIxY67jjONEDRQX26sRP9bg8fH1aBO1ZmIEinwzYvupU7ugdwqrGT908zzVB0UA/3SOQRtfIlGEOxfkkq3jLVoaWzb8zHltXyRUxMWxQd1BVWByKC9ciaHiF1KcwH7i7MRp/Lgz/uH/tYeZnFDr2OkJ/GHceZNig6qM02J3JTonieUiVmJURizbxE/Gl/NXr6Rz9WXlptR25yFMKDDYErjjEJKTao3R6B40NHx5l63HNFNuzdA3jDVDvix11uD8prueM40xbFBvW5lk70DLh5flplCjJikZ8Wg227z8E9wrHyyvoO9Ay4sYSDmmmIYoP6ixOJvONDTYgI9xRlo6atGx9WNHzp4yZLG4DBQGdMKxQc1A6EGHR84EGFvp6XhMzp4di6qwpCXDyqNtW0Izk6FCkxfBKVaYdyg9rmwNzkKBj0iv1PYKPQ6wjfK8zGkdp2fH6u7aKPmarbeH6aaY4iU87jEaiwOrGApz1U6+YlMzAtIhglF1zWZGvvgc3Ry0HNNEeRQV1r70ZHn4uvNlWxsGA9Ni3PwD9ONOFMUwcAvoiJaZcig5qvNtWGO1ZkIMSgw7O7Bo+Vmyx2hAXpMS+Zf5Ji2qLMoLY5EKQn5CTyQqKaTY8MwS0FM/Dnw1Y0OXtRVmPHorRoBPG6BNMYbzq8pBHRJ0R0nIgqiGhLIAobi9nqwOxEI0IMeqlLYX529+psDHg8+N1nZ1Fhc6IgY5rUJTEWcN4MTVwAfiKEyAWwHMAPiCjXv2WNTgiBCpuT56c1IjMuAlfnJuEP+6rh9gien2aa5E2Hl3ohRNnQrzsAVAJI9Xdho6l39KKtq58PumhI8RXZGN5OvTidL2Ji2jOhW22IKBPAYgAHR/hYMYBiAEhPT/dBaSM7Zh282jSPFxI1Y0l6LC7PmobOPhdiwoOlLoexgPM6qIkoEsBbAO4XQjgv/bgQogRACQAUFBR8+ZIGH6mwOqAjYF4Sj6i15NnvFKDf5ZG6DMYk4VVQE1EQBkP6JSHE2/4taWxmmxOzEiIRFswLiVoSFRokdQmMScabXR8E4DkAlUKIJ/1f0tjMVgcvJDLGNMWbXR+rAGwC8DUiKh/65xo/1zWiJmcvmjr6eH6aMaYp4059CCH2AJBFC5UK29CJRG5myxjTEEUd8TIP7fjI5aBmjGmIsoLa5kBWXASMvLDEGNMQZQW11Yk8Hk0zxjRGMUFt7+qHtb2Hb8xjjGmOYoL6i4VEDmrGmLYoJqjNtsGFRL7jgzGmNcoJaqsDM2LD+K4HxpjmKCao+WpTxphWKSKoO3oHcK6li6c9GGOapIigPj60kMhHxxljWqSIoDbzjg/GmIYpIqgrrA4kRoUg3hgidSmMMRZwighqs42vNmWMaZfsg7q734UzTZ08P80Y0yzZB3VlfQc8gq82ZYxpl+yDuuL8iUQeUTPGtMmbVlzPE1ETEZkDUdClzFYHpkUEIzk6VIqXZ4wxyXkzov4DgLV+rmNUw1ebDrZuZIwx7Rk3qIUQuwC0BaCWL+lzuXGqsYOnPRhjmuazOWoiKiaiUiIqbW5u9slznmrohMsjeGseY0zTfBbUQogSIUSBEKIgPj7eJ8/JV5syxpjMd32YrQ4YQw1InxYudSmMMSYZeQe1jRcSGWPMm+15rwDYD2AOEdUR0ff8XxYw4Pagsp7voGaMMcN4DxBC3B6IQi51trkT/S4PFszgoGaMaZtspz7M1qE7qHlEzRjTOBkHtQPhwXpkxUVIXQpjjElKtkFdYXMgNzkKeh0vJDLGtE2WQe3xiMFmtnwikTHG5BnU51q70N3vRh5fbcoYY/IMarOVrzZljLFhsgzqCpsTwQYdZiVESl0KY4xJTpZBfazOgXlJRgTpZVkeY4wFlOySUAgBs83BPRIZY2yI7IK6tq0HHb0uPjrOGGNDZBfUfLUpY4xdTH5BbXXAoCPMTjRKXQpjjMmC/ILa5kROohGhQXqpS2GMMVmQVVALIVBhdWA+H3RhjLHzZBXUDc5etHb180EXxhi7gKyCevhqU15IZIyxL3gV1ES0lohOEtEZInrQX8WYrQ7oCJiXzEHNGGPDvGnFpQfwWwDrAOQCuJ2Icv1RTIXNgZnxkQgPHrfxDGOMaYY3I+plAM4IIaqEEP0AXgVwoz+KMVv5alPGGLuUN0GdCqD2gt/XDf3ZRYiomIhKiai0ubl5woX0uzxYnROHK2bHT/hzGWNMzXw2xyCEKAFQAgAFBQViop8fbNDh8VsW+aocxhhTDW9G1FYAaRf8fsbQnzHGGAsAb4L6EIAcIsoiomAAtwH4i3/LYowxNmzcqQ8hhIuIfgjgQwB6AM8LISr8XhljjDEAXs5RCyHeA/Cen2thjDE2AlmdTGSMMfZlHNSMMSZzHNSMMSZzHNSMMSZzJMSEz6aM/6REzQAsk/z0OAAtPixHyfi9uBi/Hxfj9+MLangvMoQQIx7N9ktQTwURlQohCqSuQw74vbgYvx8X4/fjC2p/L3jqgzHGZI6DmjHGZE6OQV0idQEywu/Fxfj9uBi/H19Q9XshuzlqxhhjF5PjiJoxxtgFOKgZY0zmZBPUgWqgqwRElEZEnxDRcSKqIKItUtckNSLSE9FhItohdS1SI6IYInqTiE4QUSURrZC6JikR0QNDf0/MRPQKEYVKXZOvySKoA9lAVyFcAH4ihMgFsBzADzT+fgDAFgCVUhchE08B+EAIMRfAImj4fSGiVAD3ASgQQszH4FXMt0lble/JIqgRwAa6SiCEqBdClA39ugODfxG/1KdSK4hoBoBrAWyTuhapEVE0gCIAzwGAEKJfCNEubVWSMwAIIyIDgHAANonr8Tm5BLVXDXS1iIgyASwGcFDaSiT1awA/A+CRuhAZyALQDGD70FTQNiKKkLooqQghrAAeB1ADoB6AQwjxkbRV+Z5cgpqNgIgiAbwF4H4hhFPqeqRARNcBaBJCmKSuRSYMAJYA+J0QYjGALgCaXdMholgM/vSdBSAFQAQRbZS2Kt+TS1BzA91LEFEQBkP6JSHE21LXI6FVAG4gomoMTol9jYhelLYkSdUBqBNCDP+E9SYGg1ur1gA4J4RoFkIMAHgbwEqJa/I5uQQ1N9C9ABERBucgK4UQT0pdj5SEEA8JIWYIITIx+HXxsRBCdSMmbwkhGgDUEtGcoT+6EsBxCUuSWg2A5UQUPvT35kqocHHVq56J/sYNdL9kFYBNAI4RUfnQn/3zUO9Kxn4E4KWhQU0VgDslrkcyQoiDRPQmgDIM7pY6DBUeJ+cj5IwxJnNymfpgjDE2Cg5qxhiTOQ5qxhiTOQ5qxhiTOQ5qxhiTOQ5qxhiTOQ5qxhiTuf8DGQ08/Q1hA6IAAAAASUVORK5CYII=\n",
+            "image/png": "iVBORw0KGgoAAAANSUhEUgAAAWoAAAD4CAYAAADFAawfAAAABHNCSVQICAgIfAhkiAAAAAlwSFlzAAALEgAACxIB0t1+/AAAADh0RVh0U29mdHdhcmUAbWF0cGxvdGxpYiB2ZXJzaW9uMy4yLjIsIGh0dHA6Ly9tYXRwbG90bGliLm9yZy+WH4yJAAAgAElEQVR4nO3dd3jb5bk38O8tydvySLwdz8QZdoaTmJBl05ZQEmZJIUCb0EKJ4XQQaPu2cM7pyxm051ysUwo9bUwgpWWvQpuw2jKyQyzHSeQ407FsS96WJW9b0nP+sB2S4CHbkn7r/lwXF0ksSzfC+frxs24SQoAxxph86aQugDHG2Ng4qBljTOY4qBljTOY4qBljTOY4qBljTOYM/njSuLg4kZmZ6Y+nZowxVTKZTC1CiPiRPuaXoM7MzERpaak/npoxxlSJiCyjfYynPhhjTOY4qBljTOY4qBljTOY4qBljTOY4qBljTOa8CmoieoCIKojITESvEFGovwtjjDE2aNygJqJUAPcBKBBCzAegB3CbvwtjjDE2yNupDwOAMCIyAAgHYPNfSYzJ174zLSirsUtdhiw4ugfw8sEa9A64pS5F9cY98CKEsBLR4wBqAPQA+EgI8dGljyOiYgDFAJCenu7rOhmTnMcjcM+LJnT2ufCjr87CfVfmwKDX5jJPaXUbtrxaDmt7D5y9A7j3iplSl6Rq3kx9xAK4EUAWgBQAEUS08dLHCSFKhBAFQoiC+PgRT0EypminmjrQ0evCnEQjfvPxGdz+7AFY23ukLiug3B6Bp/9xGreWHIBeR5ifGoXte8+h3+WRujRV82Y4sAbAOSFEsxBiAMDbAFb6tyzG5MdkGZzy+P3Gpfj1rfk4bnPimqd24wNzg8SVBUaDoxcbtx3EE387hesWJmPnfavx/66ei0ZnH94tt0pdnqp5E9Q1AJYTUTgREYArAVT6tyzG5MdUbUdcZDAypofjG4tTsfO+QqRPC8e9L5rwr+8cU/Vc7T8qG7HuqV0or23HYzcvxK9vzYcxNAhFOXGYm2TEs7urwG39/GfcoBZCHATwJoAyAMeGPqfEz3UxJjumGjuWpMdicLwCZMZF4K1/WonNhVl48UANvvHbvTjd2CFxlb7V53Lj3/9age+9UIrk6DDsuG81bilIO/8eEBE2F2bjVGMnPj3VLHG16uXVSogQ4mEhxFwhxHwhxCYhRJ+/C2NMTpo7+mBp7UZBZuxFfx5s0OFfrs3F9jsvQ3NHH65/Zg9e+bxGFaPLquZOrP/ffdi+txrfXZmJt7+/EjPjI7/0uOsXpSApKhQln1VJUKU2aHPJmrEJGp6fXpoRO+LHvzonAe9vKURBxjQ89PYx/PDlw3D0DASyRJ96y1SH657eA1t7D7bdUYB/uyEPoUH6ER8bbNDhrtWZ2F/VimN1jgBXqg0c1Ix5oazGjmC9Dnkp0aM+JiEqFH+8axl+tnYOPqhowLW/2X0+4JWis8+FB14rx0/eOIIFqdF4f0sR1uQmjvt5ty9LhzHEgK27zgagSu3hoGbMCyaLHQtmRI86qhym0xG+/5VZeOPeFQCADVv347efnIHHI/+pkKN17bj2N7vxbrkVD6yZjZc3L0dStHe3RRhDg3D75el471g9atu6/Vyp9nBQMzaO3gE3jtU5Rp32GMmS9FjsvK8Qa+cn4bEPT2LT8wfR5Oz1Y5WT5/EIbNtdhW/+bh8GXB68WrwCW9bkQK+jCT3PnasyoSPCc3vO+alS7eKgZmwcFTYH+t2eCQU1AESHBeGZ2xfjv9cvgMlix7qnduOTk01+qnJyWjr7cNcLh/DIzkp8dU4C3ttSiGVZ0yb1XMnRYbghPwWvHapFe3e/jyvVNg5qxsZRWj04z7wkfWJBDQxuX7ttWTr++sPViDeG4M7th/DIjuOyOMm390wL1j21G/vOtuI/b8zD1k1LERMePKXnLC7KRs+AGy8eGLX9H5sEDmrGxmGy2JExPRzxxpBJP0dOohHv/GAVNi3PwLY953Dz7/ehuqXLh1V6b8DtwaMfnMDG5w4iOiwI7/5gFTatyDy/N3oq5iZF4YrZ8fjDPouqDwAFGgc1Y2MQQqCsxj7haY+RhAbp8Z/fmI/fb1yK6pYuXPub3XjncGCPXte2dWPD1v3430/P4taCNPzlh6swLznKp69RXJSNls6+gP+3qRkHNWNjsLR2o6Wz3ydBPWzt/CS8f38RclOicP9r5fjJ60fQ1efy2fOPZufRelzzm90409iJp29fjP/+5kKEB497geaErZw5HXkpUSjZXaWI3S5KwEHN2BiG90EXZExugW00qTFheGXzctx3ZQ7ePlyH65/eA7PVP4dFevrdeOjto/jBy2WYGR+J97YU4vpFKX55LWBwXr64KBtVzV34xwl5LZ4qFQc1Y2MotdhhDDEgJ+HLR6enyqDX4cdXzcbLdy9Hd78b6/93H57fc86nx89PNDhxwzN78OqhWvzTV2bijXtXIG1auM+efzTXLkhGakwYSvgAjE9wUDM2hjKLHYszYqGb4J7iiVgxczre21KIotlx+I8dx3H3C6Vo65ra9jYhBP50wIIbn9kLe/cA/njXMvx87VwEBajRgUGvw/dWZ+FQtZ074vgABzVjo3D0DOBUUwcKfDg/PZppEcF49o4CPHx9LnafbsG6p3Zh39mWST1Xe3c//unFMvziHTMuz56O97cUojAn8M08br0sDVGhBjy7iy9rmioOasZGcbjGDiFGv4jJ14gId67KwtvfX4mIYAO+ve0gnvjoJFxu7/dcH6puwzVP7cbfKxvxL9fMwx++e9mUthVORUSIARuXZ+CDigbJtiKqBQc1Y6Mos9ihIyA/LSagrzs/NRp//dFqfHPJDDz98RncVjJ+y6/zLbK27odBrxu8J7so269TNt747spMBOl02LaHR9VTwUHN2ChKLXbMS45CRIjvt7CNJyLEgMdvWYSnbsvHiYYOrPv1Lnxgrh/xsQ2OXnx72wE88bdTuH5RCnbetxqLAvzNZTQJUaG4aXEq3iitQ2snX2M/Wd40t51DROUX/OMkovsDURxjUnG5PSivbQ/YtMdobsxPxc77ViMzLgL3vliGf/nzxS2/hltkHal1XNQiS042F2Whz+XBn/hY+aSNO1QQQpwEkA8ARKQHYAXwZz/XxZikTjR0oLvfLXlQA0DG9Ai8ee9KPP7RSZTsqkJptR1PbFiEt8rqsH1vNXKTo/D0txaP2H1FDmYlGHHl3AT8cb8F9xTNRFjw2FfFKpXHI0AEnxzFv9REf6a7EsBZIYRqvzV297tw74tlsE9xe5QvTIsIxqM3L0RilHd3AjPfGa+jS6AFG3T452vmYeXM6fjpG0dw3dN7AAzOAT+4bu6492RLrbgoG7eWHMCbZXXYtDxD6nL84vm957DrdAt+v3GJz098TvTZbgPwykgfIKJiAMUAkJ6ePsWypHO4ph27TjWjICMWUWHS/gi572wLfv7WUWz/7mV++S7NRmey2JEUFYrUmDCpS7nIV4auIv2fv53GmnkJuHLe+N1X5GBZ1jQsSovBtt1V+Nay9AnfdS13pxs78OiHJ1GUE48wP3zT9DqoiSgYwA0AHhrp40KIEgx1Jy8oKFDsAf/hY7wldxRgWsTUrnycqhf2VePhv1Tg1UO1uH2Zcr/5KZHJMngRkxy/QSYYQ/Ff6xdIXcaEEBHuKcrG918qw0cVDVi3IFnqknxmwO3BA6+XIzLEgP9av8AvXzMT2fWxDkCZEKLR51XIiNnmRGpMmOQhDQCblmdg1azp+M8dx1HTyu2NAqXe0QNrew+WyGTaQy2uzktC+rRwbN1VpYou7cOe+fgMzFYnfvmN+X7bsz6RoL4do0x7qEmF1YG8FN9e+zhZOh3hsZsXQU+En75xBG6+iSwgyiztABCQE4laotcR7i7MQnltO0oV1vR3NEfr2vHMJ2dw0+JUv/6U4FVQE1EEgKsAvO23SmSgo3cAVS1dWJA6eqfpQEuJCcPDN+Th8+o2PM+96AKi1NKG0CAdcmXyDVtNblmahtjwIGz9TPkHYHoH3Pjx60cQHxmCf7shz6+v5VVQCyG6hBDThRD+uYdRJirrOwAMngyTk28uScVVuYl47KOTONXYIXU5qldmsWPRjJiAXWCkJWHBemxakYm/VzbiTFOn1OVMyeMfnsSZpk48evNCRPt54wF/JV5geCExL1VeIykiwn+tXwBjiAE/fr0cAxO4+4FNTE+/GxU2p2y25anRHSsyEGLQ4TkFHys/UNWK5/aew8bl6Sia7f8LrzioL2C2OZBgDEGCUX77luMiQ/DLmxbAbHXi6Y/PSF2Oah2pa4fLIzio/SguMgTfXDoDb5VZ0dyhvGPlnX0u/PSNI0ifFo5/vmZeQF6Tg/oCZqtDdtMeF1o7PwnrF6fit5+cwZHadqnLUaXhgy6T6TjOvLe5MBsDbg9e2FctdSkT9siO47C19+DJDYv80spsJBzUQ3r63TjT1In5Ml9AeviGPCQYQ/Dj18u5y7MfmCx2zIyPQKwMtmeqWVZcBL6em4g/HbAEpF+kr3x8ohGvHqpFcdFMLPVxe7axcFAPqWxwwiOAPBmPqAEgOiwIj968EGebu/DYhyelLkdVPJ7BjuO+7o/IRlZcNBOOngG8XlordSlesXf14+dvHcPcJCMeuConoK/NQT2kYmghUc5TH8MKc+Jxx4oMPL/3HPafbZW6HNWoaulEe/cAz08HyNKMWBRkxOK5Pecm1BxBKv/6rhnt3f14YsMihBgCe7cKB/UQs9WJ2PAgpETLbyFxJA+um4uMaeH46RtH0NE7IHU5qnB+fpqDOmA2F2Wjzt6D980NUpcypr8csWHn0XpsuTIHeSmBH8xxUA8x2wYXEuV4t8NIwoMNeGJDPuodPXhkR6XU5aiCyWJHTHgQZsZHSF2KZlw1LxHZcREokfGx8kZnL37xjhn5aTG494qZktTAQQ2gz+XGqcYOSb5TTsXSjFjcc8VMvFZai49PqPoKloAotdixNF2eFzGplU5HuLswG8esDuyvkt80nhACP3/rKPpcbjy5YREMEh2C4qAGcLqxEwNugfkyO+jijfvX5GBukhE/f+uYLO7QVqq2rn5UNXdhaSZPewTa+iWpiIsMRokMu5W/eqgWn55sxoNr5yJbwsYMHNT44kTifIWNqAEgxKDHkxvy0d7dj3991yx1OYpVNtwogPdPB1xokB7fWZGJT08242SDfK5IqGntxiM7jmPlzOm4Y0WmpLVwUGNwftoYYkD6tHCpS5mU3JQo3L9mNnYercdfjtikLkeRTDV2GHSEhTPk0RRWazYuz0BYkB7P7pbHqNrtEfjpG0egI8JjtyySvJs7BzUGd3zkpkRJ/j9jKu4pysbi9Bj84h0zGp29UpejOCaLHXmp0art5yd3sRHB2FAwA++WW9HgkP7r9/k95/B5dRseviFPFl1+NB/ULrcHlfVOReyfHotBr8OTG/LR53LjZ28ele0Kuhz1uzw4UtvO0x4Su7swG26PwPZ90l7ne6qxA499dBJX5Sbim0tSJa1lmOaD+mxzF/pcHkUuJF4qKy4CD62bh89ONeOVz5Vx2ksOjtc70efyoIAXEiWVNi0c6xYk4+UDNZKdDRhwe/BjP7fVmgzNB7WSFxJHMty+65Gd3L7LW6XVbQDk03Fcy4oLs9HR58Jrh6QZaAy31frVTfMRF+mftlqT4W2HlxgiepOIThBRJRGt8HdhgWK2ORAWpJd0640vnW/fpeP2Xd4qq7EjNSYMiVHKOJWqZovSYnB51jQ8v+dcwO9dP1L7RVuttfPl1XzX2xH1UwA+EELMBbAIgGqOwlUMLSSqqX19SkwY/u36wfZdSr6cPRCEEDBZ7DztISP3XJENm6MXO44GbgfTYFut8oC01ZqMcYOaiKIBFAF4DgCEEP1CCFVchuzxCFTYHLK/2nQy1i9JxddzE/H4h6e4fdcY6uw9aHT28bSHjHxldgJyEiKx9bPAHSt/7MOTgzdS3uL/tlqT4c2IOgtAM4DtRHSYiLYNNbu9CBEVE1EpEZU2Nzf7vFB/qG7tQle/W/ZXm04GEeFX6xfAGMrtu8ZSVjN00IWDWjZ0OsLmomycaOjAnjMtfn+9A1WteH7vOWxanoHCHP+31ZoMb4LaAGAJgN8JIRYD6ALw4KUPEkKUCCEKhBAF8fHy/I+9lNnmBKCehcRLcfuu8ZVW2xERrMecRKPUpbAL3JifggRjiN+PlXf0DuCnbxxBxrRwPHTNXL++1lR4E9R1AOqEEAeHfv8mBoNb8cxWB4L1OuQkqmMhcSRr5ydh/RJu3zUak8WO/PQYyS7bYSMLMejx3VWZ2H26BRU2h99e55EdlbC19+CJALbVmoxxvzqFEA0AaoloztAfXQnguF+rChCz1YG5yUYEqfwv6cPXc/uukXT2uXCiwRnQlkrMe9++PAMRwXo866dR9ccnGvFaaS3uuSKwbbUmw9uE+hGAl4joKIB8AL/yX0mBIYSA2epQ3NWmkxEdFoTHbl6Es81dePQDbt81rLymHR7B89NyFR0WhNuWpeOvR+thbe/x6XNf2Fbr/jWBbas1GV4FtRCifGj+eaEQ4htCCLu/C/O3OnsPnL0uVZxI9MbqnDhu33UJk8UOImBxOl/EJFd3rc4CAGzf49tj5cNttZ7ckB/wtlqToe6f+cegthOJ3nhw3VxkTuf2XcNMNXbMSTQiKlR+27HYoNSYMFy3MBmvfF4DR49vvmaH22rdv2Y2chWyNVe7QW1zQK8jzEnSzmo/t+/6gtsjcNhi5/6IClBclI2ufjdePlgz5ecabqu1OD0G9xRl+6C6wNBuUFudyEmIRGiQ/H/s8aWlGbG4d6h91z8qtdu+63RTBzr6XCjgoJa9vJRorJ4Vh+17z6HPNfnFcCEEfvbmYFutJ26Rrq3WZCinUh8aXkhU+tWmk7XlgvZdbRpt31VazQddlKS4KBtNHX14t3zyx8pf+bwWn51qxkPr5inubh9NBnWjsw+tXf2qPDrujRCDHv9zaz4cPf34xTtmTd5dXWaxIy4yRLFdfbSmMCcOc5OMeHaS3cprWrvxyM7jWDVrOjYtz/BDhf6lyaA+v5Co0RE1AMxLHmrfdUyb7btMNXYszYiRzX3DbGxEhOKibJxu6sSnJyd2RcVwWy09Dd4sqcROTtoMapsDRINhpWXD7bv+/7sVmmrf1dzRB0trN097KMz1i1KQHB2KrbvOTujzLmyrlSKDtlqToc2gtjqRHReBiBD5HhkNhOH2Xf0uj6bad5mGO47L/DQau1iQXoe7VmXhQFUbjtZ5dx3CqcYOPPbhSXxdRm21JkOTQV1h0+5C4qWy4iLw0DVz8dmpZrz8+dS3PymBydKGYINOM4ed1OS2ZWkwhhiw1Ytj5cNttYyhBvxKRm21JkNzQd3S2Yd6R6+mDrqMZ+PlGVg9Kw6/3FkJS2uX1OX4nclix8LUaEWcSGMXM4YG4VvL0/H+sXrUto3dau7pobZav7xpgazaak2G5oK6YvhqUx5Rn6fTER69eaEm2nf1Drhhtjp5flrB7lyZBb2O8NwYx8qP1Lbjt5+cwfrFqVg7PymA1fmH5oJ6eMeHUo6OBspw+65D1XZVt+8yWx3od3v4RKKCJUWH4oZFqXjtUC3sI5wDGG6rlWAMwcMybKs1GZoL6gqbAxnTw2XZbkdq65ek4uo8dbfv+mIhkYNayYqLstEz4MaLByxf+tijHwy21Xr0Znm21ZoMzQW12erk+elREBF+ddNg+64HXitHv0t97btKLXZkTg9X/Jyl1s1JMuIrc+Lxwv7qi+5Y3392sK3WHSvk21ZrMjQV1I7uAdS0dSOPV/tHNT0yBL9avwAVNiee+fi01OX4lBACZRY7b8tTieLCbLR09uPPh60AvmirlTk9HA+uk29brcnwKqiJqJqIjhFRORGV+rsofxlu6cMj6rFdnTfUvuvTs6pq32Vp7UZrVz9Pe6jEipnTMT81Cs/uroLHI/DIjkrUO3rwxIZ8WbfVmoyJjKi/KoTIF0IU+K0aPzMPBXUeLySOS43tu0p5flpVBo+Vz0RVcxd+8a75grZa6vv/q6mpD7PViZToUEzn+clxqbF9l8lihzHUgJwEZd2cxkZ3zfwkzIgNw0sHaxTTVmsyvA1qAeAjIjIRUfFIDyCiYiIqJaLS5uaJXZoSKGabA3m8f9prq3PisGl5BrbvO4fqFuUfhDFZ2rAkPVaRl/KwkRn0Otz3tRwYQwyKaas1Gd4G9WohxBIA6wD8gIiKLn2AEKJkqK9iQXy8/FZbO/tcONfSxfPTE/SjK2chSKfDNoXvrXb0DOBUYyc3ClChDZelofQXa1R9NsLb5rbWoX83AfgzgGX+LMofKuudEAJ8v8MEJRhDcdPiVLxRWofWzj6py5m0wzU8P61mah1JDxs3qIkogoiMw78G8HUAZn8X5mt8B/XkbS7KQp/Lgz/u//LhAqUwWezQ6wiL0rjjOFMeb0bUiQD2ENERAJ8D2CmE+MC/Zfme2epEXGQIEoy8kDhRsxKMWDMvAX/cX42efmXuADFZ7JiXbNT81bZMmcYNaiFElRBi0dA/eUKIXwaiMF8bvNo0StFXHUqpuGgm7N0DeLOsTupSJszl9qC8th1L03nagymTJrbn9Q64cbqpkxcSp+CyzFjkp8Vg2+4qxd2ud6KhA939bizN5BOJTJk0EdQnGjrg9gheSJyC4Z51ltZufFTRIHU5E8IXMTGl00RQDy8k5vGIekquzktCxvRwbJ1kJ2iplFrsSIoKRUp0qNSlMDYpmgjqCpsD0WFBmBGrzMaWcqHXEe5enYXy2nYcqrZLXY7Xyix2LM2M5fUJpliaCGqz1ckLiT5y89I0xIYHocSLnnVyUO/ogbW9hxcSmaKpPqj7XR6cbOjg/dM+Ehasx6YVmfh7ZSPONHVKXc64huenCzI5qJlyqT6oTzd1oN/t4R0fPvSdFRkIMeiwbbf8R9Umix2hQTrMS+aFZKZcqg/qCis3s/W16ZEhuHnpDLxdZkVTR6/U5YzJZLFj0YwYBOlV/6XOVEz1X71mmwORIQZkTAuXuhRVubswGwMeD17YVy11KaPq7nehwubkaQ+meOoPaqsDuSlRfLWlj2XFReDq3CS8eKAGXX0uqcsZ0ZFaB9wewfunmeKpOqhdbg+O13MzW3/ZXJQNR88AXi+tlbqUEZUN3Zi3hHd8MIVTdVBXtXShd8DDJxL9ZGlGLAoyYvHcnnNwueXXsdxksWNWQiRiwoOlLoWxKVF1UPPVpv5XXJSNOnsP3jPL61i5xyNgsth5/zRTBZUHtROhQTpkx0VIXYpqrZmXiOz4CJTsOiurY+VVLZ1w9AxgKS8kMhVQd1DbHJiXHAUDb83yG52OsLkwG2arE/urWqUu57zSar6IiamHahPM4xE4buOFxEC4aXEq4iKDZXWs3GSxIzY8iH+aYqrgdVATkZ6IDhPRDn8W5CuWtm509rl4ITEAQoP0+M6KTHx6shknGzqkLgcAYKqxY2kGX8TE1GEiI+otACr9VYiv8dWmgbVxeQbCgvSyGFW3dfWjqrkLS3jag6mEV0FNRDMAXAtgm3/L8R2zzYEgPWF2olHqUjQhNiIYt16Whr8csaLBIe2x8rLhi5gyuKMLUwdvR9S/BvAzAKNuliWiYiIqJaLS5uZmnxQ3FRVWJ+YkGRFsUO00vOx8b3UW3B6B7fvOSVqHqcaOID1h4Qz+aYqpw7gpRkTXAWgSQpjGepwQokQIUSCEKIiPj/dZgZMhhIDZ5uCFxABLmxaOdQuS8fKBGnT0DkhWh6najryUaIQG6SWrgTFf8ma4uQrADURUDeBVAF8johf9WtUUWdt70N49gDw+6BJw9xRlo6PPhVc/l+ZYeb/LgyN17bwtj6nKuEEthHhICDFDCJEJ4DYAHwshNvq9sikwD19tmsI7PgJt4YwYLM+ehuf3nsOABMfKK2wO9Lk8HNRMVVQ5gVthc0CvI74sXiL3FM1EvaMXfz1iC/hrc8dxpkYTCmohxKdCiOv8VYyvmK0O5CRE8hylRK6YHY+chEiUSNCtvKzGjhmxYUiM4o7jTD1UOaI225y8f1pCOh1hc1E2TjR0YPfploC9rhACpdV2FPBomqmM6oK6ydmL5o4+PpEosRvzU5BgDAnoAZg6ew+aOvp42oOpjuqC2mzjq03lIMSgx52rsrDnTMv5U6L+Njw/zScSmdqoL6itThCBFxJl4FuXpyMiWB+wbuUmix0RwXrMTeL/90xdVBfUx6wOZMVFIDLEIHUpmhcdFoTblqXjr0frYW3v8fvrmSx2LE6PhZ77YzKVUV1QV1j5RKKc3LU6CwDw/B7/Hivv7HPhRIOT56eZKqkqqFs7+2Bz9PJCooykxoTh+oXJePXzGjh6/HesvLymHR7B+6eZOqkqqCtswycSeUQtJ8VFM9HV78ZLBy1+e41SSxuIgPz0GL+9BmNSUVVQD+/44D3U8pKbEoXCnDj8YW81+lxuv7yGyWLHnEQjokKD/PL8jElJVUFdYXUibVoYosP5L6vcbC7MRlNHH94t9/2xcrdHoLyGL2Ji6qWqoOarTeWrMCcO85Kj8OyuKng8vj1WfqqxAx19LhRwx3GmUqoJakfPACyt3XzQRaaICMVFWTjd1IlPTzX59LnPX8SUzh1dmDqpJqiPDy0k5vHVprJ13cIUJEeHYutnvj0AY7LYERcZgrRpYT59XsbkQjVBXcELibIXpNfhrlVZOHiuDUdq2332vCbL4EVM3HGcqZVqgtpsdSApKhTxxhCpS2FjuG1ZGowhBpT46Fh5U0cvatq6eSGRqZp6gtrm5IMuCmAMDcK3lqfj/WP1qGntnvLzDXccX8oLiUzFvGluG0pEnxPRESKqIKJ/D0RhE9Hd78LZ5k6e9lCIu1ZlQa8jPLdn6qNqk8WOYIOO1yaYqnkzou4D8DUhxCIA+QDWEtFy/5Y1MZX1TggBLOAdH4qQGBWKG/NT8XppHexd/VN6rlKLHQtToxFi4G4+TL28aW4rhBCdQ78NGvonsP2VxnG+mS0HtWJsLsxGz4AbLx6Y/LHy3gE3zFYHT3sw1fNqjpqI9ERUDqAJwN+EEDsIr18AAAtPSURBVAdHeEwxEZUSUWlzc7Ov6xyT2epAXGQwEqN4IVEp5iQZ8ZU58XhhfzV6ByZ3rNxsdWDALbA0nYOaqZtXQS2EcAsh8gHMALCMiOaP8JgSIUSBEKIgPj7e13WOabhHIm/PUpbiomy0dPbj7TLrpD6/lDuOM42YaBfydgCfAFjrn3ImrnfAjdONHbzjQ4FWZE/HgtRobNs9uWPlJosdWXERmB7JP0kxdfNm10c8EcUM/ToMwFUATvi7MG+dauyAyyP4jg8FGjxWno2qli78rbJxQp8rhECZxY4lPO3BNMCbEXUygE+I6CiAQxico97h37K8xwuJyrZufhJmxIbh2Ql2K69u7UZrVz9fxMQ0wZtdH0eFEIuFEAuFEPOFEP8RiMK8dczqQFSoATNi+Z4HJTLodfje6iyUWuznL1fyhonnp5mGKP5kYoXNgfmpvJCoZBsK0hAdFoSSXWe9/hyTpQ1RoQbMio/0Y2WMyYOig3rA7cGJ+g6e9lC4iBADNi3PwEfHG1HV3Dn+J2BwRL0kIxY67jjONEDRQX26sRP9bg8fH1aBO1ZmIEinwzYvupU7ugdwqrGT908zzVB0UA/3SOQRtfIlGEOxfkkq3jLVoaWzb8zHltXyRUxMWxQd1BVWByKC9ciaHiF1KcwH7i7MRp/Lgz/uH/tYeZnFDr2OkJ/GHceZNig6qM02J3JTonieUiVmJURizbxE/Gl/NXr6Rz9WXlptR25yFMKDDYErjjEJKTao3R6B40NHx5l63HNFNuzdA3jDVDvix11uD8prueM40xbFBvW5lk70DLh5flplCjJikZ8Wg227z8E9wrHyyvoO9Ay4sYSDmmmIYoP6ixOJvONDTYgI9xRlo6atGx9WNHzp4yZLG4DBQGdMKxQc1A6EGHR84EGFvp6XhMzp4di6qwpCXDyqNtW0Izk6FCkxfBKVaYdyg9rmwNzkKBj0iv1PYKPQ6wjfK8zGkdp2fH6u7aKPmarbeH6aaY4iU87jEaiwOrGApz1U6+YlMzAtIhglF1zWZGvvgc3Ry0HNNEeRQV1r70ZHn4uvNlWxsGA9Ni3PwD9ONOFMUwcAvoiJaZcig5qvNtWGO1ZkIMSgw7O7Bo+Vmyx2hAXpMS+Zf5Ji2qLMoLY5EKQn5CTyQqKaTY8MwS0FM/Dnw1Y0OXtRVmPHorRoBPG6BNMYbzq8pBHRJ0R0nIgqiGhLIAobi9nqwOxEI0IMeqlLYX529+psDHg8+N1nZ1Fhc6IgY5rUJTEWcN4MTVwAfiKEyAWwHMAPiCjXv2WNTgiBCpuT56c1IjMuAlfnJuEP+6rh9gien2aa5E2Hl3ohRNnQrzsAVAJI9Xdho6l39KKtq58PumhI8RXZGN5OvTidL2Ji2jOhW22IKBPAYgAHR/hYMYBiAEhPT/dBaSM7Zh282jSPFxI1Y0l6LC7PmobOPhdiwoOlLoexgPM6qIkoEsBbAO4XQjgv/bgQogRACQAUFBR8+ZIGH6mwOqAjYF4Sj6i15NnvFKDf5ZG6DMYk4VVQE1EQBkP6JSHE2/4taWxmmxOzEiIRFswLiVoSFRokdQmMScabXR8E4DkAlUKIJ/1f0tjMVgcvJDLGNMWbXR+rAGwC8DUiKh/65xo/1zWiJmcvmjr6eH6aMaYp4059CCH2AJBFC5UK29CJRG5myxjTEEUd8TIP7fjI5aBmjGmIsoLa5kBWXASMvLDEGNMQZQW11Yk8Hk0zxjRGMUFt7+qHtb2Hb8xjjGmOYoL6i4VEDmrGmLYoJqjNtsGFRL7jgzGmNcoJaqsDM2LD+K4HxpjmKCao+WpTxphWKSKoO3oHcK6li6c9GGOapIigPj60kMhHxxljWqSIoDbzjg/GmIYpIqgrrA4kRoUg3hgidSmMMRZwighqs42vNmWMaZfsg7q734UzTZ08P80Y0yzZB3VlfQc8gq82ZYxpl+yDuuL8iUQeUTPGtMmbVlzPE1ETEZkDUdClzFYHpkUEIzk6VIqXZ4wxyXkzov4DgLV+rmNUw1ebDrZuZIwx7Rk3qIUQuwC0BaCWL+lzuXGqsYOnPRhjmuazOWoiKiaiUiIqbW5u9slznmrohMsjeGseY0zTfBbUQogSIUSBEKIgPj7eJ8/JV5syxpjMd32YrQ4YQw1InxYudSmMMSYZeQe1jRcSGWPMm+15rwDYD2AOEdUR0ff8XxYw4Pagsp7voGaMMcN4DxBC3B6IQi51trkT/S4PFszgoGaMaZtspz7M1qE7qHlEzRjTOBkHtQPhwXpkxUVIXQpjjElKtkFdYXMgNzkKeh0vJDLGtE2WQe3xiMFmtnwikTHG5BnU51q70N3vRh5fbcoYY/IMarOVrzZljLFhsgzqCpsTwQYdZiVESl0KY4xJTpZBfazOgXlJRgTpZVkeY4wFlOySUAgBs83BPRIZY2yI7IK6tq0HHb0uPjrOGGNDZBfUfLUpY4xdTH5BbXXAoCPMTjRKXQpjjMmC/ILa5kROohGhQXqpS2GMMVmQVVALIVBhdWA+H3RhjLHzZBXUDc5etHb180EXxhi7gKyCevhqU15IZIyxL3gV1ES0lohOEtEZInrQX8WYrQ7oCJiXzEHNGGPDvGnFpQfwWwDrAOQCuJ2Icv1RTIXNgZnxkQgPHrfxDGOMaYY3I+plAM4IIaqEEP0AXgVwoz+KMVv5alPGGLuUN0GdCqD2gt/XDf3ZRYiomIhKiai0ubl5woX0uzxYnROHK2bHT/hzGWNMzXw2xyCEKAFQAgAFBQViop8fbNDh8VsW+aocxhhTDW9G1FYAaRf8fsbQnzHGGAsAb4L6EIAcIsoiomAAtwH4i3/LYowxNmzcqQ8hhIuIfgjgQwB6AM8LISr8XhljjDEAXs5RCyHeA/Cen2thjDE2AlmdTGSMMfZlHNSMMSZzHNSMMSZzHNSMMSZzJMSEz6aM/6REzQAsk/z0OAAtPixHyfi9uBi/Hxfj9+MLangvMoQQIx7N9ktQTwURlQohCqSuQw74vbgYvx8X4/fjC2p/L3jqgzHGZI6DmjHGZE6OQV0idQEywu/Fxfj9uBi/H19Q9XshuzlqxhhjF5PjiJoxxtgFOKgZY0zmZBPUgWqgqwRElEZEnxDRcSKqIKItUtckNSLSE9FhItohdS1SI6IYInqTiE4QUSURrZC6JikR0QNDf0/MRPQKEYVKXZOvySKoA9lAVyFcAH4ihMgFsBzADzT+fgDAFgCVUhchE08B+EAIMRfAImj4fSGiVAD3ASgQQszH4FXMt0lble/JIqgRwAa6SiCEqBdClA39ugODfxG/1KdSK4hoBoBrAWyTuhapEVE0gCIAzwGAEKJfCNEubVWSMwAIIyIDgHAANonr8Tm5BLVXDXS1iIgyASwGcFDaSiT1awA/A+CRuhAZyALQDGD70FTQNiKKkLooqQghrAAeB1ADoB6AQwjxkbRV+Z5cgpqNgIgiAbwF4H4hhFPqeqRARNcBaBJCmKSuRSYMAJYA+J0QYjGALgCaXdMholgM/vSdBSAFQAQRbZS2Kt+TS1BzA91LEFEQBkP6JSHE21LXI6FVAG4gomoMTol9jYhelLYkSdUBqBNCDP+E9SYGg1ur1gA4J4RoFkIMAHgbwEqJa/I5uQQ1N9C9ABERBucgK4UQT0pdj5SEEA8JIWYIITIx+HXxsRBCdSMmbwkhGgDUEtGcoT+6EsBxCUuSWg2A5UQUPvT35kqocHHVq56J/sYNdL9kFYBNAI4RUfnQn/3zUO9Kxn4E4KWhQU0VgDslrkcyQoiDRPQmgDIM7pY6DBUeJ+cj5IwxJnNymfpgjDE2Cg5qxhiTOQ5qxhiTOQ5qxhiTOQ5qxhiTOQ5qxhiTOQ5qxhiTuf8DGQ08/Q1hA6IAAAAASUVORK5CYII=",
             "text/plain": [
               "<Figure size 432x288 with 1 Axes>"
             ]
           },
           "metadata": {
             "needs_background": "light"
-          }
+          },
+          "output_type": "display_data"
         }
+      ],
+      "source": [
+        "df = pd.DataFrame(np.random.randint(10, size=(10,4)), columns=list(\"ABCD\"))\n",
+        "\n",
+        "df.A.plot.line()\n",
+        "plt.show()"
       ]
     },
     {
@@ -6324,32 +6301,32 @@
     },
     {
       "cell_type": "code",
+      "execution_count": 111,
       "metadata": {
         "colab": {
           "base_uri": "https://localhost:8080/",
           "height": 248
         },
         "id": "AoPKA6NiA9xm",
-        "outputId": "8feb6409-fc2b-4b07-d6ee-ba9b9d839e6f"
+        "outputId": "c67fc549-2e1d-4e74-aeb0-360bf790a9d6"
       },
+      "outputs": [
+        {
+          "data": {
+            "image/png": "iVBORw0KGgoAAAANSUhEUgAAAPUAAADnCAYAAADGrxD1AAAABHNCSVQICAgIfAhkiAAAAAlwSFlzAAALEgAACxIB0t1+/AAAADh0RVh0U29mdHdhcmUAbWF0cGxvdGxpYiB2ZXJzaW9uMy4yLjIsIGh0dHA6Ly9tYXRwbG90bGliLm9yZy+WH4yJAAAWD0lEQVR4nO3deXxcZb3H8c+TrUlbMi1tkya0kILApTBsRRYpyxWUJYgL6qUgDlKgCKJwr9S5cK8eBDW4gSKyXEFyARGhinqDCrK0wC2LLOXUlpYCKS1rQ2taCk0mM49/nKnE0JBJOnN+c57ze79e8wotyZwvL+ab58yZ5zyPsdailHJHhXQApVRxaamVcoyWWinHaKmVcoyWWinHaKmVcoyWWinHaKmVcoyWWinHaKmVcoyWWinHaKmVcoyWWinHaKmVcoyWWinHaKmVcoyWWinHaKmVcoyWWinHaKmVcoyWWinHaKmVcoyWWinHaKmVcoyWWinHaKmVcoyWWinHVEkHUCXiJZqAHYGdgGnAJKAe2GbA17H5n+jp9+jNf90ErAFWAy8P+PoaXnc2pP8aNQxGN8iLOC8xDdgPmAFMJyjyNGB0iY/cBzwLPAU8/Y+vXve6Eh9XDUFLHSVeohr4IDAz/zgImCia6b1WAk8A9wJ343WvEM4TO1rqcuclxgPHAscDRwEJ2UDD9gJwD/An4D687m7hPM7TUpcjL7ET8HHgYwQjsivXPvqAB4GbgTvwutcL53GSlrpceIk64LPA6QRFdt0m4HfATcAf8br7hPM4Q0stzUvsDZwBnEz0Tq2LZQ3wS+AavO4l0mGiTkstwUtUAScB5xJcuVYBC9wNXI7X/SfpMFGlpQ5TcPU6BfwnwUdPags22lFLd+/5eQa4DLits61VPw8fBi11GLzEKOA0IA1sL5ym7F2aOfn/f5Zt/VD+jy8AHnBzZ1urvlgLoKUuJS9RCcwBLgS2E04TCX22YvWuPe2Ts1QOvOL/FDC3s631zxK5okTnfpeKlzgUeBK4Ci10wW7JHvn8FgoNsA9wT0u6408t6Y69ws4VJTpSF5uXaAa+D8ySjhI1Ocvf9ui5ofptascM9a3Az4ELOttadVrqADpSF4uXqMZLzAWWoYUekXtz+z5dQKEheN3OBpa0pDs+XeJYkaMjdTF4iT2BW4A9pKNElbX0HNjzk+7X2bZhBD9+J3BOZ1vrK8XOFUU6Um8NL2HwEv8OPIYWeqv4dtpjIyw0wCcIRu3Ti5kpqnSkHqngvXM7cKR0lKizFntMb9uLz9rti/HZ/W3AGZ1trRuK8FyRpCP1SHiJTwE+WuiieIUJjxep0AD/BjzZku7Yu0jPFzla6uHwEpV4iSuAecC20nFccVFmdm2Rn/IDwCMt6Y6zi/y8kaCn34XyEgmCU7ujpKO4ZL2tW7xnz/WlvB5xK/CFzrbWnhIeo6w4N1IbY24wxrxhjFlctCcN7m9eiBa66L7Xd+JbJT7ELODelnTHhBIfp2w4V2rgRuDooj2blzgceBTYrWjPqQDotZUrb84esX8IhzoYWNiS7vhACMcS51yprbULgLVFeTIvcSrBrYCx+S0fpp9nj15pqQjrNbgzQbE/NOR3RpxzpS4aL/FF4AagWjqKi3LWdF3e9+kPhnzYiQSn4h8P+bih0lJviZc4F/gpYKSjuOqu3P6LNzGqTuDQtcDtLhdbSz2Qlzgf+LF0DJdZyztfz5yaFIxQjcPF1lL3F9yQ8UPpGK57wu7y+FoS0tcpnC22c6U2xtxK8PHTrsaY1caY2QX9YFDoy0qZTYG15OZmztxBOkfe5mIfLx2kmHTyCYCXSBF8FKZKrDPXuPDw3ssPks4xwCbgw51trQulgxSDcyP1sHmJo4GfSceIi3Tf6fXSGbagFvhdS7pjJ+kgxRDvUgf3Qd+OOztglLV1duyiR3K77y6dYxATgT+4MPMsvqX2EpOB3/PuVq6qxL7dd1KvdIYh7Azc2ZLuGDXSJzDGHG2MWWaMWWGMSRcxW8HiWWovUUuwWoYu1xuSHlv9/O3Zw6KwccFMgklHw2aMqSRYaPIYgm2FZxljphcxW0HiWWq4HDhAOkScXJM97hUwUZnMc1JLuuOsEfzc/sAKa+0L1tpegq2EQv/ILH6lDhY4GMn/MDVCWWveuKrvE2HcuFFMl49goYXtgFX9/rwageWh41VqL7EDcL10jLi5MzdzSS/VI36fKqQW+FVLumMb6SDDFZ9SB5vS/QIYJx0lTqzlrYszp+wjnWOEdgauG8b3vwxM7ffnKfm/C1V8Sg3fBJy/7a7cLMxNf2I9Y6O8Re+Jw1il9HFgZ2PMNGNMDXAiwR7coYrHjDIvcRhwH/H6JSbOWvoO7b3i9VW2IerbDq0H9uhsa1011DcaY44FrgAqgRustd8qdbiB3J904SVqgGvRQoduhW1+dJVtOFg6RxHUA/9DASvqWGvvAu4qeaL3EYcX+lxgV+kQcTQ3M2eidIYiOqol3XGKdIhCuH36HSwYuJjgSqYKUZetf2q/nmuieoFsMGuA3TrbWt+UDvJ+XB+pr0ILLeLizOez0hlKYBLwXekQQ3F3pPYSnyVYp1uF7B1bs3y3nht3kc5RIjlgRmdb69PSQQbj5kjtJeoIpoIqAVf2fXKNdIYSqqDMF9Nws9RwDtAsHSKO+mzFq9dlW6M2JXS4PtqS7viIdIjBuFdqLzEW+Jp0jLj6Vfbw5X1UxWFZ5cta0h1leYOKe6WGLxPc8K5CZi3d3+o7eV/pHCHZBzhZOsSWuFXqYBO7r0rHiKsHcns9tZG6yN0AsRUubkl3VEqHGMitUsP5wHjpEHFkLb0XZk7/F+kcIdsR+JR0iIHcKXUwSp8vHSOultrtH3uVCZOlcwgouzNDd0oNXyCYo6tCZi32gsycOBYaYP+WdMeh0iH6c6PUXsIAX5SOEVevM/6Jv9ppsdgmdhAXSAfoz41SwxGAqzOYyt7XM6eW3cWikLW2pDvKZv9yV0p9tnSAuNpoa5fenfugazduDJcBzpAOsVn0S+0ltgOc2gspSn7Q95l10hnKxMkt6Y6yWJ8g+qWGOQSrTKiQZWzlqhuzR+lSy4EGgvW+xblQ6kjcuO6im7IfeSFHhf5CfVdKOgBE/dZLLzED+It0jDjKWdbt0XNDzdvUjpHOUkZ6gabOtta1kiGiPlKfIB0gru7J7bdIC/0em1cQFRX1UpfdFL04sJZNF2VOK9fdK6WFvs3OQNEttZfYHV1QUMQiu9PjXYybJJ2jTB3Wku4QPYOJbqn11FuEteTmZs6cIp2jjI0CjpQMEOVSf1I6QBy9zMS/LLdTp0nnKHOtkgePZqm9xLbAXtIx4ujCzGxdnXVoWuoROJhgap4K0Xo72l+Q22tP6RwR0NyS7hAbdKJa6kOkA8RRW9+JG6UzRIjYdkNaalWQXlvVeWv2w66vElpMB0odOHqlDtb0niEdI26uzx7zkqUieq8XOWJz4qP4P+kAIA5L0JaNnDVrrug7QUfp4dm5Jd2xrcSBo1jqg6QDxM3/5Q78aw81etV7eAxCo3UUSz1dOkCcWMvb38ik9Ir3yIic3USx1Do1NESP210fX0e9yGmkA0SWTNZSq0FZS3Zu5swdpXNE2M4SB41Wqb3EZHQZ4NB02smPddqmqdI5IkxLXYC47QAhKp05PSGdIeLqW9IdDWEfNGql1lPvkKyzY59+1E7Xi5JbL/TROmql3kk6QFxcmvlcRjqDI7TUQ4jr1i6h2mSrn5+XO2Q/6RyOaAz7gFErdejvT+Lo6r7jXwWjd8EVR+gfB0at1LqETollrXntp9mP65TQ4pkQ9gGjVmqdBFFi87KHPJuhqkY6h0N0pB6CfsRSQtay4ZK+U+K+L1ax6Ug9BJ14UkIP5/Z4cgNj9BdncelIPSgvUYvumVUy1tKX7jtDZAaU40aHfcBhl9oYM9MYc1Upwig5z9ntHlttJzVL53BQ6ANRQVtvGmP2AU4CPgO8CPy6lKEGkRU4ZmzMzcwJ/b1fTIR+NjxoqY0xuwCz8o8u4DaCDfX+NaRsA+WEjuu0Nysquk5talz2YvXPdhsLohu7ualifdgrBg+666UxJgc8CMy21q7I/90L1lq5W/G8RIS36Cw/1yXqH/rJ+MR0a4x+VFg6nX7KD3Xzg/c7/f4UwQ5+9xtj/gj8Evm1tm0ZZIi8l6qqVqeaGl/rqqqcKZ0lBkJ/2zjo+b619k5r7YkEtzveD5wHNBhjrjbGfDSsgAPo++qtkIPcpRPGz2+d0jS+q6pS53aHI/QbY4a8UGat3Qj8AviFMWY8wcWyrwF3lzjblvRS4MU99c8W19Q8d3pTQ+/GiorDpLPETOjXKYZVEGvtOuC6/EPCGmAHoWNHUi/0XNAwceF9o+sOxhhdWjl8XWEfMGqj3utoqQv2YF3tM+c1Thrba8zh0llibE3YB4xiqdUQ3jJmwxcnNzz19KiaQzB6C6Ww0EsdnWmigdekA5S7O8eOeezgHaa89XTtqEO10GVBR+oh6Eg9iK7KijWnNjU+t7K6+kPSWdQ/Cf09ddRGai31FlybqH/4w1O3q9JCl6XQX7NRG6lflg5QTvKTSF7vqqoU2wtZDWl52AeMWqmXSAcoBznIfXvC+Adv22bsfhgzRTqPGtTbwMqwDxq1Uq8ANgGx3YFRJ5FEyjI/5Yd+I1K03lN73VngWekYEnqh58sNE+fPam5s2VhRsbt0HlWQpRIHjdpIDbAY2Fs6RJj6TSLR0TlaRN4uRrXUsfCWMRvOmtzw1CKdRBJVIqWO1ul3IBal/k1+EskinUQSZSKv1SiO1E9IByil/CSSFSurqw+SzqK2ymt+yn9O4sDRG6m97tdw9GLZtePqH8pPItFCR98CqQNHcaQGuA+H9qpeWVW1KtXU+MabuhKJS+ZLHTh6I3XgfukAxZCF7DcnjJ9/3JSmCW9WVc6QzqOKSqzUUR2pHyDi65X5NTXLz2hq6NNJJE7qQnD2YzRHaq+7i4heBe+FnnMbJs4/qblx2saKiunSeVRJLPBTvtjKt1EdqSF4X52UDjEcC+pqF53XOKk+o5NIXHeP5MGjXOrfA1+RDlGIDcasP2tyw6JnRtXM1M+cnZdFZgebf4jm6XfgASJwf/Wvx455bOYOUzY+UztKZ4XFwwI/5b8hGSC6pQ5u7rhDOsZguior1hw3pWnhNyZN2D9nTJN0HhWaX0kHiG6pA7+UDrAlV+skkrgSP/WGaL+nBngYWAVMlQ4CwSSSzzc3rllbqZNIYkr81BuiPlJ73ZYyON3pP4lkbWXlvtJ5lBjx1yJEvdSBWyQP7tfULD94hynLbq/f5jCMGS2ZRYnaCNwqHQJcKLXX/RSwMOzD5ieRPHBSc+OOOolEATf5Kb9bOgS4UOrAj8I82IK62kUHtkx95YExow/HmKhfl1DF8RPpAJu58oKcB6wGSrqy5gZj1s+Z3LDI10kk6p/d76f8v0qH2MyNkdrr7gOuKuUhNk8i8XUSiXqvK6UD9OfKSA3B9rpfB+qK+aRr8iuRvKSfOastewn4nXSI/twYqQG87rXATcV8yqvH1T90xNTtqrXQ6n1c4af8rHSI/lwaqQEuA74AbNXm6p1VVS+lmhu7dBKJGsLLwNXSIQZyZ6QG8LpfIDgNH5EsZL0J287/2JSmiTqJRBXgEj/lb5IOMZBrIzXAJcCpwJjh/NAzo2qWnTG5Ifu2rkSiCvM8cL10iC1xa6QG8LpfBy4v9Nt7DJu+1DjxgZObGnd6WyeRqMJ9w0/5fdIhtsS9Uge+RwGbfc+vq1100A5TX50/WieRqGFZTJlMCd0SN0vtda8HvjPYv15fYbpnNTU++KXGSXtmjJkWYjLlhrTEbpaFcrPUgauAZQP/8o6xYx49ZPsp7yzWSSRqZOb5Kb9DOsT7cbfUXncPcNbmP66prFhz7JSmRy6eNOGAnDGTBZOp6FoPfFk6xFCMtWIrmYbDS9x41bjEjteOq09aY8ZJx1GRdo6f8n8qHWIozl8cOmJq8/lvVFUtBbTQamssBK6RDlEId0+/8+6dvXQdcI50DhVpGeDMcr441p/zpQbwU/484HbpHCqyvuOn/MjsCBOLUuedRXBHjVLD8TDwTekQw+H+hbJ+ku3JAwj2Da6RzqIi4W/AXn7Kj9RgEKeRGj/lPwp8VTqHiozTolZoiFmpAfyUfyVlspSrKms/8FP+b6RDjETsSp13OrBcOoQqWw8BaekQIxXLUvspfwNwAvCWdBZVdp4HTijXO7AKEctSA+Q/ojiB4DNIpSC4s++Yctg6Z2vEttQAfsq/GzgNiM9HAGow7wAf81P+c9JBtlasSw3gp/ybga9J51CicsAsP+U/Ih2kGGJfagA/5X+PYayWopxzrp/yfysdoli01O/6D8p4NQtVMv8dhTuvhkNLneenfAucQpHXDldl7QI/5V8qHaLYtNT95BdlTwFO/eZW72GBL/kp//vSQUohVnO/hyPZnmxDL6C5KEdwG2VZLu9bDFrq95FsT14IfEs6hyqaLJDyU/4t0kFKSUs9hGR78mzgx0CldBa1VbqBk/yUf5d0kFLTUhcg2Z48ErgN2FY6ixqR54Dj/ZT/rHSQMOiFsgL4Kf/PwH6AL51FDdvdwP5xKTRoqQvmp/wXgYOAO6SzqIJdARzrp/y/SQcJk55+j0CyPXkRwRI3+kuxPL1F8JFVu3QQCVrqEUq2Jw8FbgR0257yshA4xU/5z0sHkaIjzQj5KX8BsCdbsR+2KqoM8F/AIXEuNOhIXRTJ9uTRBHsVN0tniaklBKPzk9JByoGO1EXgp/w/AnsAN0tniZkMwbbFM7TQ79KRusiS7cnDCW7j3Fs4iuvuAs73U76uNTeAlroEku3JCoIVVS4FGoXjuGY5QZmdnxk2UlrqEkq2J7cBLgLOA0YJx4m69cAlwI/8lK/ryr0PLXUIku3JaQTlPgXdHWS41gFXEpR5rXSYKNBShyjZnmwGzgfmANsIxyl3rwM/BK7OL+msCqSlFpBsT44Dzga+AjQIxyk3LwHfBa73U/4m6TBRpKUWlGxP1gKfI9gx5ADhOJIyQAdwA3BXfgUaNUJa6jKRbE/uDswGZgGTheOEZQlBkW+K+gL65URLXWaS7clK4EjgZOA4YLxsoqJbDfwWuNmVdbbLjZa6jOULfgBwNHAMMAMwoqGGLwc8AfwB+K3O/Co9LXWEJNuTk4Cj8o/9gZ0pv5L3As8AjwMPAnf7Kf9N2UjxoqWOsGR7sh7YB9iXYBSfAexCeHP6e4EVBAXe/Fjkp/yekI6vtkBL7Zhke7IOmAps3+/r5n9uBkYDdf0eAyfDZICNBAsNbMw/1gIrgc4Bj1f8lJ8r3X+NGgktdczl37fXAVXARp2CGX1aaiXCGDMV+F+CG14scJ219keyqdygpVYijDFNQJO19kljzDYEV8g/Ya1dIhwt8nSRBCXCWvuqtfbJ/D9vAJYC28mmcoOWWokzxrQQXMV/VDaJG7TUSpQxZiwwDzjPWrteOo8LtNRKjDGmmqDQt1hrfy2dxxV6oUyJMMYYoB1Ya609TzqPS7TUSoQxZibBNFKfYH44wIXWWl17bCtpqZVyjL6nVsoxWmqlHKOlVsoxWmqlHKOlVsoxWmqlHKOlVsoxWmqlHKOlVsoxWmqlHKOlVsoxWmqlHKOlVsoxWmqlHKOlVsoxWmqlHKOlVsoxWmqlHKOlVsoxfwcMr/oLYfsDRgAAAABJRU5ErkJggg==",
+            "text/plain": [
+              "<Figure size 432x288 with 1 Axes>"
+            ]
+          },
+          "metadata": {},
+          "output_type": "display_data"
+        }
+      ],
       "source": [
         "df = pd.DataFrame(np.random.randint(10, size=(3,4)), columns=list(\"ABCD\"))\n",
         "\n",
         "df.A.plot.pie(y=\"A\")\n",
         "plt.show()"
-      ],
-      "execution_count": 457,
-      "outputs": [
-        {
-          "output_type": "display_data",
-          "data": {
-            "image/png": "iVBORw0KGgoAAAANSUhEUgAAAPUAAADnCAYAAADGrxD1AAAABHNCSVQICAgIfAhkiAAAAAlwSFlzAAALEgAACxIB0t1+/AAAADh0RVh0U29mdHdhcmUAbWF0cGxvdGxpYiB2ZXJzaW9uMy4yLjIsIGh0dHA6Ly9tYXRwbG90bGliLm9yZy+WH4yJAAAWD0lEQVR4nO3deXxcZb3H8c+TrUlbMi1tkya0kILApTBsRRYpyxWUJYgL6qUgDlKgCKJwr9S5cK8eBDW4gSKyXEFyARGhinqDCrK0wC2LLOXUlpYCKS1rQ2taCk0mM49/nKnE0JBJOnN+c57ze79e8wotyZwvL+ab58yZ5zyPsdailHJHhXQApVRxaamVcoyWWinHaKmVcoyWWinHaKmVcoyWWinHaKmVcoyWWinHaKmVcoyWWinHaKmVcoyWWinHaKmVcoyWWinHaKmVcoyWWinHaKmVcoyWWinHaKmVcoyWWinHaKmVcoyWWinHaKmVcoyWWinHaKmVcoyWWinHVEkHUCXiJZqAHYGdgGnAJKAe2GbA17H5n+jp9+jNf90ErAFWAy8P+PoaXnc2pP8aNQxGN8iLOC8xDdgPmAFMJyjyNGB0iY/cBzwLPAU8/Y+vXve6Eh9XDUFLHSVeohr4IDAz/zgImCia6b1WAk8A9wJ343WvEM4TO1rqcuclxgPHAscDRwEJ2UDD9gJwD/An4D687m7hPM7TUpcjL7ET8HHgYwQjsivXPvqAB4GbgTvwutcL53GSlrpceIk64LPA6QRFdt0m4HfATcAf8br7hPM4Q0stzUvsDZwBnEz0Tq2LZQ3wS+AavO4l0mGiTkstwUtUAScB5xJcuVYBC9wNXI7X/SfpMFGlpQ5TcPU6BfwnwUdPags22lFLd+/5eQa4DLits61VPw8fBi11GLzEKOA0IA1sL5ym7F2aOfn/f5Zt/VD+jy8AHnBzZ1urvlgLoKUuJS9RCcwBLgS2E04TCX22YvWuPe2Ts1QOvOL/FDC3s631zxK5okTnfpeKlzgUeBK4Ci10wW7JHvn8FgoNsA9wT0u6408t6Y69ws4VJTpSF5uXaAa+D8ySjhI1Ocvf9ui5ofptascM9a3Az4ELOttadVrqADpSF4uXqMZLzAWWoYUekXtz+z5dQKEheN3OBpa0pDs+XeJYkaMjdTF4iT2BW4A9pKNElbX0HNjzk+7X2bZhBD9+J3BOZ1vrK8XOFUU6Um8NL2HwEv8OPIYWeqv4dtpjIyw0wCcIRu3Ti5kpqnSkHqngvXM7cKR0lKizFntMb9uLz9rti/HZ/W3AGZ1trRuK8FyRpCP1SHiJTwE+WuiieIUJjxep0AD/BjzZku7Yu0jPFzla6uHwEpV4iSuAecC20nFccVFmdm2Rn/IDwCMt6Y6zi/y8kaCn34XyEgmCU7ujpKO4ZL2tW7xnz/WlvB5xK/CFzrbWnhIeo6w4N1IbY24wxrxhjFlctCcN7m9eiBa66L7Xd+JbJT7ELODelnTHhBIfp2w4V2rgRuDooj2blzgceBTYrWjPqQDotZUrb84esX8IhzoYWNiS7vhACMcS51yprbULgLVFeTIvcSrBrYCx+S0fpp9nj15pqQjrNbgzQbE/NOR3RpxzpS4aL/FF4AagWjqKi3LWdF3e9+kPhnzYiQSn4h8P+bih0lJviZc4F/gpYKSjuOqu3P6LNzGqTuDQtcDtLhdbSz2Qlzgf+LF0DJdZyztfz5yaFIxQjcPF1lL3F9yQ8UPpGK57wu7y+FoS0tcpnC22c6U2xtxK8PHTrsaY1caY2QX9YFDoy0qZTYG15OZmztxBOkfe5mIfLx2kmHTyCYCXSBF8FKZKrDPXuPDw3ssPks4xwCbgw51trQulgxSDcyP1sHmJo4GfSceIi3Tf6fXSGbagFvhdS7pjJ+kgxRDvUgf3Qd+OOztglLV1duyiR3K77y6dYxATgT+4MPMsvqX2EpOB3/PuVq6qxL7dd1KvdIYh7Azc2ZLuGDXSJzDGHG2MWWaMWWGMSRcxW8HiWWovUUuwWoYu1xuSHlv9/O3Zw6KwccFMgklHw2aMqSRYaPIYgm2FZxljphcxW0HiWWq4HDhAOkScXJM97hUwUZnMc1JLuuOsEfzc/sAKa+0L1tpegq2EQv/ILH6lDhY4GMn/MDVCWWveuKrvE2HcuFFMl49goYXtgFX9/rwageWh41VqL7EDcL10jLi5MzdzSS/VI36fKqQW+FVLumMb6SDDFZ9SB5vS/QIYJx0lTqzlrYszp+wjnWOEdgauG8b3vwxM7ffnKfm/C1V8Sg3fBJy/7a7cLMxNf2I9Y6O8Re+Jw1il9HFgZ2PMNGNMDXAiwR7coYrHjDIvcRhwH/H6JSbOWvoO7b3i9VW2IerbDq0H9uhsa1011DcaY44FrgAqgRustd8qdbiB3J904SVqgGvRQoduhW1+dJVtOFg6RxHUA/9DASvqWGvvAu4qeaL3EYcX+lxgV+kQcTQ3M2eidIYiOqol3XGKdIhCuH36HSwYuJjgSqYKUZetf2q/nmuieoFsMGuA3TrbWt+UDvJ+XB+pr0ILLeLizOez0hlKYBLwXekQQ3F3pPYSnyVYp1uF7B1bs3y3nht3kc5RIjlgRmdb69PSQQbj5kjtJeoIpoIqAVf2fXKNdIYSqqDMF9Nws9RwDtAsHSKO+mzFq9dlW6M2JXS4PtqS7viIdIjBuFdqLzEW+Jp0jLj6Vfbw5X1UxWFZ5cta0h1leYOKe6WGLxPc8K5CZi3d3+o7eV/pHCHZBzhZOsSWuFXqYBO7r0rHiKsHcns9tZG6yN0AsRUubkl3VEqHGMitUsP5wHjpEHFkLb0XZk7/F+kcIdsR+JR0iIHcKXUwSp8vHSOultrtH3uVCZOlcwgouzNDd0oNXyCYo6tCZi32gsycOBYaYP+WdMeh0iH6c6PUXsIAX5SOEVevM/6Jv9ppsdgmdhAXSAfoz41SwxGAqzOYyt7XM6eW3cWikLW2pDvKZv9yV0p9tnSAuNpoa5fenfugazduDJcBzpAOsVn0S+0ltgOc2gspSn7Q95l10hnKxMkt6Y6yWJ8g+qWGOQSrTKiQZWzlqhuzR+lSy4EGgvW+xblQ6kjcuO6im7IfeSFHhf5CfVdKOgBE/dZLLzED+It0jDjKWdbt0XNDzdvUjpHOUkZ6gabOtta1kiGiPlKfIB0gru7J7bdIC/0em1cQFRX1UpfdFL04sJZNF2VOK9fdK6WFvs3OQNEttZfYHV1QUMQiu9PjXYybJJ2jTB3Wku4QPYOJbqn11FuEteTmZs6cIp2jjI0CjpQMEOVSf1I6QBy9zMS/LLdTp0nnKHOtkgePZqm9xLbAXtIx4ujCzGxdnXVoWuoROJhgap4K0Xo72l+Q22tP6RwR0NyS7hAbdKJa6kOkA8RRW9+JG6UzRIjYdkNaalWQXlvVeWv2w66vElpMB0odOHqlDtb0niEdI26uzx7zkqUieq8XOWJz4qP4P+kAIA5L0JaNnDVrrug7QUfp4dm5Jd2xrcSBo1jqg6QDxM3/5Q78aw81etV7eAxCo3UUSz1dOkCcWMvb38ik9Ir3yIic3USx1Do1NESP210fX0e9yGmkA0SWTNZSq0FZS3Zu5swdpXNE2M4SB41Wqb3EZHQZ4NB02smPddqmqdI5IkxLXYC47QAhKp05PSGdIeLqW9IdDWEfNGql1lPvkKyzY59+1E7Xi5JbL/TROmql3kk6QFxcmvlcRjqDI7TUQ4jr1i6h2mSrn5+XO2Q/6RyOaAz7gFErdejvT+Lo6r7jXwWjd8EVR+gfB0at1LqETollrXntp9mP65TQ4pkQ9gGjVmqdBFFi87KHPJuhqkY6h0N0pB6CfsRSQtay4ZK+U+K+L1ax6Ug9BJ14UkIP5/Z4cgNj9BdncelIPSgvUYvumVUy1tKX7jtDZAaU40aHfcBhl9oYM9MYc1Upwig5z9ntHlttJzVL53BQ6ANRQVtvGmP2AU4CPgO8CPy6lKEGkRU4ZmzMzcwJ/b1fTIR+NjxoqY0xuwCz8o8u4DaCDfX+NaRsA+WEjuu0Nysquk5talz2YvXPdhsLohu7ualifdgrBg+666UxJgc8CMy21q7I/90L1lq5W/G8RIS36Cw/1yXqH/rJ+MR0a4x+VFg6nX7KD3Xzg/c7/f4UwQ5+9xtj/gj8Evm1tm0ZZIi8l6qqVqeaGl/rqqqcKZ0lBkJ/2zjo+b619k5r7YkEtzveD5wHNBhjrjbGfDSsgAPo++qtkIPcpRPGz2+d0jS+q6pS53aHI/QbY4a8UGat3Qj8AviFMWY8wcWyrwF3lzjblvRS4MU99c8W19Q8d3pTQ+/GiorDpLPETOjXKYZVEGvtOuC6/EPCGmAHoWNHUi/0XNAwceF9o+sOxhhdWjl8XWEfMGqj3utoqQv2YF3tM+c1Thrba8zh0llibE3YB4xiqdUQ3jJmwxcnNzz19KiaQzB6C6Ww0EsdnWmigdekA5S7O8eOeezgHaa89XTtqEO10GVBR+oh6Eg9iK7KijWnNjU+t7K6+kPSWdQ/Cf09ddRGai31FlybqH/4w1O3q9JCl6XQX7NRG6lflg5QTvKTSF7vqqoU2wtZDWl52AeMWqmXSAcoBznIfXvC+Adv22bsfhgzRTqPGtTbwMqwDxq1Uq8ANgGx3YFRJ5FEyjI/5Yd+I1K03lN73VngWekYEnqh58sNE+fPam5s2VhRsbt0HlWQpRIHjdpIDbAY2Fs6RJj6TSLR0TlaRN4uRrXUsfCWMRvOmtzw1CKdRBJVIqWO1ul3IBal/k1+EskinUQSZSKv1SiO1E9IByil/CSSFSurqw+SzqK2ymt+yn9O4sDRG6m97tdw9GLZtePqH8pPItFCR98CqQNHcaQGuA+H9qpeWVW1KtXU+MabuhKJS+ZLHTh6I3XgfukAxZCF7DcnjJ9/3JSmCW9WVc6QzqOKSqzUUR2pHyDi65X5NTXLz2hq6NNJJE7qQnD2YzRHaq+7i4heBe+FnnMbJs4/qblx2saKiunSeVRJLPBTvtjKt1EdqSF4X52UDjEcC+pqF53XOKk+o5NIXHeP5MGjXOrfA1+RDlGIDcasP2tyw6JnRtXM1M+cnZdFZgebf4jm6XfgASJwf/Wvx455bOYOUzY+UztKZ4XFwwI/5b8hGSC6pQ5u7rhDOsZguior1hw3pWnhNyZN2D9nTJN0HhWaX0kHiG6pA7+UDrAlV+skkrgSP/WGaL+nBngYWAVMlQ4CwSSSzzc3rllbqZNIYkr81BuiPlJ73ZYyON3pP4lkbWXlvtJ5lBjx1yJEvdSBWyQP7tfULD94hynLbq/f5jCMGS2ZRYnaCNwqHQJcKLXX/RSwMOzD5ieRPHBSc+OOOolEATf5Kb9bOgS4UOrAj8I82IK62kUHtkx95YExow/HmKhfl1DF8RPpAJu58oKcB6wGSrqy5gZj1s+Z3LDI10kk6p/d76f8v0qH2MyNkdrr7gOuKuUhNk8i8XUSiXqvK6UD9OfKSA3B9rpfB+qK+aRr8iuRvKSfOastewn4nXSI/twYqQG87rXATcV8yqvH1T90xNTtqrXQ6n1c4af8rHSI/lwaqQEuA74AbNXm6p1VVS+lmhu7dBKJGsLLwNXSIQZyZ6QG8LpfIDgNH5EsZL0J287/2JSmiTqJRBXgEj/lb5IOMZBrIzXAJcCpwJjh/NAzo2qWnTG5Ifu2rkSiCvM8cL10iC1xa6QG8LpfBy4v9Nt7DJu+1DjxgZObGnd6WyeRqMJ9w0/5fdIhtsS9Uge+RwGbfc+vq1100A5TX50/WieRqGFZTJlMCd0SN0vtda8HvjPYv15fYbpnNTU++KXGSXtmjJkWYjLlhrTEbpaFcrPUgauAZQP/8o6xYx49ZPsp7yzWSSRqZOb5Kb9DOsT7cbfUXncPcNbmP66prFhz7JSmRy6eNOGAnDGTBZOp6FoPfFk6xFCMtWIrmYbDS9x41bjEjteOq09aY8ZJx1GRdo6f8n8qHWIozl8cOmJq8/lvVFUtBbTQamssBK6RDlEId0+/8+6dvXQdcI50DhVpGeDMcr441p/zpQbwU/484HbpHCqyvuOn/MjsCBOLUuedRXBHjVLD8TDwTekQw+H+hbJ+ku3JAwj2Da6RzqIi4W/AXn7Kj9RgEKeRGj/lPwp8VTqHiozTolZoiFmpAfyUfyVlspSrKms/8FP+b6RDjETsSp13OrBcOoQqWw8BaekQIxXLUvspfwNwAvCWdBZVdp4HTijXO7AKEctSA+Q/ojiB4DNIpSC4s++Yctg6Z2vEttQAfsq/GzgNiM9HAGow7wAf81P+c9JBtlasSw3gp/ybga9J51CicsAsP+U/Ih2kGGJfagA/5X+PYayWopxzrp/yfysdoli01O/6D8p4NQtVMv8dhTuvhkNLneenfAucQpHXDldl7QI/5V8qHaLYtNT95BdlTwFO/eZW72GBL/kp//vSQUohVnO/hyPZnmxDL6C5KEdwG2VZLu9bDFrq95FsT14IfEs6hyqaLJDyU/4t0kFKSUs9hGR78mzgx0CldBa1VbqBk/yUf5d0kFLTUhcg2Z48ErgN2FY6ixqR54Dj/ZT/rHSQMOiFsgL4Kf/PwH6AL51FDdvdwP5xKTRoqQvmp/wXgYOAO6SzqIJdARzrp/y/SQcJk55+j0CyPXkRwRI3+kuxPL1F8JFVu3QQCVrqEUq2Jw8FbgR0257yshA4xU/5z0sHkaIjzQj5KX8BsCdbsR+2KqoM8F/AIXEuNOhIXRTJ9uTRBHsVN0tniaklBKPzk9JByoGO1EXgp/w/AnsAN0tniZkMwbbFM7TQ79KRusiS7cnDCW7j3Fs4iuvuAs73U76uNTeAlroEku3JCoIVVS4FGoXjuGY5QZmdnxk2UlrqEkq2J7cBLgLOA0YJx4m69cAlwI/8lK/ryr0PLXUIku3JaQTlPgXdHWS41gFXEpR5rXSYKNBShyjZnmwGzgfmANsIxyl3rwM/BK7OL+msCqSlFpBsT44Dzga+AjQIxyk3LwHfBa73U/4m6TBRpKUWlGxP1gKfI9gx5ADhOJIyQAdwA3BXfgUaNUJa6jKRbE/uDswGZgGTheOEZQlBkW+K+gL65URLXWaS7clK4EjgZOA4YLxsoqJbDfwWuNmVdbbLjZa6jOULfgBwNHAMMAMwoqGGLwc8AfwB+K3O/Co9LXWEJNuTk4Cj8o/9gZ0pv5L3As8AjwMPAnf7Kf9N2UjxoqWOsGR7sh7YB9iXYBSfAexCeHP6e4EVBAXe/Fjkp/yekI6vtkBL7Zhke7IOmAps3+/r5n9uBkYDdf0eAyfDZICNBAsNbMw/1gIrgc4Bj1f8lJ8r3X+NGgktdczl37fXAVXARp2CGX1aaiXCGDMV+F+CG14scJ219keyqdygpVYijDFNQJO19kljzDYEV8g/Ya1dIhwt8nSRBCXCWvuqtfbJ/D9vAJYC28mmcoOWWokzxrQQXMV/VDaJG7TUSpQxZiwwDzjPWrteOo8LtNRKjDGmmqDQt1hrfy2dxxV6oUyJMMYYoB1Ya609TzqPS7TUSoQxZibBNFKfYH44wIXWWl17bCtpqZVyjL6nVsoxWmqlHKOlVsoxWmqlHKOlVsoxWmqlHKOlVsoxWmqlHKOlVsoxWmqlHKOlVsoxWmqlHKOlVsoxWmqlHKOlVsoxWmqlHKOlVsoxWmqlHKOlVsoxfwcMr/oLYfsDRgAAAABJRU5ErkJggg==\n",
-            "text/plain": [
-              "<Figure size 432x288 with 1 Axes>"
-            ]
-          },
-          "metadata": {}
-        }
       ]
     },
     {
@@ -6367,74 +6344,68 @@
         "id": "wChDRQpa82cA"
       },
       "source": [
-        "### column별 historgram"
+        "### column별 histogram"
       ]
     },
     {
       "cell_type": "code",
+      "execution_count": 112,
       "metadata": {
-        "id": "lgu86-2hBC6P",
         "colab": {
           "base_uri": "https://localhost:8080/",
           "height": 281
         },
-        "outputId": "66c5a647-1010-4653-dd7b-7195a3f80852"
+        "id": "lgu86-2hBC6P",
+        "outputId": "ac8246f2-cde7-4959-bf08-a4e1e62a48ea"
       },
-      "source": [
-        "df = pd.DataFrame(np.random.randn(1000, 4), columns=list(\"ABCD\"))\n",
-        "df = df.cumsum()\n",
-        "\n",
-        "df.diff().hist()\n",
-        "plt.show()"
-      ],
-      "execution_count": 458,
       "outputs": [
         {
-          "output_type": "display_data",
           "data": {
-            "image/png": "iVBORw0KGgoAAAANSUhEUgAAAXcAAAEICAYAAACktLTqAAAABHNCSVQICAgIfAhkiAAAAAlwSFlzAAALEgAACxIB0t1+/AAAADh0RVh0U29mdHdhcmUAbWF0cGxvdGxpYiB2ZXJzaW9uMy4yLjIsIGh0dHA6Ly9tYXRwbG90bGliLm9yZy+WH4yJAAAWBElEQVR4nO3df4xlZ33f8fcnQAgxtMZdNKzWKyZ/WFGsbFPQFrsKKaMYUtu4tf+I3ADCPwJaRbElHK0qr0Bq/kLdNIIGGkS1SSxsxQ2hBWpLOA3gMAXULsW2kI3tEG/RWrbrHxgQeE1bNPDtH/eMuTve2Zm5M/eec595v6TR3Pvce+d8Z+Y5Hz33Oc85N1WFJKktP9N3AZKknWe4S1KDDHdJapDhLkkNMtwlqUGGuyQ1yHCXpAYZ7nMgyXKS7yV5ed+1SNOU5GSS/5PkVNfnP5tkf991zSPDfeCSLAK/BhTwL3otRpqNf15VrwT2Ak8D/77neuaS4T581wDHgY8D1/ZbijQ7VfV/gf8MXNh3LfPopX0XoA1dA3wI+CpwPMlCVT3dc03S1CX5eeBfMhrcaIsM9wFL8ibgdcAnq+rZJP8LeAfw7/qtTJqq/5JkBTgH+Dbwz3quZy45LTNs1wKfq6pnu/v/Eadm1L6rqupc4OeAG4H/luS1Pdc0dwz3gUryCuBq4M1JnkryFPB7wK8k+ZV+q5Omr6p+XFWfBn4MvKnveuaN4T5cVzHq1BcC/6j7+iXgy4zm4aWmZeRK4NXAw33XM2/i9dyHKcl/BR6sqsNr2q8GPgKcX1UrvRQnTUmSk8ACo4FNAY8C/6aqbu+zrnlkuEtSg5yWkaQGGe6S1CDDXZIaZLhLUoMGcYbqnj17anFxsZdtP//885xzzjm9bPtshloXDLe2e++999mqek3fdWxGn31+I0P9/64aen0wuxrP1ucHEe6Li4vcc889vWx7eXmZpaWlXrZ9NkOtC4ZbW5JH+65hs/rs8xsZ6v931dDrg9nVeLY+77SMJDXIcJekBhnuktSgQcy5a2OLRz675decPPq2KVQizcZ6ff7wgRWuW+cx+/xPOXKXpAY5cu/BZkbhZxudSNJGHLlLUoMMd0lqkOEuSQ0y3CWpQYa7JDXIcJekBhnuktQgw12SGmS4S1KDNgz3JPuTfDHJQ0keTPLerv28JJ9P8kj3/dVde5J8JMmJJPcnecO0fwlJ0uk2M3JfAQ5X1YXAxcANSS4EjgB3V9UFwN3dfYDLgAu6r0PAx3a8aknSWW14bZmqehJ4srv9XJKHgX3AlcBS97RbgWXg5q79tqoq4HiSc5Ps7X5OUya5UqMkzcKWLhyWZBF4PfBVYGEssJ8CFrrb+4DHxl72eNd2WrgnOcRoZM/CwgLLy8tbq3yHnDp1auJtHz6wsrPFjFl4xfZ//rT+ptv5m0majU2He5JXAp8CbqqqHyR54bGqqiS1lQ1X1THgGMDBgwerr89E3M5nHU7zqo2HD6zwwQe2d9HOk+9c2pli1piHz7CUdrtNrZZJ8jJGwX57VX26a346yd7u8b3AM137E8D+sZef37VJkmZkM6tlAvwZ8HBVfWjsoTuBa7vb1wJ3jLVf062auRj4fovz7ZI0ZJsZuf8q8C7g15N8vfu6HDgKvDXJI8BbuvsAdwHfAk4AfwL87s6XLU2Py3/Vgs2slvkKkHUevuQMzy/ghm3WJfVpdfnvfUleBdyb5PPAdYyW/x5NcoTR8t+bOX3570WMlv9e1EvlUseP2ZPWcPnv/Jp0eXKLH6xtuEtn0eLy340MZanrekuBd2KZ8Fo7/fsO4W9ouEvraHX570amsdR1shH1meNpJ5YJr7XTy4aHsFzYC4dJZ+DyX807w11aw+W/aoHTMtKLrS7/fSDJ17u29zFa7vvJJO8GHgWu7h67C7ic0fLfHwLXz7Zc6cUMd2kNl/+qBU7LSFKDDHdJapDhLkkNMtwlqUGGuyQ1yHCXpAYZ7pLUIMNdkhpkuEtSgwx3SWqQlx9o2CSXWW3xQwuk3ciRuyQ1yHCXpAYZ7pLUIMNdkhpkuEtSgwx3SWqQ4S5JDTLcJalBhrskNchwl6QGbRjuSW5J8kySb4y1nZfk80ke6b6/umtPko8kOZHk/iRvmGbxkqQz28zI/ePApWvajgB3V9UFwN3dfYDLgAu6r0PAx3amTEnSVmx44bCq+lKSxTXNVwJL3e1bgWXg5q79tqoq4HiSc5Psraond6pgSf2a5IJ0mr1J59wXxgL7KWChu70PeGzseY93bZKkGdr2JX+rqpLUVl+X5BCjqRsWFhZYXl7ebikTOXXq1MTbPnxgZWeLGbPwiun+/PVs5m+xnb/ZvEhyC3AF8ExV/XLXdh7wl8AicBK4uqq+lyTAh4HLgR8C11XVfX3ULa2aNNyfXp1uSbIXeKZrfwLYP/a887u2F6mqY8AxgIMHD9bS0tKEpWzP8vIyS0tLE77VnN7l8A8fWOGDD8z+cvsn37m04XNW/2aN+zjwx8BtY22rx5qOJjnS3b+Z0481XcToWNNFM61W29LiZx9MOi1zJ3Btd/ta4I6x9mu6VTMXA993vl3zqKq+BHx3TfOVjI4x0X2/aqz9tho5DpzbDXqk3mw4NEzyF4wOnu5J8jjw+8BR4JNJ3g08ClzdPf0uRm9NTzB6e3r9FGqW+rLVY02nDWyGMhW5kY2m3fqYLhzX15TlWmf7Gw1h6nIzq2Xevs5Dl5zhuQXcsN2ipKGb5FjTUKYiN7LRtNt1Pa+W6WvKcq2zTWEOYerSM1SlzXt6dbpl0mNN0qwY7tLmeaxJc6P/9zbSAHmsSfPOcJfOwGNNmndOy0hSgwx3SWqQ4S5JDTLcJalBhrskNchwl6QGGe6S1CDDXZIaZLhLUoMMd0lqkOEuSQ3y2jI6zWY+buzwgZUXXdN76B85Ju02hrskTeBsA6EzDYBgtoMgp2UkqUGGuyQ1yGkZaZdab1phvSkFzRdH7pLUIMNdkhrU5LTMZpbzrfItqKQWOXKXpAYZ7pLUIMNdkhpkuEtSgwx3SWpQk6tlpN1mKyvEtDtMJdyTXAp8GHgJ8KdVdXQa29FwTBIurV1J0n6vjcxyP9nxaZkkLwE+ClwGXAi8PcmFO70daUjs9xqaaYzc3wicqKpvAST5BHAl8NAkP8y3m+1qbLS/o/1e2q5U1c7+wOQ3gUur6j3d/XcBF1XVjWuedwg41N39ReCbO1rI5u0Bnu1p22cz1LpguLW9rqpe08eGN9PvB9TnNzLU/++qodcHs6tx3T7f2wHVqjoGHOtr+6uS3FNVB/uuY62h1gXDrm3IhtLnNzL0/+/Q64Nh1DiNpZBPAPvH7p/ftUkts99rUKYR7l8DLkjyC0l+Fvgt4M4pbEcaEvu9BmXHp2WqaiXJjcBfM1oSdktVPbjT29lBQ32bPNS6YNi19WIO+/3ZDP3/O/T6YAA17vgBVUlS/7z8gCQ1yHCXpAYZ7kCSP0zyt0nuT/KZJOf2XM+lSb6Z5ESSI33WMi7J/iRfTPJQkgeTvLfvmjQdQ9snVg1134Dh7R/OuQNJfgP4m+6g2B8AVNXNPdXyEuDvgLcCjzNahfH2qur9TMcke4G9VXVfklcB9wJXDaE27awh7RNjNQ1234Dh7R+O3IGq+lxVrXR3jzNao9yXF05jr6ofAaunsfeuqp6sqvu6288BDwP7+q1K0zCwfWLVYPcNGN7+Ybi/2G8Df9Xj9vcBj43df5wBBmiSReD1wFf7rUQz0Pc+sWou9g0Yxv6xa67nnuQLwGvP8ND7q+qO7jnvB1aA22dZ27xJ8krgU8BNVfWDvuvRZNwnpmMo+8euCfeqesvZHk9yHXAFcEn1eyBi0KexJ3kZo457e1V9uu96NLk52idWDXrfgGHtHx5Q5YUPWfgQ8Oaq+nbPtbyU0UGjSxh13EeA54DF7vvXgQ9U1Vd6qC3ArcB3q+qmWW9fs9PXPpHkJLDA6N3CjxldMvk2Rmd8/gyn7xtfA94xlDOBh7Z/GO5AkhPAy4HvdE3Hq+p3eqzncuCPgPOAnwOuYXRa+4+AS4F/WlX/qoe63gR8GXgA+EnX/L6qumvWtWi6+tonunB/T1V9IcnfB97M6NOtlqvq+rF9Y/USDx+Ydk2bNbT9w3AfqK5jPwFcX1X/qe96pFkYD/extjcyWrHzD6vqG33VNm9cLTNc/4TRqP0zfRci9amq/iejlTG/1nct88RwH65/ADw7ttZY2s3+N6NpSm2S4T5c3wH2dAdYpd1uH/DdvouYJ4b7cP0P4P8BV/VdiNSnJP+YUbjPfIXYPDPcB6qqvg/8a+CjSa5K8vNJXpbksiT/tu/6pGlL8veSXMHoMgN/XlUP9F3TPHG1zMAleSfwe8AvMVrnfi+jde7/vdfCpClYs879J4zWuf858B+q6sc9ljZ3DHdJapDTMpLUIMNdkhpkuEtSgwx3SWrQIE6Q2bNnTy0uLs50m88//zznnHPOTLc5iXmocyg13nvvvc9W1Wv6rmMz+ujz6xnK/2+tIdY1tJrO1ucHEe6Li4vcc889M93m8vIyS0tLM93mJOahzqHUmOTRvmvYrD76/HqG8v9ba4h1Da2ms/V5p2UkqUGGuyQ1yHCXpAYNYs5dG1s88tktv+bk0bdNoRJp6ybpv4cPrHDdFl9nn/8pR+6S1CDDXZIaZLhLUoMMd0lqkOEuSQ0y3CWpQYa7JDXIde492Mqa30nW+kqSI3dJapDhLkkN2jDck+xP8sUkDyV5MMl7u/bzknw+ySPd91d37UnykSQnktyf5A3T/iUkSafbzMh9BThcVRcCFwM3JLkQOALcXVUXAHd39wEuAy7ovg4BH9vxqiVJZ7VhuFfVk1V1X3f7OeBhYB9wJXBr97Rbgau621cCt9XIceDcJHt3vHJJ0rq2tFomySLweuCrwEJVPdk99BSw0N3eBzw29rLHu7Ynx9pIcojRyJ6FhQWWl5e3Vvk2nTp1aubbXHX4wMqmn7vwiq09f9ysfr8+/5aSzmzT4Z7klcCngJuq6gdJXnisqipJbWXDVXUMOAZw8ODBmvVHV/X5cVlbWdp4+MAKH3xgshWrJ9+5NNHrtmpoHz0maZOrZZK8jFGw315Vn+6an16dbum+P9O1PwHsH3v5+V2bJGlGNrNaJsCfAQ9X1YfGHroTuLa7fS1wx1j7Nd2qmYuB749N30iD5woxtWAzI/dfBd4F/HqSr3dflwNHgbcmeQR4S3cf4C7gW8AJ4E+A3935sqWpcoWY5t6Gk7lV9RUg6zx8yRmeX8AN26xL6k33TvPJ7vZzScZXiC11T7sVWAZuZmyFGHA8yblJ9vqOVX3y2jLSWbS0Qmw9s1jtNMmKr0lWik3795inlWGGu7SO1laIrWcWq50mufjdJCvFpr1CbJ5WhnltGekMXCGmeWe4S2u4QkwtcFpGerHVFWIPJPl61/Y+RivCPpnk3cCjwNXdY3cBlzNaIfZD4PrZliu9mOEureEKMbXAaRlJapDhLkkNMtwlqUHOuW/DVj7oWpJmyZG7JDXIcJekBhnuktQg59wlbcmQjzVNWtvJo2/b4Ur658hdkhrkyL1hk4xiWhzBSLuRI3dJapDhLkkNMtwlqUGGuyQ1yHCXpAYZ7pLUIMNdkhpkuEtSgwx3SWqQ4S5JDTLcJalBhrskNchwl6QGbRjuSW5J8kySb4y1nZfk80ke6b6/umtPko8kOZHk/iRvmGbxkqQz28zI/ePApWvajgB3V9UFwN3dfYDLgAu6r0PAx3amTEnSVmx4Pfeq+lKSxTXNVwJL3e1bgWXg5q79tqoq4HiSc5Psraond6rgaRnyp8tI0lZN+mEdC2OB/RSw0N3eBzw29rzHu7YXhXuSQ4xG9ywsLLC8vDxhKZM5derUads8fGBlptvfrIVXzLa2Sf4Pa/+WLUhyC3AF8ExV/XLXdh7wl8AicBK4uqq+lyTAh4HLgR8C11XVfX3ULa3a9icxVVUlqQledww4BnDw4MFaWlrabilbsry8zPg2rxvoyP3wgRU++MDsPjDr5DuXtvyatX/LRnwc+GPgtrG21enIo0mOdPdv5vTpyIsYTUdeNNNqpTUmXS3zdJK9AN33Z7r2J4D9Y887v2uT5kpVfQn47prmKxlNQ9J9v2qs/bYaOQ6cu7p/SH2ZdEh4J3AtcLT7fsdY+41JPsFo5PL9eZhvlzZpW9ORfU9Frmer02qzmiac5ZTkZn//eZqC3DDck/wFo4One5I8Dvw+o1D/ZJJ3A48CV3dPv4vRvOMJRnOP10+hZql3k0xH9j0VuZ6tTqvNagpzllOSm52OnKcpyM2slnn7Og9dcobnFnDDdouSBurp1dVfTkdq6DxDVdq81elIePF05DXdSXwX43SkBmB2yzCkOeJ0pOad4S6dgdORmndOy0hSgwx3SWqQ4S5JDXLOXaeZ5AJqhw+svHAVOUnD4MhdkhpkuEtSg5yWkbTrbXY68vCBlRcuv3Dy6NumWdK2Ge7SLrUaaOOBpXY4LSNJDTLcJalBhrskNchwl6QGGe6S1CDDXZIaZLhLUoMMd0lqkOEuSQ1q8gzVzZxK7Fl5klrmyF2SGmS4S1KDmpyW0exN8iEfQ7+qnjTPHLlLUoMMd0lqkOEuSQ1yzl1qwCTHPNS2wYe7nVaStm4q4Z7kUuDDwEuAP62qo9PYjjQk9vvdZegrxHY83JO8BPgo8FbgceBrSe6sqod2eluab0PfObZiJ/u971a1E6Yxcn8jcKKqvgWQ5BPAlYDhrpbZ77WhWQ5oUlUTvXDdH5j8JnBpVb2nu/8u4KKqunHN8w4Bh7q7vwh8c0cL2dge4NkZb3MS81DnUGp8XVW9po8Nb6bfD6DPr2co/7+1hljX0Gpat8/3dkC1qo4Bx/rafpJ7qupgX9vfrHmocx5qHIK++/x6hvr/G2JdQ6xpPdNY5/4EsH/s/vldm9Qy+70GZRrh/jXggiS/kORngd8C7pzCdqQhsd9rUHZ8WqaqVpLcCPw1oyVht1TVgzu9nR0wuLfH65iHOuehxqmao35/JkP9/w2xriHWdEY7fkBVktQ/ry0jSQ0y3CWpQbs63JP8YZK/TXJ/ks8kObfvmlYluTTJN5OcSHKk73rOJMn+JF9M8lCSB5O8t++aNJkh7QtD7Pvz2Nd39Zx7kt8A/qY7GPYHAFV1c89lrZ7K/neMncoOvH1ol3BIshfYW1X3JXkVcC9w1dDq1MaGsi8Mte/PY1/f1SP3qvpcVa10d48zWps8BC+cyl5VPwJWT2UflKp6sqru624/BzwM7Ou3Kk1iQPvCIPv+PPb1XR3ua/w28Fd9F9HZBzw2dv9xBt6RkiwCrwe+2m8l2gF97guD7/vz0tcHfz337UryBeC1Z3jo/VV1R/ec9wMrwO2zrK0VSV4JfAq4qap+0Hc9OjP3he2bp77efLhX1VvO9niS64ArgEtqOAcg5uZU9iQvY9TZb6+qT/ddj9Y3J/vCYPv+vPX13X5A9VLgQ8Cbq+rbfdezKslLGR1UuoRRx/4a8I6hnfGYJMCtwHer6qa+69HkhrIvDLXvz2Nf3+3hfgJ4OfCdrul4Vf1OjyW9IMnlwB/x01PZP9BzSS+S5E3Al4EHgJ90ze+rqrv6q0qTGNK+MMS+P499fVeHuyS1ytUyktQgw12SGmS4S1KDDHdJapDhLkkNMtwlqUGGuyQ16P8DaD/UbQ1VIloAAAAASUVORK5CYII=\n",
+            "image/png": "iVBORw0KGgoAAAANSUhEUgAAAXcAAAEICAYAAACktLTqAAAABHNCSVQICAgIfAhkiAAAAAlwSFlzAAALEgAACxIB0t1+/AAAADh0RVh0U29mdHdhcmUAbWF0cGxvdGxpYiB2ZXJzaW9uMy4yLjIsIGh0dHA6Ly9tYXRwbG90bGliLm9yZy+WH4yJAAAWBElEQVR4nO3df4xlZ33f8fcnQAgxtMZdNKzWKyZ/WFGsbFPQFrsKKaMYUtu4tf+I3ADCPwJaRbElHK0qr0Bq/kLdNIIGGkS1SSxsxQ2hBWpLOA3gMAXULsW2kI3tEG/RWrbrHxgQeE1bNPDtH/eMuTve2Zm5M/eec595v6TR3Pvce+d8Z+Y5Hz33Oc85N1WFJKktP9N3AZKknWe4S1KDDHdJapDhLkkNMtwlqUGGuyQ1yHCXpAYZ7nMgyXKS7yV5ed+1SNOU5GSS/5PkVNfnP5tkf991zSPDfeCSLAK/BhTwL3otRpqNf15VrwT2Ak8D/77neuaS4T581wDHgY8D1/ZbijQ7VfV/gf8MXNh3LfPopX0XoA1dA3wI+CpwPMlCVT3dc03S1CX5eeBfMhrcaIsM9wFL8ibgdcAnq+rZJP8LeAfw7/qtTJqq/5JkBTgH+Dbwz3quZy45LTNs1wKfq6pnu/v/Eadm1L6rqupc4OeAG4H/luS1Pdc0dwz3gUryCuBq4M1JnkryFPB7wK8k+ZV+q5Omr6p+XFWfBn4MvKnveuaN4T5cVzHq1BcC/6j7+iXgy4zm4aWmZeRK4NXAw33XM2/i9dyHKcl/BR6sqsNr2q8GPgKcX1UrvRQnTUmSk8ACo4FNAY8C/6aqbu+zrnlkuEtSg5yWkaQGGe6S1CDDXZIaZLhLUoMGcYbqnj17anFxsZdtP//885xzzjm9bPtshloXDLe2e++999mqek3fdWxGn31+I0P9/64aen0wuxrP1ucHEe6Li4vcc889vWx7eXmZpaWlXrZ9NkOtC4ZbW5JH+65hs/rs8xsZ6v931dDrg9nVeLY+77SMJDXIcJekBhnuktSgQcy5a2OLRz675decPPq2KVQizcZ6ff7wgRWuW+cx+/xPOXKXpAY5cu/BZkbhZxudSNJGHLlLUoMMd0lqkOEuSQ0y3CWpQYa7JDXIcJekBhnuktQgw12SGmS4S1KDNgz3JPuTfDHJQ0keTPLerv28JJ9P8kj3/dVde5J8JMmJJPcnecO0fwlJ0uk2M3JfAQ5X1YXAxcANSS4EjgB3V9UFwN3dfYDLgAu6r0PAx3a8aknSWW14bZmqehJ4srv9XJKHgX3AlcBS97RbgWXg5q79tqoq4HiSc5Ps7X5OUya5UqMkzcKWLhyWZBF4PfBVYGEssJ8CFrrb+4DHxl72eNd2WrgnOcRoZM/CwgLLy8tbq3yHnDp1auJtHz6wsrPFjFl4xfZ//rT+ptv5m0majU2He5JXAp8CbqqqHyR54bGqqiS1lQ1X1THgGMDBgwerr89E3M5nHU7zqo2HD6zwwQe2d9HOk+9c2pli1piHz7CUdrtNrZZJ8jJGwX57VX26a346yd7u8b3AM137E8D+sZef37VJkmZkM6tlAvwZ8HBVfWjsoTuBa7vb1wJ3jLVf062auRj4fovz7ZI0ZJsZuf8q8C7g15N8vfu6HDgKvDXJI8BbuvsAdwHfAk4AfwL87s6XLU2Py3/Vgs2slvkKkHUevuQMzy/ghm3WJfVpdfnvfUleBdyb5PPAdYyW/x5NcoTR8t+bOX3570WMlv9e1EvlUseP2ZPWcPnv/Jp0eXKLH6xtuEtn0eLy340MZanrekuBd2KZ8Fo7/fsO4W9ouEvraHX570amsdR1shH1meNpJ5YJr7XTy4aHsFzYC4dJZ+DyX807w11aw+W/aoHTMtKLrS7/fSDJ17u29zFa7vvJJO8GHgWu7h67C7ic0fLfHwLXz7Zc6cUMd2kNl/+qBU7LSFKDDHdJapDhLkkNMtwlqUGGuyQ1yHCXpAYZ7pLUIMNdkhpkuEtSgwx3SWqQlx9o2CSXWW3xQwuk3ciRuyQ1yHCXpAYZ7pLUIMNdkhpkuEtSgwx3SWqQ4S5JDTLcJalBhrskNchwl6QGbRjuSW5J8kySb4y1nZfk80ke6b6/umtPko8kOZHk/iRvmGbxkqQz28zI/ePApWvajgB3V9UFwN3dfYDLgAu6r0PAx3amTEnSVmx44bCq+lKSxTXNVwJL3e1bgWXg5q79tqoq4HiSc5Psraond6pgSf2a5IJ0mr1J59wXxgL7KWChu70PeGzseY93bZKkGdr2JX+rqpLUVl+X5BCjqRsWFhZYXl7ebikTOXXq1MTbPnxgZWeLGbPwiun+/PVs5m+xnb/ZvEhyC3AF8ExV/XLXdh7wl8AicBK4uqq+lyTAh4HLgR8C11XVfX3ULa2aNNyfXp1uSbIXeKZrfwLYP/a887u2F6mqY8AxgIMHD9bS0tKEpWzP8vIyS0tLE77VnN7l8A8fWOGDD8z+cvsn37m04XNW/2aN+zjwx8BtY22rx5qOJjnS3b+Z0481XcToWNNFM61W29LiZx9MOi1zJ3Btd/ta4I6x9mu6VTMXA993vl3zqKq+BHx3TfOVjI4x0X2/aqz9tho5DpzbDXqk3mw4NEzyF4wOnu5J8jjw+8BR4JNJ3g08ClzdPf0uRm9NTzB6e3r9FGqW+rLVY02nDWyGMhW5kY2m3fqYLhzX15TlWmf7Gw1h6nIzq2Xevs5Dl5zhuQXcsN2ipKGb5FjTUKYiN7LRtNt1Pa+W6WvKcq2zTWEOYerSM1SlzXt6dbpl0mNN0qwY7tLmeaxJc6P/9zbSAHmsSfPOcJfOwGNNmndOy0hSgwx3SWqQ4S5JDTLcJalBhrskNchwl6QGGe6S1CDDXZIaZLhLUoMMd0lqkOEuSQ3y2jI6zWY+buzwgZUXXdN76B85Ju02hrskTeBsA6EzDYBgtoMgp2UkqUGGuyQ1yGkZaZdab1phvSkFzRdH7pLUIMNdkhrU5LTMZpbzrfItqKQWOXKXpAYZ7pLUIMNdkhpkuEtSgwx3SWpQk6tlpN1mKyvEtDtMJdyTXAp8GHgJ8KdVdXQa29FwTBIurV1J0n6vjcxyP9nxaZkkLwE+ClwGXAi8PcmFO70daUjs9xqaaYzc3wicqKpvAST5BHAl8NAkP8y3m+1qbLS/o/1e2q5U1c7+wOQ3gUur6j3d/XcBF1XVjWuedwg41N39ReCbO1rI5u0Bnu1p22cz1LpguLW9rqpe08eGN9PvB9TnNzLU/++qodcHs6tx3T7f2wHVqjoGHOtr+6uS3FNVB/uuY62h1gXDrm3IhtLnNzL0/+/Q64Nh1DiNpZBPAPvH7p/ftUkts99rUKYR7l8DLkjyC0l+Fvgt4M4pbEcaEvu9BmXHp2WqaiXJjcBfM1oSdktVPbjT29lBQ32bPNS6YNi19WIO+/3ZDP3/O/T6YAA17vgBVUlS/7z8gCQ1yHCXpAYZ7kCSP0zyt0nuT/KZJOf2XM+lSb6Z5ESSI33WMi7J/iRfTPJQkgeTvLfvmjQdQ9snVg1134Dh7R/OuQNJfgP4m+6g2B8AVNXNPdXyEuDvgLcCjzNahfH2qur9TMcke4G9VXVfklcB9wJXDaE27awh7RNjNQ1234Dh7R+O3IGq+lxVrXR3jzNao9yXF05jr6ofAaunsfeuqp6sqvu6288BDwP7+q1K0zCwfWLVYPcNGN7+Ybi/2G8Df9Xj9vcBj43df5wBBmiSReD1wFf7rUQz0Pc+sWou9g0Yxv6xa67nnuQLwGvP8ND7q+qO7jnvB1aA22dZ27xJ8krgU8BNVfWDvuvRZNwnpmMo+8euCfeqesvZHk9yHXAFcEn1eyBi0KexJ3kZo457e1V9uu96NLk52idWDXrfgGHtHx5Q5YUPWfgQ8Oaq+nbPtbyU0UGjSxh13EeA54DF7vvXgQ9U1Vd6qC3ArcB3q+qmWW9fs9PXPpHkJLDA6N3CjxldMvk2Rmd8/gyn7xtfA94xlDOBh7Z/GO5AkhPAy4HvdE3Hq+p3eqzncuCPgPOAnwOuYXRa+4+AS4F/WlX/qoe63gR8GXgA+EnX/L6qumvWtWi6+tonunB/T1V9IcnfB97M6NOtlqvq+rF9Y/USDx+Ydk2bNbT9w3AfqK5jPwFcX1X/qe96pFkYD/extjcyWrHzD6vqG33VNm9cLTNc/4TRqP0zfRci9amq/iejlTG/1nct88RwH65/ADw7ttZY2s3+N6NpSm2S4T5c3wH2dAdYpd1uH/DdvouYJ4b7cP0P4P8BV/VdiNSnJP+YUbjPfIXYPDPcB6qqvg/8a+CjSa5K8vNJXpbksiT/tu/6pGlL8veSXMHoMgN/XlUP9F3TPHG1zMAleSfwe8AvMVrnfi+jde7/vdfCpClYs879J4zWuf858B+q6sc9ljZ3DHdJapDTMpLUIMNdkhpkuEtSgwx3SWrQIE6Q2bNnTy0uLs50m88//zznnHPOTLc5iXmocyg13nvvvc9W1Wv6rmMz+ujz6xnK/2+tIdY1tJrO1ucHEe6Li4vcc889M93m8vIyS0tLM93mJOahzqHUmOTRvmvYrD76/HqG8v9ba4h1Da2ms/V5p2UkqUGGuyQ1yHCXpAYNYs5dG1s88tktv+bk0bdNoRJp6ybpv4cPrHDdFl9nn/8pR+6S1CDDXZIaZLhLUoMMd0lqkOEuSQ0y3CWpQYa7JDXIde492Mqa30nW+kqSI3dJapDhLkkN2jDck+xP8sUkDyV5MMl7u/bzknw+ySPd91d37UnykSQnktyf5A3T/iUkSafbzMh9BThcVRcCFwM3JLkQOALcXVUXAHd39wEuAy7ovg4BH9vxqiVJZ7VhuFfVk1V1X3f7OeBhYB9wJXBr97Rbgau621cCt9XIceDcJHt3vHJJ0rq2tFomySLweuCrwEJVPdk99BSw0N3eBzw29rLHu7Ynx9pIcojRyJ6FhQWWl5e3Vvk2nTp1aubbXHX4wMqmn7vwiq09f9ysfr8+/5aSzmzT4Z7klcCngJuq6gdJXnisqipJbWXDVXUMOAZw8ODBmvVHV/X5cVlbWdp4+MAKH3xgshWrJ9+5NNHrtmpoHz0maZOrZZK8jFGw315Vn+6an16dbum+P9O1PwHsH3v5+V2bJGlGNrNaJsCfAQ9X1YfGHroTuLa7fS1wx1j7Nd2qmYuB749N30iD5woxtWAzI/dfBd4F/HqSr3dflwNHgbcmeQR4S3cf4C7gW8AJ4E+A3935sqWpcoWY5t6Gk7lV9RUg6zx8yRmeX8AN26xL6k33TvPJ7vZzScZXiC11T7sVWAZuZmyFGHA8yblJ9vqOVX3y2jLSWbS0Qmw9s1jtNMmKr0lWik3795inlWGGu7SO1laIrWcWq50mufjdJCvFpr1CbJ5WhnltGekMXCGmeWe4S2u4QkwtcFpGerHVFWIPJPl61/Y+RivCPpnk3cCjwNXdY3cBlzNaIfZD4PrZliu9mOEureEKMbXAaRlJapDhLkkNMtwlqUHOuW/DVj7oWpJmyZG7JDXIcJekBhnuktQg59wlbcmQjzVNWtvJo2/b4Ur658hdkhrkyL1hk4xiWhzBSLuRI3dJapDhLkkNMtwlqUGGuyQ1yHCXpAYZ7pLUIMNdkhpkuEtSgwx3SWqQ4S5JDTLcJalBhrskNchwl6QGbRjuSW5J8kySb4y1nZfk80ke6b6/umtPko8kOZHk/iRvmGbxkqQz28zI/ePApWvajgB3V9UFwN3dfYDLgAu6r0PAx3amTEnSVmx4Pfeq+lKSxTXNVwJL3e1bgWXg5q79tqoq4HiSc5Psraond6rgaRnyp8tI0lZN+mEdC2OB/RSw0N3eBzw29rzHu7YXhXuSQ4xG9ywsLLC8vDxhKZM5derUads8fGBlptvfrIVXzLa2Sf4Pa/+WLUhyC3AF8ExV/XLXdh7wl8AicBK4uqq+lyTAh4HLgR8C11XVfX3ULa3a9icxVVUlqQledww4BnDw4MFaWlrabilbsry8zPg2rxvoyP3wgRU++MDsPjDr5DuXtvyatX/LRnwc+GPgtrG21enIo0mOdPdv5vTpyIsYTUdeNNNqpTUmXS3zdJK9AN33Z7r2J4D9Y887v2uT5kpVfQn47prmKxlNQ9J9v2qs/bYaOQ6cu7p/SH2ZdEh4J3AtcLT7fsdY+41JPsFo5PL9eZhvlzZpW9ORfU9Frmer02qzmiac5ZTkZn//eZqC3DDck/wFo4One5I8Dvw+o1D/ZJJ3A48CV3dPv4vRvOMJRnOP10+hZql3k0xH9j0VuZ6tTqvNagpzllOSm52OnKcpyM2slnn7Og9dcobnFnDDdouSBurp1dVfTkdq6DxDVdq81elIePF05DXdSXwX43SkBmB2yzCkOeJ0pOad4S6dgdORmndOy0hSgwx3SWqQ4S5JDXLOXaeZ5AJqhw+svHAVOUnD4MhdkhpkuEtSg5yWkbTrbXY68vCBlRcuv3Dy6NumWdK2Ge7SLrUaaOOBpXY4LSNJDTLcJalBhrskNchwl6QGGe6S1CDDXZIaZLhLUoMMd0lqkOEuSQ1q8gzVzZxK7Fl5klrmyF2SGmS4S1KDmpyW0exN8iEfQ7+qnjTPHLlLUoMMd0lqkOEuSQ1yzl1qwCTHPNS2wYe7nVaStm4q4Z7kUuDDwEuAP62qo9PYjjQk9vvdZegrxHY83JO8BPgo8FbgceBrSe6sqod2eluab0PfObZiJ/u971a1E6Yxcn8jcKKqvgWQ5BPAlYDhrpbZ77WhWQ5oUlUTvXDdH5j8JnBpVb2nu/8u4KKqunHN8w4Bh7q7vwh8c0cL2dge4NkZb3MS81DnUGp8XVW9po8Nb6bfD6DPr2co/7+1hljX0Gpat8/3dkC1qo4Bx/rafpJ7qupgX9vfrHmocx5qHIK++/x6hvr/G2JdQ6xpPdNY5/4EsH/s/vldm9Qy+70GZRrh/jXggiS/kORngd8C7pzCdqQhsd9rUHZ8WqaqVpLcCPw1oyVht1TVgzu9nR0wuLfH65iHOuehxqmao35/JkP9/w2xriHWdEY7fkBVktQ/ry0jSQ0y3CWpQbs63JP8YZK/TXJ/ks8kObfvmlYluTTJN5OcSHKk73rOJMn+JF9M8lCSB5O8t++aNJkh7QtD7Pvz2Nd39Zx7kt8A/qY7GPYHAFV1c89lrZ7K/neMncoOvH1ol3BIshfYW1X3JXkVcC9w1dDq1MaGsi8Mte/PY1/f1SP3qvpcVa10d48zWps8BC+cyl5VPwJWT2UflKp6sqru624/BzwM7Ou3Kk1iQPvCIPv+PPb1XR3ua/w28Fd9F9HZBzw2dv9xBt6RkiwCrwe+2m8l2gF97guD7/vz0tcHfz337UryBeC1Z3jo/VV1R/ec9wMrwO2zrK0VSV4JfAq4qap+0Hc9OjP3he2bp77efLhX1VvO9niS64ArgEtqOAcg5uZU9iQvY9TZb6+qT/ddj9Y3J/vCYPv+vPX13X5A9VLgQ8Cbq+rbfdezKslLGR1UuoRRx/4a8I6hnfGYJMCtwHer6qa+69HkhrIvDLXvz2Nf3+3hfgJ4OfCdrul4Vf1OjyW9IMnlwB/x01PZP9BzSS+S5E3Al4EHgJ90ze+rqrv6q0qTGNK+MMS+P499fVeHuyS1ytUyktQgw12SGmS4S1KDDHdJapDhLkkNMtwlqUGGuyQ16P8DaD/UbQ1VIloAAAAASUVORK5CYII=",
             "text/plain": [
               "<Figure size 432x288 with 4 Axes>"
             ]
           },
           "metadata": {
             "needs_background": "light"
-          }
+          },
+          "output_type": "display_data"
         }
+      ],
+      "source": [
+        "df = pd.DataFrame(np.random.randn(1000, 4), columns=list(\"ABCD\"))\n",
+        "df = df.cumsum()\n",
+        "\n",
+        "df.diff().hist()\n",
+        "plt.show()"
       ]
     },
     {
       "cell_type": "code",
+      "execution_count": 112,
       "metadata": {
         "id": "n9u2uVKtBC2x"
       },
-      "source": [
-        ""
-      ],
-      "execution_count": 458,
-      "outputs": []
+      "outputs": [],
+      "source": []
     },
     {
       "cell_type": "code",
+      "execution_count": 112,
       "metadata": {
         "id": "90gH4dG3BCtw"
       },
-      "source": [
-        ""
-      ],
-      "execution_count": 458,
-      "outputs": []
+      "outputs": [],
+      "source": []
     },
     {
       "cell_type": "code",
+      "execution_count": 112,
       "metadata": {
         "id": "vfUSF6aQBCiY"
       },
-      "source": [
-        ""
-      ],
-      "execution_count": 458,
-      "outputs": []
+      "outputs": [],
+      "source": []
     },
     {
       "cell_type": "markdown",
@@ -6458,25 +6429,18 @@
     },
     {
       "cell_type": "code",
+      "execution_count": 113,
       "metadata": {
-        "id": "Rt2wLbhRiEaT",
         "colab": {
           "base_uri": "https://localhost:8080/"
         },
-        "outputId": "675dcaf4-25c3-4b42-fa79-bd3aaa05a90e"
+        "id": "Rt2wLbhRiEaT",
+        "outputId": "f2797980-3b0e-4521-9d4a-a8659b8b2d7d"
       },
-      "source": [
-        "df = pd.DataFrame(\n",
-        "        {\"AAA\": [4, 5, 6, 7], \"BBB\": [10, 20, 30, 40], \"CCC\": [100, 50, -30, -50]}\n",
-        ")\n",
-        "n = df.to_numpy()\n",
-        "print(n)"
-      ],
-      "execution_count": 459,
       "outputs": [
         {
-          "output_type": "stream",
           "name": "stdout",
+          "output_type": "stream",
           "text": [
             "[[  4  10 100]\n",
             " [  5  20  50]\n",
@@ -6484,17 +6448,38 @@
             " [  7  40 -50]]\n"
           ]
         }
+      ],
+      "source": [
+        "df = pd.DataFrame(\n",
+        "        {\"AAA\": [4, 5, 6, 7], \"BBB\": [10, 20, 30, 40], \"CCC\": [100, 50, -30, -50]}\n",
+        ")\n",
+        "n = df.to_numpy()\n",
+        "print(n)"
       ]
     },
     {
       "cell_type": "code",
+      "execution_count": 114,
       "metadata": {
-        "id": "nODR3tKojFCb",
-        "outputId": "0e38cf64-629d-4754-94cb-a2fe5ec784fe",
         "colab": {
           "base_uri": "https://localhost:8080/"
-        }
+        },
+        "id": "nODR3tKojFCb",
+        "outputId": "b9c35dd9-e655-43a0-800e-772196d27677"
       },
+      "outputs": [
+        {
+          "name": "stdout",
+          "output_type": "stream",
+          "text": [
+            "[[ 4 10]\n",
+            " [ 5 20]\n",
+            " [ 6 30]\n",
+            " [ 7 40]]\n",
+            "[100  50 -30 -50]\n"
+          ]
+        }
+      ],
       "source": [
         "df = pd.DataFrame(\n",
         "        {\"AAA\": [4, 5, 6, 7], \"BBB\": [10, 20, 30, 40], \"CCC\": [100, 50, -30, -50]}\n",
@@ -6505,56 +6490,31 @@
         "\n",
         "y = df.CCC.to_numpy()\n",
         "print(y)"
-      ],
-      "execution_count": 460,
-      "outputs": [
-        {
-          "output_type": "stream",
-          "name": "stdout",
-          "text": [
-            "[[ 4 10]\n",
-            " [ 5 20]\n",
-            " [ 6 30]\n",
-            " [ 7 40]]\n",
-            "[100  50 -30 -50]\n"
-          ]
-        }
       ]
     },
     {
       "cell_type": "markdown",
-      "source": [
-        "## shuffle"
-      ],
       "metadata": {
         "id": "YJeQOJipx4L5"
-      }
+      },
+      "source": [
+        "## shuffle"
+      ]
     },
     {
       "cell_type": "code",
-      "source": [
-        "df = pd.DataFrame(\n",
-        "        {\"AAA\": [4, 5, 6, 7], \"BBB\": [10, 20, 30, 40], \"CCC\": [100, 50, -30, -50]}\n",
-        ")\n",
-        "print(df)\n",
-        "print()\n",
-        "\n",
-        "df = df.sample(frac=1).reset_index(drop=True)\n",
-        "\n",
-        "print(df)"
-      ],
+      "execution_count": 115,
       "metadata": {
-        "id": "WCv0j9flx6CN",
-        "outputId": "e2199aa8-a50f-4324-ed6d-9dad439b2762",
         "colab": {
           "base_uri": "https://localhost:8080/"
-        }
+        },
+        "id": "WCv0j9flx6CN",
+        "outputId": "3cc46984-da52-4d9c-b2c3-cb362ed17f0f"
       },
-      "execution_count": 461,
       "outputs": [
         {
-          "output_type": "stream",
           "name": "stdout",
+          "output_type": "stream",
           "text": [
             "   AAA  BBB  CCC\n",
             "0    4   10  100\n",
@@ -6569,42 +6529,42 @@
             "3    4   10  100\n"
           ]
         }
+      ],
+      "source": [
+        "df = pd.DataFrame(\n",
+        "        {\"AAA\": [4, 5, 6, 7], \"BBB\": [10, 20, 30, 40], \"CCC\": [100, 50, -30, -50]}\n",
+        ")\n",
+        "print(df)\n",
+        "print()\n",
+        "\n",
+        "df = df.sample(frac=1).reset_index(drop=True)\n",
+        "\n",
+        "print(df)"
       ]
     },
     {
       "cell_type": "markdown",
-      "source": [
-        "## one-hot 인코딩"
-      ],
       "metadata": {
         "id": "Y4TI2wa5xNFx"
-      }
+      },
+      "source": [
+        "## one-hot 인코딩"
+      ]
     },
     {
       "cell_type": "code",
+      "execution_count": 116,
       "metadata": {
-        "outputId": "65b3d665-7c9f-4363-da79-d2c2788904e3",
         "colab": {
           "base_uri": "https://localhost:8080/"
         },
-        "id": "mtRtmb3zzsDL"
+        "id": "mtRtmb3zzsDL",
+        "outputId": "f8e2da13-699a-4a39-af53-1a3f5d50f6d5"
       },
-      "source": [
-        "df = pd.DataFrame(\n",
-        "        {\"AAA\": [0, 1, 2, 0, 1, 2], \"BBB\": [10, 20, 30, 40, 50, 60]}\n",
-        ")\n",
-        "\n",
-        "print(df)\n",
-        "print()\n",
-        "\n",
-        "df = pd.get_dummies(df, columns = ['AAA'])\n",
-        "print(df)\n"
-      ],
-      "execution_count": 462,
       "outputs": [
         {
-          "output_type": "stream",
           "name": "stdout",
+          "output_type": "stream",
           "text": [
             "   AAA  BBB\n",
             "0    0   10\n",
@@ -6623,13 +6583,10 @@
             "5   60      0      0      1\n"
           ]
         }
-      ]
-    },
-    {
-      "cell_type": "code",
+      ],
       "source": [
         "df = pd.DataFrame(\n",
-        "        {\"AAA\": ['A', 'B', 'C', 'A', 'B', 'C'], \"BBB\": [10, 20, 30, 40, 50, 60]}\n",
+        "        {\"AAA\": [0, 1, 2, 0, 1, 2], \"BBB\": [10, 20, 30, 40, 50, 60]}\n",
         ")\n",
         "\n",
         "print(df)\n",
@@ -6637,19 +6594,22 @@
         "\n",
         "df = pd.get_dummies(df, columns = ['AAA'])\n",
         "print(df)\n"
-      ],
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 117,
       "metadata": {
-        "id": "rtXghkmfxkPq",
-        "outputId": "a27a179a-750e-4d87-e763-8ec019382f20",
         "colab": {
           "base_uri": "https://localhost:8080/"
-        }
+        },
+        "id": "rtXghkmfxkPq",
+        "outputId": "a668e289-e32f-4527-a2f2-ba567925b2db"
       },
-      "execution_count": 463,
       "outputs": [
         {
-          "output_type": "stream",
           "name": "stdout",
+          "output_type": "stream",
           "text": [
             "  AAA  BBB\n",
             "0   A   10\n",
@@ -6668,18 +6628,27 @@
             "5   60      0      0      1\n"
           ]
         }
+      ],
+      "source": [
+        "df = pd.DataFrame(\n",
+        "        {\"AAA\": ['A', 'B', 'C', 'A', 'B', 'C'], \"BBB\": [10, 20, 30, 40, 50, 60]}\n",
+        ")\n",
+        "\n",
+        "print(df)\n",
+        "print()\n",
+        "\n",
+        "df = pd.get_dummies(df, columns = ['AAA'])\n",
+        "print(df)\n"
       ]
     },
     {
       "cell_type": "code",
+      "execution_count": 117,
       "metadata": {
         "id": "43gLO1ICjaa7"
       },
-      "source": [
-        ""
-      ],
-      "execution_count": 463,
-      "outputs": []
+      "outputs": [],
+      "source": []
     },
     {
       "cell_type": "markdown",
@@ -6692,22 +6661,18 @@
     },
     {
       "cell_type": "code",
+      "execution_count": 118,
       "metadata": {
-        "id": "0AcNMVpCjdQQ",
         "colab": {
           "base_uri": "https://localhost:8080/"
         },
-        "outputId": "64da4954-f2bc-479d-d493-c364fa3e4cd9"
+        "id": "0AcNMVpCjdQQ",
+        "outputId": "84ea4a06-5d15-4b29-b4eb-ddb916b77ca2"
       },
-      "source": [
-        "df.to_csv('saved.csv')\n",
-        "!head -10 saved.csv"
-      ],
-      "execution_count": 464,
       "outputs": [
         {
-          "output_type": "stream",
           "name": "stdout",
+          "output_type": "stream",
           "text": [
             ",BBB,AAA_A,AAA_B,AAA_C\n",
             "0,10,1,0,0\n",
@@ -6718,6 +6683,10 @@
             "5,60,0,0,1\n"
           ]
         }
+      ],
+      "source": [
+        "df.to_csv('saved.csv')\n",
+        "!head -10 saved.csv"
       ]
     },
     {
@@ -6731,67 +6700,63 @@
     },
     {
       "cell_type": "code",
+      "execution_count": 119,
       "metadata": {
-        "id": "0W1IxT0okD5R",
         "colab": {
           "base_uri": "https://localhost:8080/"
         },
-        "outputId": "be1b6928-6642-4b3d-e6ec-bf61f2c345de"
+        "id": "0W1IxT0okD5R",
+        "outputId": "f044dbb7-c1b1-47bc-d3cb-0f5c1d4f2095"
       },
+      "outputs": [
+        {
+          "name": "stdout",
+          "output_type": "stream",
+          "text": [
+            "total 4048\n",
+            "drwxr-xr-x 1 root root    4096 Jul 13 08:41 .\n",
+            "drwxr-xr-x 1 root root    4096 Jul 13 07:38 ..\n",
+            "drwxr-xr-x 4 root root    4096 Jul  6 13:21 .config\n",
+            "-rw-r--r-- 1 root root 4115852 Jul 13 08:41 RegularSeasonCompactResults.csv\n",
+            "drwxr-xr-x 1 root root    4096 Jul  6 13:22 sample_data\n",
+            "-rw-r--r-- 1 root root      89 Jul 13 08:41 saved.csv\n",
+            "-rw-r--r-- 1 root root    5083 Jul 13 08:41 saved.xlsx\n"
+          ]
+        }
+      ],
       "source": [
         "df.to_excel(\"saved.xlsx\")\n",
         "!ls -al "
-      ],
-      "execution_count": 465,
-      "outputs": [
-        {
-          "output_type": "stream",
-          "name": "stdout",
-          "text": [
-            "total 4048\n",
-            "drwxr-xr-x 1 root root    4096 Dec 23 01:02 .\n",
-            "drwxr-xr-x 1 root root    4096 Dec 23 00:42 ..\n",
-            "drwxr-xr-x 4 root root    4096 Dec  3 14:33 .config\n",
-            "-rw-r--r-- 1 root root 4115852 Dec 23 01:02 RegularSeasonCompactResults.csv\n",
-            "drwxr-xr-x 1 root root    4096 Dec  3 14:33 sample_data\n",
-            "-rw-r--r-- 1 root root      89 Dec 23 01:02 saved.csv\n",
-            "-rw-r--r-- 1 root root    5107 Dec 23 01:02 saved.xlsx\n"
-          ]
-        }
       ]
     },
     {
       "cell_type": "code",
+      "execution_count": 120,
       "metadata": {
         "id": "m-BqpbwqkKzX"
       },
+      "outputs": [],
       "source": [
         "df2 = pd.read_excel('saved.xlsx')"
-      ],
-      "execution_count": 466,
-      "outputs": []
+      ]
     },
     {
       "cell_type": "code",
+      "execution_count": 121,
       "metadata": {
-        "id": "3znoNI5KkWZ5",
         "colab": {
           "base_uri": "https://localhost:8080/",
-          "height": 204
+          "height": 206
         },
-        "outputId": "2b44361f-62e2-4bbe-e16e-dddfc35069b0"
+        "id": "3znoNI5KkWZ5",
+        "outputId": "b1a2bcf3-eb27-4b82-cd3a-aea27f04960e"
       },
-      "source": [
-        "df2.head()"
-      ],
-      "execution_count": 467,
       "outputs": [
         {
-          "output_type": "execute_result",
           "data": {
             "text/html": [
               "\n",
-              "  <div id=\"df-76cfa2a4-737d-4b56-936e-bd4d3bf2ad72\">\n",
+              "  <div id=\"df-9af31f84-2ec7-4e6c-bd20-0119a6dce56a\">\n",
               "    <div class=\"colab-df-container\">\n",
               "      <div>\n",
               "<style scoped>\n",
@@ -6862,7 +6827,7 @@
               "  </tbody>\n",
               "</table>\n",
               "</div>\n",
-              "      <button class=\"colab-df-convert\" onclick=\"convertToInteractive('df-76cfa2a4-737d-4b56-936e-bd4d3bf2ad72')\"\n",
+              "      <button class=\"colab-df-convert\" onclick=\"convertToInteractive('df-9af31f84-2ec7-4e6c-bd20-0119a6dce56a')\"\n",
               "              title=\"Convert this dataframe to an interactive table.\"\n",
               "              style=\"display:none;\">\n",
               "        \n",
@@ -6913,12 +6878,12 @@
               "\n",
               "      <script>\n",
               "        const buttonEl =\n",
-              "          document.querySelector('#df-76cfa2a4-737d-4b56-936e-bd4d3bf2ad72 button.colab-df-convert');\n",
+              "          document.querySelector('#df-9af31f84-2ec7-4e6c-bd20-0119a6dce56a button.colab-df-convert');\n",
               "        buttonEl.style.display =\n",
               "          google.colab.kernel.accessAllowed ? 'block' : 'none';\n",
               "\n",
               "        async function convertToInteractive(key) {\n",
-              "          const element = document.querySelector('#df-76cfa2a4-737d-4b56-936e-bd4d3bf2ad72');\n",
+              "          const element = document.querySelector('#df-9af31f84-2ec7-4e6c-bd20-0119a6dce56a');\n",
               "          const dataTable =\n",
               "            await google.colab.kernel.invokeFunction('convertToInteractive',\n",
               "                                                     [key], {});\n",
@@ -6948,21 +6913,47 @@
               "4           4   50      0      1      0"
             ]
           },
+          "execution_count": 121,
           "metadata": {},
-          "execution_count": 467
+          "output_type": "execute_result"
         }
+      ],
+      "source": [
+        "df2.head()"
       ]
     },
     {
       "cell_type": "code",
+      "execution_count": 121,
       "metadata": {
         "id": "s1eC2SURkXOR"
       },
-      "source": [
-        ""
-      ],
-      "execution_count": 467,
-      "outputs": []
+      "outputs": [],
+      "source": []
     }
-  ]
+  ],
+  "metadata": {
+    "colab": {
+      "collapsed_sections": [],
+      "name": "pandas_for_deep_learning.ipynb",
+      "provenance": [],
+      "toc_visible": true
+    },
+    "kernelspec": {
+      "display_name": "Python 3.9.13 64-bit",
+      "language": "python",
+      "name": "python3"
+    },
+    "language_info": {
+      "name": "python",
+      "version": "3.9.13"
+    },
+    "vscode": {
+      "interpreter": {
+        "hash": "b0fa6594d8f4cbf19f97940f81e996739fb7646882a419484c72d19e05852a7e"
+      }
+    }
+  },
+  "nbformat": 4,
+  "nbformat_minor": 0
 }


### PR DESCRIPTION
기존 코드의 main 브랜치가 master 브랜치로 옮겨가면서 이미지 링크가 깨진 것을 수정하였고,
기존 pandas ipynb 파일의 adeshpande3/Pandas-Tutorial 레포지토리의 main 브랜치가 현재 master로 변경되어 파일 다운로드가 진행되지 않던 것을 고쳤습니다.
그 외에도, 사소한 몇몇 오타를 수정하였습니다.